### PR TITLE
chore: role labels in tree (exposure call #2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Non-custodial subscriber that pushes external Nostr events into per-agent Buzz
 inboxes, so agents stop polling "the West" (Armada / NIP-DA / Concord planes) by
 hand. **v1 forwards Armada NIP-17 DMs only.**
 
-- **Owner:** Neil (bridge manager). Crypto / agent-side unwrap: My Dude.
+- **Owner:** the read-lane engineer (bridge manager). Crypto / agent-side unwrap: the outbox engineer.
 - **Design:** `../../PLANS/WEST_BRIDGE_SCOPING.md`
 - **Origin:** promoted from the working prototype `../../.scratch/da-consumer/mydude_west_bridge.mjs`.
 
@@ -22,7 +22,7 @@ The agent unwraps with its own in-runtime key.
 
 1. **Bridge Buzz identity** — its own posting account: `BUZZ_PRIVATE_KEY`,
    `BUZZ_RELAY_URL`, `BUZZ_AUTH_TAG`. Not any agent's key.
-2. **Three inbox channels** — one per agent (My Dude / Dennis / Kerouac), with
+2. **Three inbox channels** — one per agent, with
    each agent added as a member so the harness routes. Put the channel UUIDs into
    `config.json`.
 

--- a/config.example.json
+++ b/config.example.json
@@ -7,9 +7,9 @@
     "wss://relay.damus.io"
   ],
   "recipients": [
-    { "name": "My Dude", "npub_hex": "0a8e0720c3ec52c6bfd9e2545d620cf58e2e8d371244255efce3ddd57ba0a32c", "inbox": "INBOX_UUID_MYDUDE" },
-    { "name": "Dennis",  "npub_hex": "9a07300d3295f392d295cd8f73c8f1d3c725809b2e50fc52815db8682ef940a5", "inbox": "INBOX_UUID_DENNIS" },
-    { "name": "Kerouac", "npub_hex": "eb586b1e9c214c10762acc0dd4d428ac9156c284162f2d9dcc98562e644d71a5", "inbox": "INBOX_UUID_KEROUAC" }
+    { "name": "AGENT_A", "npub_hex": "<64-hex pubkey of agent A>", "inbox": "INBOX_UUID_AGENT_A" },
+    { "name": "AGENT_B", "npub_hex": "<64-hex pubkey of agent B>", "inbox": "INBOX_UUID_AGENT_B" },
+    { "name": "AGENT_C", "npub_hex": "<64-hex pubkey of agent C>", "inbox": "INBOX_UUID_AGENT_C" }
   ],
   "public": {
     "_comment": "Public kind:1 read lane. Phase-0 safety gates: quarantine + bounds + rate limits.",

--- a/src/bridge.mjs
+++ b/src/bridge.mjs
@@ -10,7 +10,7 @@
 // (BUZZ_PRIVATE_KEY) to post into the inbox channels. Safe on a server that holds
 // no agent keys.
 //
-// Promoted from the .scratch prototype (My Dude, 2026-07-24) by Neil (bridge mgr):
+// Promoted from the .scratch prototype (the outbox engineer, 2026-07-24) by the read-lane engineer:
 //   - config externalized to config.json (relays + recipients + inbox UUIDs)
 //   - dedup is now DURABLE (survives restarts) so a bounce can't re-deliver
 //   - the NIP-59 48h backdate window is the DEFAULT, not an opt-in flag
@@ -47,7 +47,7 @@ const FORWARD_MODE = process.env.FORWARD_MODE || 'buzz'
 // SEALED_LANES=off runs the PUBLIC read lane ONLY — no DM lane, no Concord channel lane. Use this
 // on a SECOND instance (e.g. a local read-lane host) when another instance already owns the sealed
 // lanes: dedup is per-process (module-level `seen` + its own seen-ids.log), so two instances both
-// routing the sealed lanes deliver every wrap TWICE, byte-identical (Dennis, 2026-07-28). Default on.
+// routing the sealed lanes deliver every wrap TWICE, byte-identical (research & verification, 2026-07-28). Default on.
 const SEALED_LANES = (process.env.SEALED_LANES || 'on').toLowerCase() !== 'off'
 const SINCE_SECS = process.env.SINCE_SECS != null ? Number(process.env.SINCE_SECS) : 172800 // 48h
 const SINCE = Math.floor(Date.now() / 1000) - SINCE_SECS
@@ -231,7 +231,7 @@ function forward(rec, ev, src) {
   // derive from the #general community_root — NOT an ECDH seal to any p-tag. A member whose
   // runtime lacks that root cannot open it; say so, rather than "go unwrap," so a missing
   // Concord grant reads as a provisioning gap instead of a bad route. (Cost six confused
-  // rounds with Kerouac, 2026-07-24, before this said so.)
+  // rounds with a team member, 2026-07-24, before this said so.)
   const label = src && src.channel
     ? `New Concord channel post on **${src.channel}** — its outer \`p\` tag is a random decoy, not a recipient. ` +
       `Decrypt with the plane key you derive from the **${src.channel} community_root** ` +

--- a/src/concord_lib.mjs
+++ b/src/concord_lib.mjs
@@ -94,7 +94,7 @@ export function groupKey(label, secret, id, epoch) {
 }
 
 // `communityId` is the ONE derivation in this file that does not route through hkdf32, so
-// My Dude's chokepoint content check never sees it — and it takes the two most hex-native
+// the outbox engineer's chokepoint content check never sees it — and it takes the two most hex-native
 // arguments in the protocol (both arrive as hex strings in the 3313 invite JSON). Unguarded
 // it was worse than silent: `[...'4010ac…']` spreads a STRING into characters, which
 // Uint8Array coerces to NaN -> 0, so a hex string produced a deterministic, plausible,


### PR DESCRIPTION
## What

Closes the second exposure call flagged in the v1.10 fold: README, `config.example.json`, and four code comments carried crew codenames (and the example config carried real npub hexes). The tip now matches the external cut's role-label posture; the example config uses placeholders, as an example file should regardless.

## Deliberately NOT done

- **No history rewrite.** The names and npubs are already public — the crew publishes kind:0 profiles under exactly these names/keys on the public relays (the Phase-2 audit's own finding). Tip-consistency is the real goal; rewriting nine commits for already-public pseudonyms is disproportionate.
- **Claude trailers stay** (history and future). Recommendation to the maintainer: AI co-authorship is standard practice and reads *better* to an external reviewer than discovering it was concealed. If the maintainer prefers the team's stricter posture, that's one line to drop from future commits — but the history keeps them either way.

Tests green post-scrub (`npm test`: A1 + A7 both PASS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)