### PR TITLE
NIP-DA admission tier (§4.1 S3) + grant issuer

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -27,6 +27,7 @@
     "deletes_per_hour": 20,
     "approver_mention": "<Buzz @name mentioned in quarantine headers so arrivals notify the approver; omit for none>",
     "approvers": ["<hex pubkey allowed to reply approve|watch|mute|reject on a quarantined post>"],
+    "grantors": ["<hex pubkey whose signed NIP-DA 440/441 admit or revoke a granted participant; defaults to approvers>"],
     "trusted_repliers": [],
     "muted_authors": []
   }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "start": "node src/bridge.mjs",
     "dryrun": "FORWARD_MODE=dryrun node src/bridge.mjs",
-    "test": "node tests/a1_quarantine.mjs && node tests/a7_deletion.mjs && node tests/lane2_caps.mjs"
+    "test": "node tests/a1_quarantine.mjs && node tests/a7_deletion.mjs && node tests/lane2_caps.mjs && node tests/nipda_admission.mjs"
   },
   "dependencies": {
     "@noble/curves": "^1.9.7",

--- a/src/bridge.mjs
+++ b/src/bridge.mjs
@@ -159,6 +159,9 @@ const PUB = cfg.public ? {
   trustedRepliers: (cfg.public.trusted_repliers || []).map(s => String(s).toLowerCase()),
   // Pubkeys allowed to issue in-channel approval commands (signed kind:9 replies in staging).
   approvers: (cfg.public.approvers || []).map(s => String(s).toLowerCase()),
+  // Keys whose signed 440/441 events the bridge honors for admission. Defaults to the
+  // approvers set — the same authority that runs the quarantine console.
+  grantors: (cfg.public.grantors || cfg.public.approvers || []).map(s => String(s).toLowerCase()),
 } : null
 
 // Channel-name resolution: public.inbox / staging_inbox may be a Buzz channel NAME instead
@@ -325,6 +328,50 @@ function l2RecipientOk(plane, inbox, ev, nowMs, boot) {
   b.tokens -= 1
   l2Bucket.set(key, b)
   return true
+}
+
+// --- NIP-DA admission tier (annex §4.1.1 — S3: granted external participants) --
+// PUBLIC signed grants from the maintainer admit a known external identity past the
+// quarantine: kind 440 admits, 441 revokes, both verified (signature + grantor set +
+// salted scope-hash binding to THIS channel) and consumed statelessly — the grant set is
+// rebuilt from the relays on every boot, so there is nothing to migrate and revocation
+// needs no restart. Provisional kinds sit behind one config knob (Marmot-band renumber).
+const NIPDA_PATH = process.env.NIPDA_KINDS_PATH || resolve(ROOT, 'config', 'nipda_kinds.json')
+const NIPDA = (() => {
+  const d = { grant: 440, revocation: 441, index: 10440, dataset: 30440, scopeTag: 'da-scope', capTag: 'da-cap' }
+  try { return { ...d, ...JSON.parse(readFileSync(NIPDA_PATH, 'utf8')) } } catch { return d }
+})()
+const scopeHash = (channelId, saltHex) =>
+  createHash('sha256').update(Buffer.concat([
+    Buffer.from('waggle/da-scope/v1'), Buffer.from([0]), Buffer.from(String(channelId)), Buffer.from(saltHex, 'hex'),
+  ])).digest('hex')
+const grantSet = new Map() // grantee pubkey -> { grantId, grantor }
+function processGrantEvent(ev) {
+  if (!ev || !ev.id || !PUB) return
+  const grantors = PUB.grantors
+  if (!grantors.includes(String(ev.pubkey || '').toLowerCase())) return
+  let ok = false
+  try { ok = verifyEvent(ev) } catch { ok = false }
+  if (!ok) { err(`NIPDA drop[bad-signature]: kind${ev.kind} ${String(ev.id).slice(0, 12)}…`); return }
+  if (ev.kind === NIPDA.revocation) {
+    const target = (ev.tags || []).filter(t => t[0] === 'e').map(t => t[1])[0]
+    for (const [pk, g] of grantSet) if (g.grantId === target) {
+      grantSet.delete(pk)
+      log(`NIPDA revoked: grantee ${pk.slice(0, 12)}… (441 ${ev.id.slice(0, 12)}…)`)
+    }
+    return
+  }
+  if (ev.kind !== NIPDA.grant) return
+  const grantee = (ev.tags || []).filter(t => t[0] === 'p').map(t => t[1])[0]
+  const scope = (ev.tags || []).find(t => t[0] === NIPDA.scopeTag)
+  const cap = (ev.tags || []).find(t => t[0] === NIPDA.capTag)?.[1]
+  if (!grantee || !scope || !cap) return
+  // The salted hash binds the grant to a channel without the channel id riding publicly;
+  // the bridge knows its own channel id, so it recomputes and compares.
+  if (scope[1] !== scopeHash(PUB.inbox, scope[2] || '')) return // scoped to some other channel — not ours
+  if (cap !== 'admit' && cap !== 'admit+read') return
+  grantSet.set(String(grantee).toLowerCase(), { grantId: ev.id, grantor: ev.pubkey })
+  log(`NIPDA granted: ${String(grantee).slice(0, 12)}… admitted (${cap}, 440 ${ev.id.slice(0, 12)}…)`)
 }
 
 // --- delivery ---------------------------------------------------------------
@@ -516,6 +563,7 @@ function routePublic(ev) {
   const trusted = PUB.authors.includes(ev.pubkey)
   let why = null, quarantine = false
   if (trusted) why = 'mirrored feed'
+  else if (grantSet.has(ev.pubkey)) why = 'granted participant' // §4.1 S3: admitted by signed 440, revocable by 441
   else if (PUB.events.length) {
     const es = (ev.tags || []).filter(t => t[0] === 'e').map(t => t[1])
     if (es.some(id => PUB.events.includes(id))) {
@@ -811,6 +859,9 @@ function connectPublic(url) {
       // A7: kind:5 deletes from watched authors. Longer lookback than the kind:1 watermark
       // (deletes are rare + idempotent; one issued during downtime must not be missed).
       if (PUB.authors.length) { expect.add('pd'); ws.send(JSON.stringify(['REQ', 'pd', { kinds: [5], authors: PUB.authors, since: Math.floor(Date.now() / 1000) - DEL_SINCE_SECS, limit: PUB.backfillLimit }])) }
+      // NIP-DA: grants + revocations from the grantor set. Wide lookback — a standing
+      // grant issued weeks ago must survive any restart (stateless consumption).
+      if (PUB.grantors.length) { expect.add('pg'); ws.send(JSON.stringify(['REQ', 'pg', { kinds: [NIPDA.grant, NIPDA.revocation], authors: PUB.grantors, limit: 200 }])) }
       // Safety: flush even if a relay never sends EOSE for a subscription.
       flushTimer = setTimeout(() => flush('EOSE timeout'), 10000)
     })
@@ -819,6 +870,7 @@ function connectPublic(url) {
       try { m = JSON.parse(d.toString()) } catch { return }
       if (m[0] === 'EVENT') {
         const ev = m[2]
+        if (ev && (ev.kind === NIPDA.grant || ev.kind === NIPDA.revocation)) { processGrantEvent(ev); return }
         if (eosed) { if (ev && ev.kind === 5) routeDelete(ev); else routePublic(ev); return }
         // A4: bound the pre-EOSE buffer app-side too — overflow dropped WITH a log, never silent.
         if (buf.length >= PUB.backfillLimit) { err(`[pub ${url}] backfill buffer cap ${PUB.backfillLimit} — dropping ${ev?.id ? ev.id.slice(0, 12) : '?'}…`); return }
@@ -838,7 +890,7 @@ function connectPublic(url) {
 // Exported so a harness can drive the REAL routing functions (not a copy) with synthetic
 // events in dryrun, without opening any relay socket. Set WB_NO_BOOT=1 to import without
 // booting the live subscriber. No effect on normal `node src/bridge.mjs` runs.
-export { route, routePublic, routeDelete, forwardPublic, clampCreated, rateOk, bumpPubWatermark, loadPubWatermark, markSeen, seen, PUB, postedMap, recordPosted, parseBuzzEventId, resolveChannels }
+export { route, routePublic, routeDelete, processGrantEvent, grantSet, forwardPublic, clampCreated, rateOk, bumpPubWatermark, loadPubWatermark, markSeen, seen, PUB, postedMap, recordPosted, parseBuzzEventId, resolveChannels }
 
 // --- boot -------------------------------------------------------------------
 if (!process.env.WB_NO_BOOT) {
@@ -860,6 +912,7 @@ if (!process.env.WB_NO_BOOT) {
     resolveChannels(() => {
     log(`public read lane -> inbox ${PUB.inbox}: ${PUB.relays.length} relay(s), ${PUB.authors.length} watched author(s), ${PUB.events.length} watched note(s), pub-since=${PUB.since} (${PUB_SINCE_SECS}s), watermark=${pubWatermark || 'none'}`)
     log(`  gates: staging=${PUB.staging || 'HOLD (none)'} · backfill<=${PUB.backfillLimit} · maxContent=${PUB.maxContentBytes}B · rate ${PUB.replierPerMin}/replier/min ${PUB.channelPerMin}/chan/min ${PUB.lanePerHour}/lane/h · deletes ${PUB.deletesPerHour}/h (A7)`)
+    if (PUB.grantors.length) log(`  admission: ${PUB.grantors.length} grantor key(s); NIP-DA kinds ${NIPDA.grant}/${NIPDA.revocation}/${NIPDA.index}`)
     PUB.relays.forEach(connectPublic)
     if (PUB.staging && PUB.approvers.length && FORWARD_MODE === 'buzz') {
       log(`approval console: watching staging for commands from ${PUB.approvers.length} approver(s)`)

--- a/tests/nipda_admission.mjs
+++ b/tests/nipda_admission.mjs
@@ -1,0 +1,99 @@
+// NIP-DA admission regression test (annex §4.1.1, S3 tier).
+//
+// Proves processGrantEvent + routePublic: a maintainer-signed 440 scoped to THIS channel
+// admits a stranger's public kind:1 past quarantine ("granted participant"); a 441 revokes
+// it (back to quarantine); a 440 signed by a NON-grantor is ignored; a 440 scoped to a
+// DIFFERENT channel is ignored; a forged-signature grant is dropped.
+//
+// Real signatures throughout (wire-form, so verifyEvent doesn't short-circuit on the
+// finalize symbol). Side-effect-free: dryrun + temp state. Drives the REAL exports.
+//
+// Run: node tests/nipda_admission.mjs   (exit 0 = pass, 1 = fail)
+
+import { mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { randomBytes, createHash } from 'node:crypto'
+import { generateSecretKey, getPublicKey, finalizeEvent } from 'nostr-tools/pure'
+
+const tmp = mkdtempSync(join(tmpdir(), 'wb-da-'))
+const grantorSk = generateSecretKey()
+const grantorPk = getPublicKey(grantorSk)
+const strangerSk = generateSecretKey()
+const strangerPk = getPublicKey(strangerSk)
+const outsiderSk = generateSecretKey() // a non-grantor who tries to issue grants
+
+const CHAN = '55555555-5555-5555-5555-555555555555'   // our community inbox (resolved uuid)
+const STAGE = '66666666-6666-6666-6666-666666666666'
+const OTHER_CHAN = '77777777-7777-7777-7777-777777777777'
+const POC = 'e'.repeat(64)
+
+writeFileSync(join(tmp, 'config.json'), JSON.stringify({
+  relays: [], recipients: [],
+  public: {
+    relays: [], inbox: CHAN, staging_inbox: STAGE,
+    watch_authors: [], watch_events: [POC],
+    grantors: [grantorPk],
+  },
+}))
+process.env.WB_NO_BOOT = '1'
+process.env.FORWARD_MODE = 'dryrun'
+process.env.CONFIG_PATH = join(tmp, 'config.json')
+process.env.SEEN_PATH = join(tmp, 'seen.log')
+process.env.PUB_WATERMARK_PATH = join(tmp, 'watermark')
+process.env.POSTED_MAP_PATH = join(tmp, 'posted-map.log')
+
+const { routePublic, processGrantEvent, grantSet, PUB } = await import('../src/bridge.mjs')
+
+const wire = (ev) => JSON.parse(JSON.stringify(ev))
+const now = () => Math.floor(Date.now() / 1000)
+const salted = (chan) => {
+  const salt = randomBytes(16).toString('hex')
+  const hash = createHash('sha256').update(Buffer.concat([
+    Buffer.from('waggle/da-scope/v1'), Buffer.from([0]), Buffer.from(chan), Buffer.from(salt, 'hex'),
+  ])).digest('hex')
+  return [hash, salt]
+}
+const grant = (sk, grantee, chan) => wire(finalizeEvent({
+  kind: 440, created_at: now(),
+  tags: [['p', grantee], ['da-scope', ...salted(chan)], ['da-cap', 'admit']], content: '',
+}, sk))
+const reply = (sk, pk) => wire(finalizeEvent({ kind: 1, created_at: now(), tags: [['e', POC]], content: 'a granted reply', pubkey: pk }, sk))
+
+let buf = ''
+console.log = console.error = (...a) => { buf += a.join(' ') + '\n' }
+const routeOf = (ev) => { const before = buf.length; routePublic(ev); return buf.slice(before) }
+
+let pass = true
+const check = (cond, label) => { console.info(`${cond ? 'ok  ' : 'FAIL'} — ${label}`); if (!cond) pass = false }
+
+// Baseline: stranger reply with no grant -> STAGING.
+check(/-> STAGING/.test(routeOf(reply(strangerSk, strangerPk))), 'ungranted stranger reply -> quarantine')
+
+// A grant from a NON-grantor is ignored (authority check).
+processGrantEvent(grant(outsiderSk, strangerPk, CHAN))
+check(!grantSet.has(strangerPk), 'grant from non-grantor ignored')
+
+// A grant scoped to a DIFFERENT channel is ignored (scope-hash binding).
+processGrantEvent(grant(grantorSk, strangerPk, OTHER_CHAN))
+check(!grantSet.has(strangerPk), 'grant scoped to another channel ignored')
+
+// A forged-signature grant is dropped.
+const forged = grant(grantorSk, strangerPk, CHAN); forged.sig = (forged.sig[0] === '0' ? '1' : '0') + forged.sig.slice(1)
+processGrantEvent(forged)
+check(!grantSet.has(strangerPk), 'forged-signature grant dropped')
+
+// The real grant admits the stranger; the reply now routes to the community inbox.
+const g = grant(grantorSk, strangerPk, CHAN)
+processGrantEvent(g)
+check(grantSet.has(strangerPk), 'valid grant admits the participant')
+check(new RegExp(`-> inbox ${CHAN}`).test(routeOf(reply(strangerSk, strangerPk))), 'granted participant reply -> community inbox (no queue)')
+
+// Revocation: the 441 e-tags the grant; the participant re-quarantines.
+const rev = wire(finalizeEvent({ kind: 441, created_at: now(), tags: [['e', g.id]], content: '' }, grantorSk))
+processGrantEvent(rev)
+check(!grantSet.has(strangerPk), 'valid 441 revokes the grant')
+check(/-> STAGING/.test(routeOf(reply(strangerSk, strangerPk))), 'revoked participant reply -> back to quarantine')
+
+console.info(pass ? '\nNIPDA PASS — admission tier holds' : '\nNIPDA FAIL')
+process.exit(pass ? 0 : 1)

--- a/tools/grant.mjs
+++ b/tools/grant.mjs
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+// NIP-DA admission issuer — the maintainer's grant pen (annex §4.1.1, S3 tier).
+//
+//   grant.mjs issue  --to <npub|hex> --channel <uuid|name> [--cap admit]   sign + publish a 440
+//   grant.mjs revoke --grant <440 event id>                                sign + publish a 441
+//   grant.mjs list                                                          own 440/441s off the relays
+//
+// A 440 is a PLAIN PUBLIC signed event: ["p", grantee], ["da-scope", <salted hash>, <salt>],
+// ["da-cap", "admit"]. The channel id never rides publicly — a fresh 16-byte salt per grant
+// keeps two grants into the same channel unlinkable, while the bridge (which knows its own
+// channel id) recomputes and matches. Revocation is a 441 e-tagging the 440. The bridge
+// consumes both statelessly off the relays; no restart needed for either direction.
+//
+// Env: GRANTOR_NSEC (nsec1…|hex — the maintainer key; the bridge honors keys in
+// cfg.public.grantors, defaulting to the approvers set). Kinds are provisional and read
+// from config/nipda_kinds.json when present (NIPDA_KINDS_PATH to override).
+
+import WebSocket from 'ws'
+import { randomBytes, createHash } from 'node:crypto'
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { finalizeEvent, getPublicKey } from 'nostr-tools/pure'
+import * as nip19 from 'nostr-tools/nip19'
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const NIPDA = (() => {
+  const d = { grant: 440, revocation: 441, index: 10440, scopeTag: 'da-scope', capTag: 'da-cap' }
+  try { return { ...d, ...JSON.parse(readFileSync(process.env.NIPDA_KINDS_PATH || resolve(ROOT, 'config', 'nipda_kinds.json'), 'utf8')) } } catch { return d }
+})()
+const CONFIG_PATH = process.env.CONFIG_PATH || resolve(ROOT, 'config.json')
+const die = (m) => { console.error(`grant: ${m}`); process.exit(1) }
+
+const raw = process.env.GRANTOR_NSEC || die('set GRANTOR_NSEC (the maintainer key that signs grants)')
+const sk = raw.startsWith('nsec1') ? nip19.decode(raw).data : Uint8Array.from(Buffer.from(raw, 'hex'))
+const pk = getPublicKey(sk)
+
+const args = process.argv.slice(2)
+const cmd = args[0]
+const flag = (n) => { const i = args.indexOf(n); return i === -1 ? null : args[i + 1] }
+const HEX64 = /^[0-9a-f]{64}$/i
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+function relays() {
+  try { const c = JSON.parse(readFileSync(CONFIG_PATH, 'utf8')); if (c.public?.relays?.length) return c.public.relays } catch { /* fall through */ }
+  return ['wss://relay.damus.io', 'wss://nos.lol', 'wss://relay.primal.net']
+}
+
+function publish(ev) {
+  return Promise.all(relays().map(url => new Promise(res => {
+    let ws
+    try { ws = new WebSocket(url) } catch { return res(`${url} CONNECT-FAIL`) }
+    const done = m => { try { ws.close() } catch { /* closed */ } res(`${url.padEnd(26)} ${m}`) }
+    const t = setTimeout(() => done('TIMEOUT'), 12000)
+    ws.on('open', () => ws.send(JSON.stringify(['EVENT', ev])))
+    ws.on('message', d => { try { const m = JSON.parse(d.toString()); if (m[0] === 'OK' && m[1] === ev.id) { clearTimeout(t); done(m[2] ? 'OK' : `REJECTED: ${m[3]}`) } } catch { /* ignore */ } })
+    ws.on('error', e => { clearTimeout(t); done(`ERR ${e.message}`) })
+  })))
+}
+
+function channelId(v) {
+  if (UUID_RE.test(v)) return v.toLowerCase()
+  // resolve by name via the bridge config's resolved channels is a runtime concern; the
+  // issuer accepts a name only when config.json's inbox/staging carries the mapping hint.
+  die(`--channel must be the channel UUID (names resolve inside the bridge, not the issuer): got '${v}'`)
+}
+
+if (cmd === 'issue') {
+  const toRaw = flag('--to') || die('issue needs --to <npub|hex>')
+  const grantee = toRaw.startsWith('npub1') ? nip19.decode(toRaw).data : (HEX64.test(toRaw) ? toRaw.toLowerCase() : die('--to must be npub or 64-hex'))
+  const chan = channelId(flag('--channel') || die('issue needs --channel <uuid>'))
+  const cap = flag('--cap') || 'admit'
+  if (cap !== 'admit') die(`only --cap admit is implemented (S3 tier); admit+read (S2) rides the 30440 work`)
+  const salt = randomBytes(16).toString('hex')
+  const hash = createHash('sha256').update(Buffer.concat([
+    Buffer.from('waggle/da-scope/v1'), Buffer.from([0]), Buffer.from(chan), Buffer.from(salt, 'hex'),
+  ])).digest('hex')
+  const ev = finalizeEvent({
+    kind: NIPDA.grant,
+    created_at: Math.floor(Date.now() / 1000),
+    tags: [['p', grantee], [NIPDA.scopeTag, hash, salt], [NIPDA.capTag, cap]],
+    content: '',
+  }, sk)
+  console.log(`440 ${ev.id}\n  grantee ${grantee}\n  scope   ${hash.slice(0, 16)}… (salted; channel never public)\n  cap     ${cap}\n  grantor ${pk}`)
+  for (const line of await publish(ev)) console.log('  ' + line)
+} else if (cmd === 'revoke') {
+  const target = flag('--grant') || die('revoke needs --grant <440 event id>')
+  if (!HEX64.test(target)) die('--grant must be a 64-hex event id')
+  const ev = finalizeEvent({
+    kind: NIPDA.revocation,
+    created_at: Math.floor(Date.now() / 1000),
+    tags: [['e', target.toLowerCase()]],
+    content: '',
+  }, sk)
+  console.log(`441 ${ev.id} revoking ${target.slice(0, 12)}…`)
+  for (const line of await publish(ev)) console.log('  ' + line)
+} else if (cmd === 'list') {
+  const found = new Map()
+  await Promise.all(relays().map(url => new Promise(res => {
+    let ws
+    try { ws = new WebSocket(url) } catch { return res() }
+    const t = setTimeout(() => { try { ws.close() } catch { } res() }, 8000)
+    ws.on('open', () => ws.send(JSON.stringify(['REQ', 'g', { kinds: [NIPDA.grant, NIPDA.revocation], authors: [pk], limit: 200 }])))
+    ws.on('message', d => { try { const m = JSON.parse(d.toString()); if (m[0] === 'EVENT') found.set(m[2].id, m[2]); if (m[0] === 'EOSE') { clearTimeout(t); ws.close(); res() } } catch { /* ignore */ } })
+    ws.on('error', () => { clearTimeout(t); res() })
+  })))
+  const evs = [...found.values()].sort((a, b) => a.created_at - b.created_at)
+  const revoked = new Set(evs.filter(e => e.kind === NIPDA.revocation).flatMap(e => e.tags.filter(t => t[0] === 'e').map(t => t[1])))
+  for (const e of evs) {
+    if (e.kind === NIPDA.grant) {
+      const grantee = e.tags.find(t => t[0] === 'p')?.[1] || '?'
+      console.log(`${revoked.has(e.id) ? 'REVOKED' : 'ACTIVE '} 440 ${e.id.slice(0, 12)}… -> ${grantee.slice(0, 12)}… (${new Date(e.created_at * 1000).toISOString()})`)
+    }
+  }
+  if (!evs.length) console.log('(no grants published by this key)')
+} else {
+  die('usage: grant.mjs issue --to <npub> --channel <uuid> | revoke --grant <id> | list')
+}


### PR DESCRIPTION
Signed 440 admits / 441 revokes a granted participant past quarantine; stateless consumption (rebuilt from relays, no restart); salted scope-hash binds each grant to the channel without leaking the id. tools/grant.mjs issuer. 8-case suite. 🤖 Generated with [Claude Code](https://claude.com/claude-code)