### PR TITLE
grant-setup: one signer approval, and never a silent wait

### DIFF
--- a/tools/grant-setup.sh
+++ b/tools/grant-setup.sh
@@ -3,60 +3,65 @@
 #
 #   sh tools/grant-setup.sh
 #
-# Prompts for your bunker connection, shows you exactly what it is about to sign, waits for a
-# yes, then issues one grant per recipient. Nothing is signed before you confirm.
+# Answer three prompts, read the plan, confirm. Nothing is signed before you say yes.
 #
-# Why a wrapper rather than a longer command: the grant is the thing that decides who may task
-# an agent, so issuing it should be a deliberate act you can read before it happens — not a
-# 200-character line with two npubs in it that you paste from a chat window and hope is right.
-# (It also removes the transcription risk. An npub typed by hand is one flipped character from
-# a stranger's key; bech32 will usually catch it, but "usually" is not a security property.)
+# Why a wrapper rather than a longer command: this grant decides who may task an agent, so
+# issuing it should be a deliberate act you can read first — not a 200-character line with two
+# npubs in it, pasted from a chat window and hoped correct. Names resolve from the published
+# directory, so the key that gets signed is the one actually published rather than one typed
+# from memory. (bech32 usually catches a mistyped npub. "Usually" is not a security property.)
 #
-# The bunker string is a SECRET — it carries the token that authorises signing. So it is:
-#   · read with the terminal echo OFF, so it never appears on screen
-#   · passed to the signer through the ENVIRONMENT, never argv (argv is world-readable in `ps`)
-#   · never written to a file, and never printed back
-# If you have ever pasted a bunker string into a chat, treat it as burned and re-mint it.
+# ONE signer approval for the whole run. Listing grants needs no signature, so it runs with
+# --grantor and never touches the signer; only the issuing step connects, and it signs the
+# whole batch over that single connection. A tool that asks for approval it does not need
+# teaches you to approve without reading, which is the opposite of what approval is for.
+#
+# The bunker string is a SECRET — it carries the token that authorises signing:
+#   · read with terminal echo OFF, so it never appears on screen
+#   · passed through the ENVIRONMENT, never argv (argv is world-readable in `ps`)
+#   · never written to disk, never echoed back
+# If a bunker string has ever been pasted into a chat, treat it as burned and re-mint it.
 set -eu
 
 TOOLS=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 NAMES_URL=${NAMES_URL:-https://nave.pub/.well-known/nostr.json}
+WORK=$(mktemp -d) || { echo "grant-setup: cannot create temp dir" >&2; exit 1; }
+trap 'rm -rf "$WORK"' EXIT INT TERM
 
 say() { printf '%s\n' "$*"; }
 die() { printf 'grant-setup: %s\n' "$*" >&2; exit 1; }
-
 command -v node >/dev/null 2>&1 || die "node not found on PATH"
 
 say ""
 say "  Grant the right to task an agent"
 say "  ────────────────────────────────"
 say "  Each grant says: <recipient> may give <agent> instructions."
-say "  It is a signed, public, revocable event. Revoke later with:"
+say "  Signed, public, revocable. Revoke later with:"
 say "     node tools/grant.mjs revoke --grant <id>"
 say ""
 
-# --- 1. Who is being tasked -------------------------------------------------------------------
 printf '  Agent to be tasked (npub, or a name from nave.pub) [claude]: '
-read -r AGENT_IN ||:
-AGENT_IN=${AGENT_IN:-claude}
+read -r AGENT_IN ||:; AGENT_IN=${AGENT_IN:-claude}
 
-# --- 2. Who may task them ---------------------------------------------------------------------
 say ""
-say "  Who may task this agent? Names are resolved from ${NAMES_URL}"
+say "  Who may task this agent? Names resolve from ${NAMES_URL},"
 say "  so nothing is transcribed by hand. Space-separated; npubs also accepted."
 printf '  Recipients [jaf mydude dennis kerouac neil]: '
-read -r RECIPS_IN ||:
-RECIPS_IN=${RECIPS_IN:-"jaf mydude dennis kerouac neil"}
+read -r RECIPS_IN ||:; RECIPS_IN=${RECIPS_IN:-"jaf mydude dennis kerouac neil"}
 
-# Resolve names -> npubs in one node pass. `jaf` maps to the workspace owner, who is not
-# published under that name, so it is special-cased here rather than silently dropped.
-RESOLVED=$(AGENT_IN="$AGENT_IN" RECIPS_IN="$RECIPS_IN" NAMES_URL="$NAMES_URL" node --input-type=module -e '
+say ""
+printf '  Your grantor npub (whose signature is the policy) [jaf]: '
+read -r GRANTOR_IN ||:; GRANTOR_IN=${GRANTOR_IN:-jaf}
+
+# Resolve every name to an npub in one pass, with no network write and no signer.
+AGENT_IN="$AGENT_IN" RECIPS_IN="$RECIPS_IN" GRANTOR_IN="$GRANTOR_IN" NAMES_URL="$NAMES_URL" \
+node --input-type=module -e '
 import { npubEncode, decode } from "nostr-tools/nip19"
 const JAF = "4010ac438206dc10018b814be3ea01ca6c92bcc22e9719e841d2413b287ea84d"
 const res = await fetch(process.env.NAMES_URL).catch(() => null)
 const names = res && res.ok ? (await res.json()).names || {} : {}
 const toNpub = (tok) => {
-  if (tok.startsWith("npub1")) { decode(tok); return tok }              // validates the checksum
+  if (tok.startsWith("npub1")) { decode(tok); return tok }               // validates the checksum
   if (/^[0-9a-f]{64}$/i.test(tok)) return npubEncode(tok.toLowerCase())
   const k = tok.toLowerCase()
   if (k === "jaf" || k === "james" || k === "owner") return npubEncode(JAF)
@@ -64,21 +69,60 @@ const toNpub = (tok) => {
   throw new Error(`cannot resolve "${tok}" — not an npub, not 64-hex, and not a published name`)
 }
 try {
-  const agent = toNpub(process.env.AGENT_IN.trim())
-  const recips = process.env.RECIPS_IN.trim().split(/\s+/).filter(Boolean).map(t => `${t}\t${toNpub(t)}`)
-  console.log("AGENT\t" + agent)
-  for (const r of recips) console.log("TO\t" + r)
+  console.log("AGENT\t" + toNpub(process.env.AGENT_IN.trim()))
+  console.log("GRANTOR\t" + toNpub(process.env.GRANTOR_IN.trim()))
+  for (const t of process.env.RECIPS_IN.trim().split(/\s+/).filter(Boolean)) {
+    console.log("TO\t" + t + "\t" + toNpub(t) + "\t" + decode(toNpub(t)).data)
+  }
 } catch (e) { console.log("ERR\t" + e.message) }
-' 2>&1) || die "resolution failed"
+' > "$WORK/resolved" 2>&1 || die "resolution failed"
 
-case "$RESOLVED" in *"ERR	"*) die "$(printf '%s' "$RESOLVED" | sed -n 's/^ERR\t//p')";; esac
+if grep -q '^ERR	' "$WORK/resolved"; then die "$(sed -n 's/^ERR\t//p' "$WORK/resolved")"; fi
+AGENT=$(sed -n 's/^AGENT\t//p' "$WORK/resolved")
+GRANTOR=$(sed -n 's/^GRANTOR\t//p' "$WORK/resolved")
+[ -n "$AGENT" ] && [ -n "$GRANTOR" ] || die "could not resolve the agent or grantor"
 
-AGENT=$(printf '%s\n' "$RESOLVED" | sed -n 's/^AGENT\t//p')
-[ -n "$AGENT" ] || die "could not resolve the agent"
-
-# --- 3. What already exists — do not mint duplicates ------------------------------------------
+# --- What already exists. No signer needed for this, so no prompt and no waiting. -------------
 say ""
-say "  Agent: $AGENT"
+say "  Agent:   $AGENT"
+say "  Grantor: $GRANTOR"
+say ""
+say "  Checking existing grants (read-only — your signer is not involved)…"
+node "$TOOLS/grant.mjs" list --grantor "$GRANTOR" --agent "$AGENT" > "$WORK/existing" 2>&1 || true
+sed 's/^/    /' "$WORK/existing"
+
+# --- Plan --------------------------------------------------------------------------------------
+: > "$WORK/plan"; : > "$WORK/skip"
+while IFS='	' read -r _tag NAME NPUB HEX; do
+  [ "$_tag" = "TO" ] || continue
+  if grep -q "ACTIVE.*$HEX" "$WORK/existing" 2>/dev/null; then
+    printf '%s\n' "$NAME" >> "$WORK/skip"
+  else
+    printf '%s\t%s\n' "$NAME" "$NPUB" >> "$WORK/plan"
+  fi
+done < "$WORK/resolved"
+
+if [ -s "$WORK/skip" ]; then
+  say ""
+  say "  Already granted (skipping):"
+  sed 's/^/    · /' "$WORK/skip"
+fi
+
+if [ ! -s "$WORK/plan" ]; then
+  say ""
+  say "  Nothing to do — everyone listed already holds a live grant for this agent."
+  exit 0
+fi
+
+say ""
+say "  About to sign and publish these grants:"
+awk -F'\t' '{printf "    · %-10s %s\n", $1, $2}' "$WORK/plan"
+say ""
+printf '  Proceed? [y/N]: '
+read -r YN ||:
+case "$YN" in y|Y|yes|YES) ;; *) say "  Nothing signed."; exit 0 ;; esac
+
+# --- Sign. One connection, one approval, the whole batch. --------------------------------------
 say ""
 printf '  Bunker connection (bunker://… — input hidden): '
 if [ -t 0 ]; then stty -echo 2>/dev/null ||:; fi
@@ -88,59 +132,25 @@ if [ -t 0 ]; then stty echo 2>/dev/null ||:; printf '\n'; fi
 case "$BUNKER" in bunker://*) ;; *) die "that does not look like a bunker:// URI" ;; esac
 export GRANTOR_BUNKER="$BUNKER"
 
+TO_LIST=$(cut -f2 "$WORK/plan" | paste -sd, -)
+
 say ""
-say "  Checking what is already granted (this connects to your signer once)…"
-EXISTING=$(node "$TOOLS/grant.mjs" list --agent "$AGENT" 2>/dev/null || true)
-printf '%s\n' "$EXISTING" | sed 's/^/    /'
-
-# --- 4. Plan, confirm, execute ----------------------------------------------------------------
-PLAN=""
-SKIP=""
-printf '%s\n' "$RESOLVED" | sed -n 's/^TO\t//p' | while IFS="$(printf '\t')" read -r NAME NPUB; do
-  printf '%s\t%s\n' "$NAME" "$NPUB"
-done > /tmp/gs_recips.$$
-trap 'rm -f /tmp/gs_recips.$$' EXIT INT TERM
-
-while IFS="$(printf '\t')" read -r NAME NPUB; do
-  HEX=$(NPUB="$NPUB" node --input-type=module -e 'import{decode}from"nostr-tools/nip19";console.log(decode(process.env.NPUB).data)')
-  if printf '%s' "$EXISTING" | grep -q "ACTIVE.*$HEX"; then
-    SKIP="$SKIP  already granted: $NAME
-"
-  else
-    PLAN="$PLAN  $NAME	$NPUB
-"
-  fi
-done < /tmp/gs_recips.$$
-
-[ -n "$SKIP" ] && { say ""; printf '%s' "$SKIP"; }
-
-if [ -z "$PLAN" ]; then
-  say ""
-  say "  Nothing to do — everyone listed already holds a live grant for this agent."
-  exit 0
+say "  ┌──────────────────────────────────────────────────────────────────────┐"
+say "  │ LOOK AT YOUR SIGNER APP NOW — the connection needs approving there   │"
+say "  │ (Amber / nsec.app / Alby). Until you approve, this waits: that is    │"
+say "  │ the signer asking, not a hang. Ctrl-C is safe.                       │"
+say "  └──────────────────────────────────────────────────────────────────────┘"
+say ""
+# stderr is deliberately NOT swallowed — it carries the approval URL, the one-time client-key
+# notice, and every connection error. Hiding it turns a normal approval pause into a mystery.
+if command -v perl >/dev/null 2>&1; then
+  perl -e 'alarm shift; exec @ARGV' 300 node "$TOOLS/grant.mjs" issue --to "$TO_LIST" --agent "$AGENT" 2>&1 | sed 's/^/    /'
+else
+  node "$TOOLS/grant.mjs" issue --to "$TO_LIST" --agent "$AGENT" 2>&1 | sed 's/^/    /'
 fi
 
 say ""
-say "  About to sign and publish these grants:"
-printf '%s' "$PLAN" | sed 's/^/    /'
+say "  Verifying what is now live (read-only again — no signer)…"
+node "$TOOLS/grant.mjs" list --grantor "$GRANTOR" --agent "$AGENT" 2>&1 | sed 's/^/    /'
 say ""
-printf '  Proceed? [y/N]: '
-read -r YN ||:
-case "$YN" in y|Y|yes|YES) ;; *) say "  Nothing signed."; exit 0 ;; esac
-
-say ""
-FAILED=0
-printf '%s' "$PLAN" | while IFS="$(printf '\t')" read -r NAME NPUB; do
-  [ -n "$NPUB" ] || continue
-  say "  → $NAME"
-  if node "$TOOLS/grant.mjs" issue --to "$NPUB" --agent "$AGENT" 2>&1 | sed 's/^/      /'; then :; else
-    say "      FAILED — $NAME was not granted"
-  fi
-done
-
-say ""
-say "  Done. Verify what the agent now sees:"
-say "     node tools/grant.mjs list --agent $AGENT"
-say ""
-say "  Revoke any one of them later with:"
-say "     node tools/grant.mjs revoke --grant <440 id>"
+say "  Revoke any one of them with:  node tools/grant.mjs revoke --grant <440 id>"

--- a/tools/grant.mjs
+++ b/tools/grant.mjs
@@ -81,13 +81,24 @@ async function resolveSigner() {
   const pubkey = getPublicKey(sk)
   return { pubkey, sign: (tmpl) => finalizeEvent(tmpl, sk), close: () => {} }
 }
-const signer = await resolveSigner()
-const pk = signer.pubkey
-
 const args = process.argv.slice(2)
 const cmd = args[0]
 const flag = (n) => { const i = args.indexOf(n); return i === -1 ? null : args[i + 1] }
 const HEX64 = /^[0-9a-f]{64}$/i
+
+// Only the commands that SIGN need a signer. `list` just reads relays, so given --grantor it
+// runs with no signer at all — no connection, no approval prompt, no wait. That matters: a tool
+// that asks your signer for permission it does not need trains you to approve without reading.
+let signer, pk
+const listOnly = cmd === 'list' && flag('--grantor')
+if (listOnly) {
+  const g = flag('--grantor')
+  pk = g.startsWith('npub1') ? nip19.decode(g).data : (HEX64.test(g) ? g.toLowerCase() : die('--grantor must be npub or 64-hex'))
+  signer = { pubkey: pk, sign: () => die('list is read-only'), close: () => {} }
+} else {
+  signer = await resolveSigner()
+  pk = signer.pubkey
+}
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
 function relays() {
@@ -121,8 +132,15 @@ if (cmd === 'whoami') {
   console.log(`  "grantors": ["${pk}"]`)
   await signer.close()
 } else if (cmd === 'issue') {
-  const toRaw = flag('--to') || die('issue needs --to <npub|hex>')
-  const grantee = toRaw.startsWith('npub1') ? nip19.decode(toRaw).data : (HEX64.test(toRaw) ? toRaw.toLowerCase() : die('--to must be npub or 64-hex'))
+  // --to accepts a comma-separated list so a batch signs over ONE signer connection. Each
+  // invocation is a fresh process and therefore a fresh NIP-46 session; issuing five grants as
+  // five commands means five approval prompts, which trains an operator to approve without
+  // reading — the opposite of what an approval is for.
+  const toRaw = flag('--to') || die('issue needs --to <npub|hex>[,<npub|hex>…]')
+  const grantees = toRaw.split(',').map(s => s.trim()).filter(Boolean).map(t =>
+    t.startsWith('npub1') ? nip19.decode(t).data : (HEX64.test(t) ? t.toLowerCase() : die(`--to entry is not an npub or 64-hex: ${t}`)))
+  if (!grantees.length) die('issue needs at least one --to')
+  const grantee = grantees[0]
   // Two things can be granted, and they differ only in what the scope binds to:
   //   --channel <uuid>  cap admit  — this grantee may enter that channel  (the S3 tier)
   //   --agent <npub>    cap task   — this grantee may TASK that agent     (attention as a scope)
@@ -139,18 +157,22 @@ if (cmd === 'whoami') {
   const cap = flag('--cap') || (agentRaw ? 'task' : 'admit')
   const allowed = agentRaw ? ['task', 'task+act'] : ['admit']
   if (!allowed.includes(cap)) die(`--cap ${cap} is not valid for this scope; expected one of: ${allowed.join(', ')}`)
-  const salt = randomBytes(16).toString('hex')
-  const hash = createHash('sha256').update(Buffer.concat([
-    Buffer.from('waggle/da-scope/v1'), Buffer.from([0]), Buffer.from(subject), Buffer.from(salt, 'hex'),
-  ])).digest('hex')
-  const ev = await signer.sign({
-    kind: NIPDA.grant,
-    created_at: Math.floor(Date.now() / 1000),
-    tags: [['p', grantee], [NIPDA.scopeTag, hash, salt], [NIPDA.capTag, cap]],
-    content: '',
-  })
-  console.log(`440 ${ev.id}\n  grantee ${grantee}\n  scope   ${hash.slice(0, 16)}… (salted; subject never public)\n  cap     ${cap}\n  grantor ${pk}`)
-  for (const line of await publish(ev)) console.log('  ' + line)
+  // One fresh salt PER grant, never one for the batch: a shared salt would make two grants into
+  // the same subject linkable, which is the exact property the salt exists to prevent.
+  for (const g of grantees) {
+    const salt = randomBytes(16).toString('hex')
+    const hash = createHash('sha256').update(Buffer.concat([
+      Buffer.from('waggle/da-scope/v1'), Buffer.from([0]), Buffer.from(subject), Buffer.from(salt, 'hex'),
+    ])).digest('hex')
+    const ev = await signer.sign({
+      kind: NIPDA.grant,
+      created_at: Math.floor(Date.now() / 1000),
+      tags: [['p', g], [NIPDA.scopeTag, hash, salt], [NIPDA.capTag, cap]],
+      content: '',
+    })
+    console.log(`440 ${ev.id}\n  grantee ${g}\n  scope   ${hash.slice(0, 16)}… (salted; subject never public)\n  cap     ${cap}\n  grantor ${pk}`)
+    for (const line of await publish(ev)) console.log('  ' + line)
+  }
   await signer.close()
 } else if (cmd === 'revoke') {
   const target = flag('--grant') || die('revoke needs --grant <440 event id>')


### PR DESCRIPTION
**The report:** the wizard stopped at `Checking what is already granted` with no further output.

It was not hung. `grant.mjs` was waiting for the connection to be approved in the signer app — and the wrapper had sent that step's stderr to `/dev/null`. stderr is exactly where the approval URL, the one-time client-key notice, and every connection error are printed. Hiding it turned a normal *approve this* pause into a mystery with nothing to act on.

**Fixing only that would have left a worse problem underneath.** Each `grant.mjs` run is a separate process, so a separate NIP-46 session: one list plus five grants = **six approval prompts**. A tool that asks repeatedly, and for permission it does not need, trains an operator to approve without reading — the opposite of what approval is for.

So the shape changed, not just the symptom:

- **`list` needs no signer.** Given `--grantor` it reads relays and returns; listing signs nothing. Signer resolution is now lazy rather than unconditional at module load.
- **`issue --to` accepts a comma-separated list** and signs the batch over one connection. Each grant still gets its **own fresh salt** — a shared salt would make grants into the same subject linkable, which is the exact property the salt exists to prevent.
- **The bunker string is requested only after the plan is confirmed**, so you decide what is being signed before handing over the means to sign it. Pre-flight and verification both run read-only.
- **stderr passes through**, the signer-approval step is called out on screen, and the wait is bounded so it fails with advice instead of hanging.

Net: one approval for the whole run, and no step that can wait silently.

Verified end to end up to the signing prompt with no signer involved: names resolve, existing grants read clean, the plan renders, and declining signs nothing.

Drafted with assistance from [Claude Code](https://claude.com/claude-code)