### PR TITLE
deploy: schedule the tripwire off-host, with a separate-key alarm (#34)

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -123,3 +123,95 @@ GRANTOR_BUNKER='bunker://…' node tools/grant.mjs revoke --grant <440 id>
 
 `GRANTOR_NSEC` (a local key) also works for demos/CI, but the bunker path is the
 zero-custody default: the maintainer authors admissions without any key touching the host.
+
+## Tripwire — out-of-process signing detection (#34)
+
+Process rate-limits cannot catch key theft: a thief with the raw poster nsec signs
+**direct**, bypassing our code entirely. `tools/tripwire.mjs` watches the **wire** instead
+of the process — it fetches the poster key's recent on-relay events and diffs them against
+the bridge's own send-journal (`data/send-journal.log`). Any post authored by our key that
+the journal does not contain was signed by something other than our process: theft, a
+second signer, an impersonation. That is the alarm.
+
+`deploy/tripwire.service` (oneshot) + `deploy/tripwire.timer` (30-min cadence) make
+detection a property of the **install**, not of anyone remembering to run a script.
+
+### Two rules the unit exists to enforce
+
+1. **The alarm is signed by a SEPARATE key, never the poster key.** An alarm signed by the
+   identity under suspicion is worthless — a thief holding the poster nsec could forge the
+   all-clear too. Set `ALARM_NSEC` to a **dedicated** key with zero authority (its only
+   power is sending a DM), so it is safe to hold on the watcher and disposable if the
+   watcher is lost. Never set it to `BUZZ_PRIVATE_KEY`.
+2. **Off-host is stronger.** A compromised box can silence an on-box watcher before it
+   fires. The recommended posture runs the tripwire on a **separate host** (your Mac, a
+   second droplet) against a synced copy of the journal — a box compromise then cannot kill
+   its own detector. On-box is the fallback, not the target.
+
+### Dependency ordering (#33)
+
+The diff is only meaningful against a **current** journal. The install must be running a
+build that writes `data/send-journal.log` on every send (both lanes) — that is exactly what
+#33's deployed-build verification confirms. Until then the journal may be stale or absent,
+and the script will (correctly) warn that **every** post looks unauthorized. **Do not arm
+the alarm DM until #33 confirms the running build is journaling.** The `since-min 60` window
+being wider than the 30-min cadence means every post is covered by ≥2 runs — one missed run
+never opens a gap.
+
+### Off-host install (recommended)
+
+On a **watcher host** that is not the box — clone this repo, `npm ci`, then:
+
+```
+# tripwire.env (0600, owner-only, NEVER committed):
+POSTER=<npub of the bridge poster key>          # PUBLIC key only — the watcher never signs as poster
+SEND_JOURNAL_PATH=/opt/waggle/data/send-journal.log   # the LOCAL synced copy (below)
+ALARM_NSEC=<dedicated alarm key nsec>           # rule 1 — a fresh, zero-authority key
+ALARM_TO=<npub to DM on alarm>
+BUZZ_RELAY_URL=<relay>                          # extra public relays come from config.json
+```
+
+The watcher **pulls** the journal (so the box needs no credentials to the watcher — the
+journal is only public event ids, nothing sensitive), on its own timer just ahead of the
+tripwire tick:
+
+```
+rsync -az bridge@<box>:/opt/west-bridge/data/send-journal.log /opt/waggle/data/send-journal.log
+```
+
+Then install the units (edit `WorkingDirectory`/`User`/paths in the unit files to match this
+host first):
+
+```
+sudo cp deploy/tripwire.{service,timer} /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now tripwire.timer
+systemctl list-timers tripwire.timer
+```
+
+On macOS (no systemd) run the same script from a `launchd` job or `cron` on the same
+30-min cadence — the units are a convenience, `tools/tripwire.mjs` is the whole detector.
+
+### On-box fallback
+
+Weaker (dies with the box it polices), but better than nothing while an off-host watcher is
+being stood up. Point `WorkingDirectory` at the sealed tree's checkout and
+`SEND_JOURNAL_PATH` at `/opt/west-bridge/data/send-journal.log` directly (grant the runtime
+user group-read on it), and update `ReadWritePaths` to that same tree's `data/` so the
+alarm log stays writable. Everything else is identical. Note the weakness is not just that
+the watcher dies with the box — the box also writes the journal it is judged against, so a
+thief who owns the box can forge journal entries to match a stolen-key post. On-box catches
+mistakes and crude theft; only off-host catches an adversary who owns the host.
+
+### Verify (positive + negative control)
+
+- **Negative control (must stay quiet):** run a tick with a healthy journal — a journaled,
+  bridge-emitted post must yield exit 0 and `OK — every on-relay post … was emitted by our
+  process.`
+- **Positive control (must fire):** temporarily point `--journal` at an empty file (or sign
+  one test event off-process) so a real on-relay post is unaccounted — the run must print
+  `🚨 TRIPWIRE`, append `data/tripwire-alarms.log`, exit 2, and (if `ALARM_*` are set) DM the
+  alarm. Restore the real journal path after.
+
+Alert on **exit 2 / unit failure** (`systemctl --failed`, or an `OnFailure=` handler) as the
+local backstop to the out-of-band alarm DM.

--- a/deploy/tripwire.service
+++ b/deploy/tripwire.service
@@ -1,0 +1,46 @@
+# waggle tripwire unit (oneshot; driven by tripwire.timer). Out-of-process detection of
+# unauthorized signing by the bridge POSTER key: tools/tripwire.mjs fetches the poster's
+# recent on-relay events and diffs them against the bridge send-journal (#33). Exit codes:
+#   0 = clean (every on-relay post came from our process)
+#   2 = ALARM — an on-relay post the bridge never emitted (theft / second signer)
+#   1 = misconfig (no POSTER, etc.)
+# systemd surfaces exit 2 as a FAILED unit; the script ALSO sends the alarm DM itself
+# (out-of-band, signed by the separate alarm key). Alert on `systemctl --failed` as the
+# local backstop to the DM. See deploy/README.md "Tripwire" for the full contract.
+#
+# TWO RULES THIS UNIT EXISTS TO ENFORCE:
+#   1. ALARM_NSEC is a DEDICATED key, NEVER the poster (BUZZ_PRIVATE_KEY) key. An alarm
+#      signed by the identity under suspicion proves nothing. The alarm key has zero
+#      authority — its only power is sending a DM — so it is safe to hold on the watcher.
+#   2. OFF-HOST IS STRONGER. A compromised box can silence an on-box watcher before it
+#      fires. Prefer a SEPARATE host running this against a synced copy of the journal.
+#
+# WorkingDirectory is a checkout of THIS repo on the watcher host (off-host: your Mac / a
+# second box — recommended; on-box fallback: point it at the sealed tree). Adjust the paths
+# and User below to that host. tripwire.env (0600, owner-only, NEVER committed) sets:
+#   POSTER=<npub|hex of the bridge poster key>   # the PUBLIC key — this watcher never signs as poster
+#   SEND_JOURNAL_PATH=<path to the (synced) send-journal.log>
+#   ALARM_NSEC=<dedicated alarm key nsec>        # rule 1 — separate identity
+#   ALARM_TO=<npub to DM on alarm>
+#   BUZZ_RELAY_URL=<relay>                       # extra public relays are read from config.json
+[Unit]
+Description=waggle tripwire — detect out-of-process signing by the bridge poster key
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+User=bridge
+Group=bridge
+WorkingDirectory=/opt/waggle
+# --since-min 60 is deliberately WIDER than the 30-min timer cadence: overlapping windows
+# mean a single missed run never opens a detection gap (see tripwire.timer).
+ExecStart=/usr/bin/node tools/tripwire.mjs --since-min 60
+EnvironmentFile=/opt/waggle/tripwire.env
+Environment=PATH=/usr/local/bin:/usr/bin:/bin
+NoNewPrivileges=yes
+ProtectSystem=strict
+ProtectHome=yes
+PrivateTmp=yes
+# Only the alarms log is written; everything else is read-only or network.
+ReadWritePaths=/opt/waggle/data

--- a/deploy/tripwire.timer
+++ b/deploy/tripwire.timer
@@ -1,0 +1,23 @@
+# Drives tripwire.service on a fixed cadence, so detection is a property of the INSTALL,
+# not of operator diligence (the whole point of #34). The cadence (30 min) is shorter than
+# the service's poll window (--since-min 60) BY DESIGN: overlapping windows mean one missed
+# or delayed run never opens a gap a thief could slip a post through unseen.
+#
+#   sudo cp deploy/tripwire.{service,timer} /etc/systemd/system/
+#   sudo systemctl daemon-reload
+#   sudo systemctl enable --now tripwire.timer
+#   systemctl list-timers tripwire.timer      # confirm it is scheduled
+[Unit]
+Description=waggle tripwire — periodic out-of-process signing check (every 30 min)
+
+[Timer]
+# First run shortly after boot, then every 30 minutes of active time.
+OnBootSec=5min
+OnUnitActiveSec=30min
+# Jitter so many installs do not hammer the relays on the same tick.
+RandomizedDelaySec=2min
+# Catch up one run if the host was down at the scheduled time.
+Persistent=true
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
Closes #34.

Makes out-of-process signing detection a property of the **install**, not of operator diligence — the scheduling and alarm path around `tools/tripwire.mjs`.

**What ships**
- `deploy/tripwire.service` — oneshot wrapper for `tools/tripwire.mjs --since-min 60`, hardened (`ProtectSystem=strict`, `NoNewPrivileges`, `ReadWritePaths` limited to the alarms log). systemd surfaces exit 2 (ALARM) as a failed unit.
- `deploy/tripwire.timer` — 30-min cadence. The poll window (`--since-min 60`) is deliberately **wider** than the cadence so a single missed run never opens a detection gap; `Persistent=true` catches up after downtime; jitter so installs don't hit relays on the same tick.
- `deploy/README.md` — the full "Tripwire" contract: the two rules, off-host install (recommended), on-box fallback, the #33 ordering dependency, and positive/negative verification controls.

**The two rules the unit exists to enforce**
1. **The alarm is signed by a SEPARATE key, never the poster key** (`ALARM_NSEC` ≠ `BUZZ_PRIVATE_KEY`). An alarm signed by the identity under suspicion proves nothing — a thief holding the poster nsec could forge the all-clear too. The alarm key has zero authority (its only power is sending a DM), so it's safe to hold on the watcher.
2. **Off-host is stronger.** A compromised box can silence an on-box watcher before it fires — *and* the box writes the very journal it's judged against, so a host-owner could forge journal entries to match a stolen-key post. The recommended posture runs the watcher on a separate host against a synced journal copy. On-box catches mistakes and crude theft; only off-host catches an adversary who owns the host.

**Dependency (#33):** the diff is only meaningful against a current send-journal, so the doc states plainly — do **not** arm the alarm DM until #33 confirms the running build is journaling. Until then the tool correctly warns that every post looks unauthorized.

**Validation:** interface verified line-by-line against `tools/tripwire.mjs` on `main` — `--since-min`, `--journal`/`SEND_JOURNAL_PATH`, `POSTER` (defaults to the `BUZZ_PRIVATE_KEY` pubkey), exit codes 0/2/1, the `data/tripwire-alarms.log` append, and the `ALARM_NSEC`/`ALARM_TO` NIP-17 alarm DM. Unit syntax eyeball-reviewed (no systemd on the dev host to run `systemd-analyze verify`).

_Originating conversation: Buzz connector channel `73f80d38-3245-41a9-814c-8ad364686944`._