### PR TITLE
tripwire: refuse to run when the alarm key is the poster key (#81)

### DIFF
--- a/tools/tripwire.mjs
+++ b/tools/tripwire.mjs
@@ -41,6 +41,14 @@ if (!poster && process.env.BUZZ_PRIVATE_KEY) {
 if (!poster) die('set POSTER=<npub|hex> (or provide BUZZ_PRIVATE_KEY to derive it)')
 const posterHex = poster.startsWith('npub1') ? nip19.decode(poster).data : poster.toLowerCase()
 
+// Rule 1 as a property of the code, not just the docs: the alarm must be signed by a SEPARATE
+// key, never the poster. If ALARM_NSEC derives to the poster, a thief holding that nsec could
+// forge the all-clear too — so refuse to run rather than offer that false assurance.
+if (process.env.ALARM_NSEC) {
+  const alarmSk = process.env.ALARM_NSEC.startsWith('nsec1') ? nip19.decode(process.env.ALARM_NSEC).data : Uint8Array.from(Buffer.from(process.env.ALARM_NSEC, 'hex'))
+  if (getPublicKey(alarmSk) === posterHex) die('ALARM_NSEC derives to the POSTER key — the alarm must be signed by a SEPARATE, zero-authority key (rule 1). An alarm signed by the identity under suspicion proves nothing.')
+}
+
 const sinceMin = Number(arg('--since-min', 120))
 const since = Math.floor(Date.now() / 1000) - sinceMin * 60
 const JOURNAL = arg('--journal', process.env.SEND_JOURNAL_PATH || resolve(ROOT, 'data', 'send-journal.log'))


### PR DESCRIPTION
Closes #81. Follow-up from the #34 / PR #80 review (raised by Claude).

Rule 1 — the alarm must be signed by a **separate** key, never the poster (`ALARM_NSEC` ≠ `BUZZ_PRIVATE_KEY`) — was only enforced in `deploy/README.md`. This makes it a property of the code: if `ALARM_NSEC` derives to `POSTER`, `tripwire.mjs` dies before doing anything, rather than running with an alarm the key under suspicion could itself forge.

The guard sits right after the poster pubkey is resolved (before any network work, so it fails fast) and reuses the file's existing `nip19`/`getPublicKey` decode idiom:

```js
if (process.env.ALARM_NSEC) {
  const alarmSk = process.env.ALARM_NSEC.startsWith('nsec1') ? nip19.decode(process.env.ALARM_NSEC).data : Uint8Array.from(Buffer.from(process.env.ALARM_NSEC, 'hex'))
  if (getPublicKey(alarmSk) === posterHex) die('ALARM_NSEC derives to the POSTER key — …')
}
```

**Verified** with a real keypair:
- `ALARM_NSEC` == poster key → dies, exit 1, rule-1 message. ✓
- `ALARM_NSEC` = a separate key → passes the guard, proceeds to the check. ✓
- Full `npm test` suite green (six suites).

One line of behavior, isolated to `tools/tripwire.mjs`. This is exactly #34's thesis — detection as a property of the install, not of operator diligence.

_Originating conversation: Buzz connector channel `73f80d38-3245-41a9-814c-8ad364686944`._