### PR TITLE
tripwire: union every lane's journal, not just one (#87)

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -165,19 +165,28 @@ On a **watcher host** that is not the box — clone this repo, `npm ci`, then:
 ```
 # tripwire.env (0600, owner-only, NEVER committed):
 POSTER=<npub of the bridge poster key>          # PUBLIC key only — the watcher never signs as poster
-SEND_JOURNAL_PATH=/opt/waggle/data/send-journal.log   # the LOCAL synced copy (below)
+SEND_JOURNAL_PATH=/opt/waggle/data/journal-sealed.log:/opt/waggle/data/journal-read.log  # BOTH lanes, :-separated (below)
 ALARM_NSEC=<dedicated alarm key nsec>           # rule 1 — a fresh, zero-authority key
 ALARM_TO=<npub to DM on alarm>
 BUZZ_RELAY_URL=<relay>                          # extra public relays come from config.json
 ```
 
-The watcher **pulls** the journal (so the box needs no credentials to the watcher — the
-journal is only public event ids, nothing sensitive), on its own timer just ahead of the
-tripwire tick:
+The watcher **pulls** the journals (so the box needs no credentials to the watcher — a journal
+is only public event ids, nothing sensitive), on its own timer just ahead of the tripwire tick.
+**Pull every lane's journal, not just one:** the poster key signs on both lanes but each bridge
+instance journals to its own tree, so the tripwire must diff against their UNION — a legitimate
+send on the lane you did not sync otherwise reads as theft. Two lanes today, sealed and the
+public read lane (pull each as a user that can read that tree — the sealed tree is not readable
+by the read-lane account):
 
 ```
-rsync -az bridge@<box>:/opt/waggle-sealed/data/send-journal.log /opt/waggle/data/send-journal.log
+rsync -az <sealed-reader>@<box>:/opt/waggle-sealed/data/send-journal.log /opt/waggle/data/journal-sealed.log
+rsync -az bridge@<box>:/opt/waggle-read/data/send-journal.log            /opt/waggle/data/journal-read.log
 ```
+
+`SEND_JOURNAL_PATH` lists both (`:`-separated, above); `tripwire.mjs` unions them and warns for
+any journal it cannot find, so a half-completed sync fails loud rather than silently narrowing
+what it checks.
 
 Then install the units (edit `WorkingDirectory`/`User`/paths in the unit files to match this
 host first):
@@ -195,13 +204,14 @@ On macOS (no systemd) run the same script from a `launchd` job or `cron` on the 
 ### On-box fallback
 
 Weaker (dies with the box it polices), but better than nothing while an off-host watcher is
-being stood up. Point `WorkingDirectory` at the sealed tree's checkout and
-`SEND_JOURNAL_PATH` at `/opt/waggle-sealed/data/send-journal.log` directly (grant the runtime
-user group-read on it), and update `ReadWritePaths` to that same tree's `data/` so the
-alarm log stays writable. Everything else is identical. Note the weakness is not just that
-the watcher dies with the box — the box also writes the journal it is judged against, so a
-thief who owns the box can forge journal entries to match a stolen-key post. On-box catches
-mistakes and crude theft; only off-host catches an adversary who owns the host.
+being stood up. Set `SEND_JOURNAL_PATH` to **both** trees' journals, `:`-separated —
+`/opt/waggle-sealed/data/send-journal.log:/opt/waggle-read/data/send-journal.log` (grant the
+runtime user read on each) — for the same union reason as above; point `WorkingDirectory` at a
+repo checkout and update `ReadWritePaths` to that checkout's `data/` so the alarm log stays
+writable. Everything else is identical. Note the weakness is not just that the watcher dies with
+the box — the box also writes the journals it is judged against, so a thief who owns the box can
+forge entries to match a stolen-key post. On-box catches mistakes and crude theft; only off-host
+catches an adversary who owns the host.
 
 ### Verify (positive + negative control)
 

--- a/tools/tripwire.mjs
+++ b/tools/tripwire.mjs
@@ -9,10 +9,15 @@
 // other than our process — theft, a second signer, an impersonation. That is the alarm.
 //
 // Runs on-box OR off-box. OFF-BOX IS STRONGER: a box compromise can kill an on-box watcher,
-// but not one running on your Mac / a separate host. Point SEND_JOURNAL_PATH at a synced copy
-// of the journal (rsync/scp on a timer) and run this anywhere.
+// but not one running on your Mac / a separate host. Sync each lane's journal (rsync/scp on a
+// timer) and run this anywhere.
 //
-//   POSTER=<npub|hex> node tools/tripwire.mjs [--since-min 120] [--journal <path>]
+// UNION THE LANES: the poster key signs on every lane, but each bridge instance journals to its
+// OWN tree (sealed -> /opt/waggle-sealed/data, public read-lane -> /opt/waggle-read/data).
+// Give the watcher ALL of them or a legitimate send on the lane it did not see reads as theft.
+//
+//   POSTER=<npub|hex> node tools/tripwire.mjs [--since-min 120] [--journal <a> --journal <b> ...]
+//   (--journal is repeatable; SEND_JOURNAL_PATH may be a `:`-separated list; all are unioned.)
 //   (POSTER defaults to the pubkey of BUZZ_PRIVATE_KEY if that env is present.)
 //
 // Alarm: loud stderr, an appended data/tripwire-alarms.log, and exit code 2. If ALARM_NSEC +
@@ -29,6 +34,7 @@ import * as nip44 from 'nostr-tools/nip44'
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..')
 const arg = (n, d) => { const i = process.argv.indexOf(n); return i === -1 ? d : process.argv[i + 1] }
+const args = (n) => process.argv.reduce((a, v, i) => (process.argv[i - 1] === n ? [...a, v] : a), [])
 const die = (m) => { console.error(`tripwire: ${m}`); process.exit(1) }
 
 // Poster identity — the key whose signing we are policing.
@@ -51,7 +57,17 @@ if (process.env.ALARM_NSEC) {
 
 const sinceMin = Number(arg('--since-min', 120))
 const since = Math.floor(Date.now() / 1000) - sinceMin * 60
-const JOURNAL = arg('--journal', process.env.SEND_JOURNAL_PATH || resolve(ROOT, 'data', 'send-journal.log'))
+// The poster key signs on BOTH lanes and each bridge instance journals to its OWN tree (sealed
+// -> /opt/waggle-sealed/data, public read-lane -> /opt/waggle-read/data). The tripwire must diff
+// on-relay posts against the UNION of every lane's journal, or a legitimate send recorded only
+// in the lane it did not sync reads as unauthorized -> false alarm. So --journal is repeatable,
+// and SEND_JOURNAL_PATH may be a `:`-separated list; every path is unioned.
+const JOURNALS = (() => {
+  const flags = args('--journal')
+  if (flags.length) return flags
+  const env = (process.env.SEND_JOURNAL_PATH || '').split(':').map(s => s.trim()).filter(Boolean)
+  return env.length ? env : [resolve(ROOT, 'data', 'send-journal.log')]
+})()
 const ALARMS = resolve(ROOT, 'data', 'tripwire-alarms.log')
 
 function loadRelays() {
@@ -64,9 +80,11 @@ function loadRelays() {
 
 function loadJournal() {
   const ids = new Set()
-  if (!existsSync(JOURNAL)) { console.error(`tripwire: WARNING — no journal at ${JOURNAL}; every post will look unauthorized. Point --journal at the bridge's send-journal.`); return ids }
-  for (const line of readFileSync(JOURNAL, 'utf8').split('\n').filter(Boolean)) {
-    try { const r = JSON.parse(line); if (r.id) ids.add(r.id) } catch { /* skip */ }
+  for (const path of JOURNALS) {
+    if (!existsSync(path)) { console.error(`tripwire: WARNING — no journal at ${path}; sends recorded only there will look unauthorized. Sync every lane's send-journal (--journal is repeatable).`); continue }
+    for (const line of readFileSync(path, 'utf8').split('\n').filter(Boolean)) {
+      try { const r = JSON.parse(line); if (r.id) ids.add(r.id) } catch { /* skip */ }
+    }
   }
   return ids
 }
@@ -106,7 +124,7 @@ const events = await fetchPosterEvents()
 const anomalies = events.filter(e => !journal.has(e.id))
 const iso = (s) => new Date(s * 1000).toISOString()
 
-console.error(`tripwire: poster ${posterHex.slice(0, 12)}… · window ${sinceMin}m · ${events.length} on-relay event(s) · ${journal.size} journaled · ${anomalies.length} unaccounted`)
+console.error(`tripwire: poster ${posterHex.slice(0, 12)}… · window ${sinceMin}m · ${events.length} on-relay event(s) · ${journal.size} journaled across ${JOURNALS.length} lane journal(s) · ${anomalies.length} unaccounted`)
 
 if (!anomalies.length) {
   console.log('OK — every on-relay post by the poster key was emitted by our process.')


### PR DESCRIPTION
Closes #87. Pre-arm blocker surfaced in the #80 review (Claude) and confirmed against `bridge.mjs` + Neil's live host verification.

**The bug:** each bridge instance journals to its own tree — public read-lane sends → `/opt/west-bridge-read/data/send-journal.log`, sealed + return-lane sends → `/opt/west-bridge/data/send-journal.log` — but **both sign as the one poster key**. The #80 watcher synced only the sealed journal, so any poster-key send recorded only in the read tree read as unaccounted → **false alarm on day one**.

**The fix — union is a property of the tool** (consistent with #82's guard: detection as a property of the install, not operator diligence):
- `tools/tripwire.mjs`: `--journal` is now **repeatable**, and `SEND_JOURNAL_PATH` may be a `:`-separated list. `loadJournal` unions every path into the id set and **warns per missing journal** (`continue`, not bail) — a half-completed sync fails loud rather than silently narrowing what it checks. The summary line reports `N journaled across M lane journal(s)`.
- `deploy/README.md`: the off-host watcher rsyncs **both** per-tree journals; the on-box fallback points `SEND_JOURNAL_PATH` at both trees. Same union reasoning documented in both.

**Verified** with real fixtures (two journals, one overlapping id):
- two `--journal` flags → **3** distinct journaled (dedup across files) vs **2** for the single-journal control. ✓
- one present + one missing → warns on the missing path, still unions the present one. ✓
- `SEND_JOURNAL_PATH` as a `:`-list → same union. ✓ Single path → backward-compatible. ✓
- Full `npm test` suite green.

No unit change needed — `tripwire.service` reads `SEND_JOURNAL_PATH` from `tripwire.env`, now a `:`-list.

_Note: the second pre-arm item — eyes-on that the **sealed** journal actually grows on a sealed send (Neil proved the read lane; sealed is outside his scope) — is tracked separately; it is host verification, not code._

_Originating conversation: Buzz connector channel `73f80d38-3245-41a9-814c-8ad364686944`._