### PR TITLE
Retire the west-bridge name: one project, one name (#62)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ no member's.
   grant-based admission tier — this repo is its working reference consumer.
 - **License:** MIT.
 
-*(Internal service name: `west-bridge` — it predates the public name and stays for
+*(Internal service name: `waggle` — it predates the public name and stays for
 deployed-unit continuity.)*
 
 
@@ -33,7 +33,6 @@ hand. **v1 forwards Armada NIP-17 DMs only.**
 
 - **Owner:** the read-lane engineer (bridge manager). Crypto / agent-side unwrap: the outbox engineer.
 - **Design:** `../../PLANS/WEST_BRIDGE_SCOPING.md`
-- **Origin:** promoted from the working prototype `../../.scratch/da-consumer/mydude_west_bridge.mjs`.
 
 ## What it does
 
@@ -93,8 +92,8 @@ Pruned to the most-recent `SEEN_CAP` ids on boot.
 ## Deploy
 
 Everything lives in [`deploy/`](deploy/README.md): checked-in systemd units for both
-instances (sealed lanes as `west-bridge.service`, public read lane as
-`west-bridge-read.service` under the non-root `bridge` user), the `bridge-user.sh`
+instances (sealed lanes as `waggle-sealed.service`, public read lane as
+`waggle-read.service` under the non-root `bridge` user), the `bridge-user.sh`
 provisioning script, the push-style `deploy.sh`, the nftables firewall, and the full
 migration runbook (cutover order, data-dir seeding, root-SSH-disable-last warning).
 The relay reconnect loop is in-process; systemd only covers a full crash.

--- a/console/index.html
+++ b/console/index.html
@@ -6,7 +6,11 @@
 <title>waggle console — who is admitted, and by whose signature</title>
 <meta name="description" content="Read-only view of a waggle bridge's live admissions. Reads signed grants off the relays and verifies them in the page. No server, no keys, no privileged access.">
 <script type="importmap">
-{ "imports": { "nostr-tools": "./vendor/nostr-tools.mjs" } }
+{ "imports": {
+    "nostr-tools": "./vendor/nostr-tools.mjs",
+    "nostr-tools/pool": "./vendor/nostr-tools-pool.mjs",
+    "nostr-tools/nip46": "./vendor/nostr-tools-nip46.mjs"
+} }
 </script>
 <style>
   :root {
@@ -15,6 +19,7 @@
     --gold:#c39a56; --gold-bright:#e2c079;
     --accent:#cf8a2e; --accent-bright:#e8a545; --accent-ink:#0b0906;
     --good:#8fae6a; --warn:#d9a648; --critical:#c0705a;
+    --alby:#ffdf6f; --alby-bright:#ffe98c; --alby-ink:#1c1400;
     --sans:-apple-system,BlinkMacSystemFont,"Segoe UI","Inter",Roboto,"Helvetica Neue",Arial,sans-serif;
     --mono:ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Roboto Mono",monospace;
     --display:"Iowan Old Style","Palatino Linotype",Palatino,Georgia,serif;
@@ -53,6 +58,18 @@
   .btn{background:var(--accent);color:var(--accent-ink);border:none;border-radius:var(--r-sm);
     padding:10px 18px;font-weight:700;font-size:15px;font-family:inherit;cursor:pointer;margin-top:14px}
   .btn:hover{background:var(--accent-bright)}
+  /* the family's standard sign-in cluster — same markup and classes as the other consoles */
+  button.primary{background:var(--accent);border:1px solid var(--accent);color:var(--accent-ink);
+    font-weight:700;text-transform:uppercase;letter-spacing:.1em}
+  button.primary:hover{background:var(--accent-bright);border-color:var(--accent-bright)}
+  .alby-bar{width:100%;display:flex;align-items:center;justify-content:center;gap:10px;padding:14px 18px;
+    font-size:15px;font-weight:700;letter-spacing:.01em;background:var(--alby);border:1px solid var(--alby);
+    color:var(--alby-ink);text-transform:none;border-radius:var(--r-sm);cursor:pointer;font-family:inherit;margin-top:4px}
+  .alby-bar:hover{background:var(--alby-bright);border-color:var(--alby-bright)}
+  .alby-bar .alby-mark{width:24px;height:24px;flex:none}
+  .alby-sub{text-align:center;color:var(--dim);font-size:12px;margin:10px 0 0}
+  .alt{margin-top:16px;color:var(--dim);font-size:14px}
+  .alt a{color:var(--accent);cursor:pointer;text-decoration:underline}
   .btn.ghost{background:transparent;color:var(--text);border:1px solid var(--line-strong)}
   .btn.ghost:hover{border-color:var(--accent);color:var(--accent-bright);background:transparent}
   .btn:disabled{opacity:.45;cursor:not-allowed}
@@ -80,41 +97,38 @@
 </style>
 </head>
 <body>
+<!-- the shared Nave identity bar (nave-connect + nave-titlebar), vendored and mounted the
+     same way every other app in the family does it — one sign-in, promoted not re-invented -->
+<div id="titlebar" style="max-width:1000px;margin:0 auto;padding:0 20px"></div>
+
 <main>
-  <div class="top">
-    <svg class="mark" viewBox="0 0 100 100" role="img" aria-label="waggle">
-      <rect x="2" y="2" width="96" height="96" rx="20" fill="#0b0906" stroke="#c39a56" stroke-opacity="0.5" stroke-width="2"/>
-      <g fill="none" stroke="#e2c079" stroke-width="2.6" stroke-linecap="round" opacity="0.9">
-        <path d="M62 34 C 38 24 22 44 38 66"/><path d="M62 34 C 86 44 74 70 38 66"/>
-      </g>
-      <polyline points="38,66 46.5,59 47.5,48 58.5,45 62,34" fill="none" stroke="#e2c079"
-        stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
-      <circle cx="62" cy="34" r="3" fill="#e2c079"/>
-    </svg>
-    <div class="title">waggle console</div>
-  </div>
-  <p class="sub">Who is admitted to your community, who may task your agents, and by whose signature.
-  This page reads the signed grants off the public relays and <b>verifies every signature here, in
+  <p class="sub" style="margin-top:26px">This page reads the signed grants off the public relays and <b>verifies every signature here, in
   your browser</b>. It needs no access to your bridge host and no key of any kind — an admission is
   a public signed event, so seeing the truth of it requires no privilege.</p>
 
-  <div class="panel" id="auth">
-    <h2>Sign in</h2>
+  <div class="panel" id="auth" style="display:none">
+    <h2>Choose a signer</h2>
     <p style="margin:0 0 12px;color:var(--dim);font-size:13.5px;max-width:74ch">
       Reading needs no key at all — leave this alone and use the lookup below. Sign in only to
       <b>act</b>: issue a grant, or revoke one. Your key never enters this page; it stays in your
       signer, which is handed an unsigned event and returns a signature.
     </p>
-    <div class="row" id="signin-buttons">
-      <button class="btn ghost" id="si-ext">Browser signer</button>
-      <button class="btn ghost" id="si-bunker">Remote signer</button>
-      <button class="btn ghost" id="si-local">Local key</button>
+    <button class="alby-bar" id="si-ext"><span class="alby-mark"><svg viewBox="0 0 28 28" fill="none" aria-hidden="true">
+      <ellipse cx="9.5" cy="9" rx="3.6" ry="5.4" fill="#1c1400" fill-opacity=".22" transform="rotate(-22 9.5 9)"/>
+      <ellipse cx="18.5" cy="9" rx="3.6" ry="5.4" fill="#1c1400" fill-opacity=".22" transform="rotate(22 18.5 9)"/>
+      <ellipse cx="14" cy="16" rx="6" ry="7.4" fill="#1c1400"/>
+      <path d="M8.6 14 H19.4 M8.6 17.6 H19.4 M10.4 21 H17.6" stroke="#ffdf6f" stroke-width="1.5" stroke-linecap="round"/>
+      <path d="M12 8.2 L10.4 4.4 M16 8.2 L17.6 4.4" stroke="#1c1400" stroke-width="1.3" stroke-linecap="round"/>
+      <circle cx="10.2" cy="3.8" r="1.05" fill="#1c1400"/><circle cx="17.8" cy="3.8" r="1.05" fill="#1c1400"/>
+    </svg></span> Sign in with Alby</button>
+    <div class="alby-sub">works with any NIP-07 signer — Alby · nos2x · Amber</div>
+    <div class="row" style="margin-top:18px">
+      <input id="bunker" placeholder="bunker://… from your remote signer (iPhone / no extension)"
+        autocomplete="off" spellcheck="false">
+      <button class="primary" id="si-bunker-go" style="flex:0 0 auto">Connect</button>
     </div>
-    <div id="bunker-row" style="display:none">
-      <label for="bunker">bunker:// connection</label>
-      <input id="bunker" placeholder="bunker://…" spellcheck="false" autocomplete="off">
-      <button class="btn" id="si-bunker-go">Connect</button>
-    </div>
+    <div class="alby-sub">NIP-46 remote signing — pair once with your bunker; the key never enters this browser</div>
+    <div class="alt"><a id="si-local">Advanced: use a local key in this tab (demo / recovery)</a></div>
     <div id="local-row" style="display:none">
       <label for="localkey">nsec — this one <b>does</b> enter the page, which is why it is last</label>
       <input id="localkey" type="password" placeholder="nsec1…" spellcheck="false" autocomplete="off">
@@ -270,6 +284,42 @@ function renderRows() {
       </tr>`).join('')
 }
 
+// ── The shared identity bar ─────────────────────────────────────────────────────────────────
+// Vendored from the estate's component rather than hand-rolled: one sign-in across the fleet,
+// promoted rather than levelled down. The bar owns the signed-in/signed-out presentation and
+// the npub pill; this page only supplies the callbacks.
+import { renderTitlebar, updateTitlebar } from './vendor/nave-titlebar.mjs'
+
+const TB = $('titlebar')
+const WAGGLE_SEAL = `<svg viewBox="0 0 100 100" fill="none" aria-hidden="true">
+  <rect x="2" y="2" width="96" height="96" rx="20" fill="#0b0906" stroke="#c39a56" stroke-opacity="0.5" stroke-width="2"/>
+  <g fill="none" stroke="#e2c079" stroke-width="2.6" stroke-linecap="round" opacity="0.9">
+    <path d="M62 34 C 38 24 22 44 38 66"/><path d="M62 34 C 86 44 74 70 38 66"/></g>
+  <polyline points="38,66 46.5,59 47.5,48 58.5,45 62,34" fill="none" stroke="#e2c079" stroke-width="4"
+    stroke-linecap="round" stroke-linejoin="round"/><circle cx="62" cy="34" r="3" fill="#e2c079"/></svg>`
+
+function drawTitlebar(npub, kind) {
+  renderTitlebar(TB, {
+    appName: 'waggle console',
+    tagline: 'who is admitted, and by whose signature',
+    sealSvg: WAGGLE_SEAL,
+    npub: npub || null,
+    kind: kind || null,
+    onSignIn: npub ? undefined : () => { $('auth').style.display = ''; $('auth').scrollIntoView({ behavior: 'smooth', block: 'center' }) },
+    onRefresh: npub ? () => $('go').click() : undefined,
+    onLogout: npub ? () => {
+      // Signed out means signed out: drop the signer, hide the actions, and re-draw the rows
+      // without them. A control plane must never leave an action visible that it cannot perform.
+      signer = null; signerPk = null
+      $('issue-panel').style.display = 'none'
+      $('confirm-panel').style.display = 'none'
+      setAuth('')
+      drawTitlebar(null, null); renderRows()
+    } : undefined,
+  })
+}
+drawTitlebar(null, null)
+
 // ── Signing ────────────────────────────────────────────────────────────────────────────────
 // The key never enters this page for the two paths that matter: a browser signer and a remote
 // signer are both handed an unsigned event and return a signature. The local-key path is last
@@ -281,10 +331,10 @@ const setAuth = (msg, cls = '') => { const s = $('authst'); s.className = 'statu
 async function adopt(s, label) {
   signer = s
   signerPk = await s.getPublicKey()
-  setAuth(`signed in via ${label} as ${short(signerPk)} — you can now issue and revoke`, 'ok')
-  $('signin-buttons').style.display = 'none'
-  $('bunker-row').style.display = 'none'
+  setAuth('')
+  $('auth').style.display = 'none'
   $('local-row').style.display = 'none'
+  drawTitlebar(nip19.npubEncode(signerPk), s.kind || label)
   $('issue-panel').style.display = ''
   // Convenience only: the grantor field is what you sign as, so default it to the signed-in key.
   if (!$('grantor').value.trim()) { $('grantor').value = nip19.npubEncode(signerPk); $('go').click() }
@@ -296,8 +346,7 @@ $('si-ext').addEventListener('click', async () => {
   try { const { nip07Signer } = await nc(); await adopt(nip07Signer(), 'a browser signer') }
   catch (e) { setAuth(e.message, 'err') }
 })
-$('si-bunker').addEventListener('click', () => { $('bunker-row').style.display = ''; $('local-row').style.display = 'none' })
-$('si-local').addEventListener('click', () => { $('local-row').style.display = ''; $('bunker-row').style.display = 'none' })
+$('si-local').addEventListener('click', () => { $('local-row').style.display = '' })
 $('si-bunker-go').addEventListener('click', async () => {
   setAuth('connecting — approve the request in your signer…')
   try {

--- a/console/vendor/nave-titlebar.mjs
+++ b/console/vendor/nave-titlebar.mjs
@@ -1,0 +1,213 @@
+// Source of truth: nave.pub/components/nave-titlebar.mjs — copy in, do not edit.
+// The unified Nave title bar (the second half of the common sign-in work —
+// nave-connect, nact#16), as a renderer. No imports, no build step: apps
+// vendor this file next to their vendored nave-connect and call
+//
+//   renderTitlebar(el, { appName, npub, kind, onRefresh, onLogout, onSignIn })
+//   updateTitlebar(el, patch)   // shallow-merge into the last opts, re-render
+//
+// with `kind` straight off nave-connect's signer (`signer.kind`):
+//   nip07 → "extension"   nip46 → "bunker"   local → "local key"
+// (a display label may also be passed through verbatim). `npub` set → the
+// signed-in cluster (kind badge, click-to-copy npub pill truncated in the
+// middle, Refresh, Log out); `npub` null → the signed-out cluster (a Sign in
+// button, rendered only when onSignIn is given). Buttons render only when
+// their callback is given. Copy uses the async clipboard API, falls back to
+// execCommand, and — if both are unavailable — expands the pill to the full
+// npub and selects it so a manual copy still works.
+//
+// Options: appName (text), tagline (text, optional), sealSvg (an inline-SVG
+// string — a TRUSTED app-authored literal, never user input), npub, kind,
+// onRefresh, onLogout, onSignIn, signInLabel. The markup and CSS here are the
+// same as components/nave-titlebar.html — keep the two in lock-step. Styling
+// is token-driven (design/tokens.css) with dark-canonical fallbacks baked in.
+
+const STYLE_ID = 'nave-titlebar-style'
+
+const CSS = `
+  .nave-titlebar { position: sticky; top: 0; z-index: 20;
+    border-bottom: 1px solid var(--line, #2a2317);
+    background: var(--bg, #0b0906);
+    background: color-mix(in srgb, var(--bg, #0b0906) 86%, transparent);
+    backdrop-filter: blur(8px); -webkit-backdrop-filter: blur(8px);
+    color: var(--text, #f4efe4);
+    font-family: var(--sans, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif); }
+  .nave-titlebar .ntb-bar { display: flex; align-items: center; gap: 13px;
+    max-width: 1080px; margin: 0 auto; padding: 13px 28px; }
+  .nave-titlebar .ntb-seal { width: 40px; height: 40px; flex: none; }
+  .nave-titlebar .ntb-seal:empty { display: none; }
+  .nave-titlebar .ntb-seal svg { width: 100%; height: 100%; display: block; }
+  .nave-titlebar .ntb-name { margin: 0; font-weight: 800; font-size: 21px;
+    letter-spacing: 0.13em; text-transform: uppercase; color: var(--accent, #c39a56); }
+  .nave-titlebar .ntb-name::first-letter { color: var(--text, #f4efe4); }
+  .nave-titlebar .ntb-tag { color: var(--dim, #9c927f); font-size: 11.5px; font-weight: 500;
+    letter-spacing: 0.06em; text-transform: uppercase;
+    padding-left: 13px; border-left: 1px solid var(--line, #2a2317); }
+  .nave-titlebar .ntb-tag:empty { display: none; }
+  .nave-titlebar .ntb-spacer { flex: 1; }
+  .nave-titlebar .ntb-me, .nave-titlebar .ntb-signin { display: flex; align-items: center; gap: 10px; }
+  .nave-titlebar:not([data-signed-in]) .ntb-me { display: none; }
+  .nave-titlebar[data-signed-in] .ntb-signin { display: none; }
+  .nave-titlebar .ntb-badge { font-size: 10.5px; padding: 3px 9px; border-radius: 999px;
+    font-family: var(--mono, ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace);
+    letter-spacing: 0.06em; border: 1px solid var(--line, #2a2317);
+    color: var(--dim, #9c927f); white-space: nowrap; }
+  .nave-titlebar .ntb-badge.ntb-kind-extension { border-color: var(--good, #8fae6a); color: var(--good, #8fae6a); }
+  .nave-titlebar .ntb-badge.ntb-kind-bunker { border-color: var(--accent, #c39a56); color: var(--accent, #c39a56); }
+  .nave-titlebar .ntb-badge.ntb-kind-local { border-color: var(--warn, #d9a648); color: var(--warn, #d9a648); }
+  .nave-titlebar .ntb-npub { font-size: 11px; letter-spacing: 0.05em;
+    font-family: var(--mono, ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace);
+    border: 1px solid var(--line, #2a2317); color: var(--dim, #9c927f); border-radius: 999px;
+    padding: 5px 12px; cursor: pointer; transition: border-color .14s, color .14s; }
+  .nave-titlebar .ntb-npub:hover { border-color: var(--accent, #c39a56); color: var(--accent-bright, #e2c079); }
+  .nave-titlebar .ntb-npub.ntb-copied { border-color: var(--good, #8fae6a); color: var(--good, #8fae6a); }
+  .nave-titlebar .ntb-npub.ntb-expanded { word-break: break-all; user-select: all; }
+  .nave-titlebar .ntb-btn { background: transparent; color: var(--text, #f4efe4);
+    border: 1px solid var(--line, #2a2317); border-radius: var(--r-sm, 6px); padding: 8px 15px;
+    font-family: inherit; font-size: 12.5px; font-weight: 600; letter-spacing: 0.02em; cursor: pointer;
+    transition: border-color .14s, color .14s, background .14s; }
+  .nave-titlebar .ntb-btn:hover { border-color: var(--accent, #c39a56); color: var(--accent-bright, #e2c079); }
+  .nave-titlebar .ntb-btn.ntb-primary { background: var(--accent, #c39a56); border-color: var(--accent, #c39a56);
+    color: var(--accent-ink, #0b0906); font-weight: 700; text-transform: uppercase; letter-spacing: 0.1em; }
+  .nave-titlebar .ntb-btn.ntb-primary:hover { background: var(--accent-bright, #e2c079);
+    border-color: var(--accent-bright, #e2c079); color: var(--accent-ink, #0b0906); }
+  @media (max-width: 640px) {
+    .nave-titlebar .ntb-tag { display: none; }
+    .nave-titlebar .ntb-bar { flex-wrap: wrap; row-gap: 10px; padding: 11px 16px; }
+    .nave-titlebar .ntb-me, .nave-titlebar .ntb-signin { flex-wrap: wrap; }
+  }
+`
+
+// signer.kind → display label (the mapping Nvoy's console set), and
+// display label → badge colour class. Unknown labels pass through undecorated.
+const KIND_LABEL = { nip07: 'extension', nip46: 'bunker', local: 'local key' }
+const KIND_CLASS = { extension: 'ntb-kind-extension', bunker: 'ntb-kind-bunker', 'local key': 'ntb-kind-local' }
+
+const truncNpub = (npub) => (npub.length > 21 ? npub.slice(0, 12) + '…' + npub.slice(-4) : npub)
+
+function ensureStyle(doc) {
+  if (doc.getElementById(STYLE_ID)) return    // the static block (or a prior render) already carries it
+  const style = doc.createElement('style')
+  style.id = STYLE_ID
+  style.textContent = CSS
+  doc.head.appendChild(style)
+}
+
+function h(doc, tag, attrs = {}, ...children) {
+  const el = doc.createElement(tag)
+  for (const [k, v] of Object.entries(attrs)) if (v != null) el.setAttribute(k, v)
+  for (const c of children) if (c != null) el.append(c)   // strings become text nodes: data stays escaped
+  return el
+}
+
+function legacyCopy(doc, text) {
+  try {
+    const ta = doc.createElement('textarea')
+    ta.value = text
+    ta.setAttribute('readonly', '')
+    ta.style.position = 'fixed'
+    ta.style.top = '-1000px'
+    doc.body.appendChild(ta)
+    ta.select()
+    const ok = doc.execCommand('copy')
+    ta.remove()
+    return ok
+  } catch { return false }
+}
+
+function selectContents(node) {
+  try {
+    const range = node.ownerDocument.createRange()
+    range.selectNodeContents(node)
+    const sel = node.ownerDocument.defaultView.getSelection()
+    sel.removeAllRanges()
+    sel.addRange(range)
+  } catch { /* selection is a nicety */ }
+}
+
+async function copyNpub(pill, npub) {
+  const doc = pill.ownerDocument
+  let ok = false
+  try { await navigator.clipboard.writeText(npub); ok = true } catch { /* fall through */ }
+  if (!ok) ok = legacyCopy(doc, npub)
+  if (ok) {
+    pill.classList.add('ntb-copied')
+    pill.textContent = 'copied'
+    setTimeout(() => { pill.classList.remove('ntb-copied'); pill.textContent = truncNpub(npub) }, 1300)
+  } else {
+    // No clipboard at all: expand to the full npub, selected, for a manual copy.
+    const expand = !pill.classList.contains('ntb-expanded')
+    pill.classList.toggle('ntb-expanded', expand)
+    pill.textContent = expand ? npub : truncNpub(npub)
+    if (expand) selectContents(pill)
+  }
+}
+
+export function renderTitlebar(el, opts = {}) {
+  const root = typeof el === 'string' ? document.querySelector(el) : el
+  if (!root) throw new Error('renderTitlebar: no such element')
+  const doc = root.ownerDocument
+  root.__naveTitlebarOpts = opts
+  ensureStyle(doc)
+
+  const { appName = '', tagline = '', sealSvg = '', npub = null, kind = null,
+          onRefresh = null, onLogout = null, onSignIn = null, signInLabel = 'Sign in' } = opts
+
+  root.classList.add('nave-titlebar')
+  if (npub) root.setAttribute('data-signed-in', '')
+  else root.removeAttribute('data-signed-in')
+  root.textContent = ''
+
+  const btn = (label, onClick, extra = '') => {
+    const b = h(doc, 'button', { class: ('ntb-btn ' + extra).trim(), type: 'button' }, label)
+    b.addEventListener('click', onClick)
+    return b
+  }
+
+  const seal = h(doc, 'span', { class: 'ntb-seal', 'aria-hidden': 'true' })
+  if (sealSvg) seal.innerHTML = sealSvg   // trusted app-authored literal (see header)
+
+  // Note: no ids here — the static block (nave-titlebar.html) carries the
+  // fleet ids (#me, #me-kind, #my-npub…) for by-id wiring; this renderer may
+  // be instantiated more than once per page and wires by callback instead.
+  const me = h(doc, 'div', { class: 'ntb-me' })
+  if (npub) {
+    const label = KIND_LABEL[kind] ?? (kind || 'local key')
+    const badge = h(doc, 'span', {
+      class: 'ntb-badge' + (KIND_CLASS[label] ? ' ' + KIND_CLASS[label] : ''),
+      title: 'how this session signs',
+    }, label)
+    const pill = h(doc, 'code', {
+      class: 'ntb-npub', title: 'click to copy',
+      role: 'button', tabindex: '0', 'aria-label': 'copy your npub',
+    }, truncNpub(npub))
+    pill.addEventListener('click', () => copyNpub(pill, npub))
+    pill.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); copyNpub(pill, npub) }
+    })
+    me.append(badge, pill)
+    if (onRefresh) me.append(btn('Refresh', onRefresh))
+    if (onLogout) me.append(btn('Log out', onLogout))
+  }
+
+  const signin = h(doc, 'div', { class: 'ntb-signin' })
+  if (!npub && onSignIn) signin.append(btn(signInLabel, onSignIn, 'ntb-primary'))
+
+  root.append(h(doc, 'div', { class: 'ntb-bar' },
+    seal,
+    h(doc, 'h1', { class: 'ntb-name' }, appName),
+    h(doc, 'div', { class: 'ntb-tag' }, tagline),
+    h(doc, 'div', { class: 'ntb-spacer' }),
+    me,
+    signin,
+  ))
+  return root
+}
+
+// Shallow-merge `patch` into the opts of the last render and re-render.
+// Pass `npub: null` to flip to the signed-out state.
+export function updateTitlebar(el, patch = {}) {
+  const root = typeof el === 'string' ? document.querySelector(el) : el
+  if (!root) throw new Error('updateTitlebar: no such element')
+  return renderTitlebar(root, { ...(root.__naveTitlebarOpts || {}), ...patch })
+}

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -8,11 +8,11 @@ claim depends on it. Read this whole file before touching the box.
 
 | | sealed lanes (existing) | public read lane (new) |
 |---|---|---|
-| Unit | `west-bridge.service` | `west-bridge-read.service` |
+| Unit | `waggle-sealed.service` | `waggle-read.service` |
 | User | root *(Phase 1: unchanged — migrating sealed off root is explicitly out of scope)* | `bridge:bridge` |
-| Tree | `/opt/west-bridge` | `/opt/west-bridge-read` (0750) |
+| Tree | `/opt/waggle-sealed` | `/opt/waggle-read` (0750) |
 | Config | **no** `public` block — boot log must read `public read lane: inactive` | **only** the `public` block |
-| Env | `/opt/west-bridge/.env` | `/opt/west-bridge-read/.env` with `SEALED_LANES=off` |
+| Env | `/opt/waggle-sealed/.env` | `/opt/waggle-read/.env` with `SEALED_LANES=off` |
 | Data | own `data/` | own `data/` (disjoint dedup by construction — the lanes are event-disjoint) |
 
 Why split: the read lane is the only lane terminating **untrusted network input**; it must
@@ -31,18 +31,18 @@ A3 watermark resumes where local stopped, and A2's seen-set makes the overlap a 
    `BRIDGE_PUB='ssh-ed25519 …' sh bridge-user.sh`
    Then create the admin user for later root-SSH disable (see the warning below) and
    **verify both logins from the Mac before proceeding.**
-2. **(box)** Create `/opt/west-bridge-read/.env` (bridge:bridge, 0600) with
+2. **(box)** Create `/opt/waggle-read/.env` (bridge:bridge, 0600) with
    `SEALED_LANES=off`, `FORWARD_MODE=dryrun`, and the `BUZZ_*` trio; create
-   `/opt/west-bridge-read/config.json` with only the `public` block.
+   `/opt/waggle-read/config.json` with only the `public` block.
 3. **(Mac)** `sh deploy/deploy.sh read bridge@<host>` — dryrun posts nothing, so the
    local read lane can keep running. Watch the journal for `[pub …] open, subscribing`
    and clean `PUBLIC[dryrun]` routing lines.
 4. **Cutover (the only ordered part):**
    a. Stop the local read-lane process.
    b. Copy the local `data/seen-ids.log`, `data/pub-watermark`, and `data/posted-map.log`
-      into `/opt/west-bridge-read/data/` (chown bridge:bridge).
-   c. Flip `.env` to `FORWARD_MODE=buzz`; `sudo systemctl restart west-bridge-read`;
-      `sudo systemctl enable west-bridge-read`.
+      into `/opt/waggle-read/data/` (chown bridge:bridge).
+   c. Flip `.env` to `FORWARD_MODE=buzz`; `sudo systemctl restart waggle-read`;
+      `sudo systemctl enable waggle-read`.
    d. Watch for `PUBLIC[buzz] ok` lines; eyeball the Buzz channel — there must be no
       duplicate posts.
 5. **(box, as root — independent)** Refresh the sealed tree to the current build:
@@ -64,8 +64,8 @@ After **every** `deploy.sh`, run the drift check for that tree and treat any mis
 failed deploy — roll forward, do not leave it:
 
 ```
-sh deploy/verify-deployed.sh sealed <admin>@<host>   [git-ref]   # /opt/west-bridge
-sh deploy/verify-deployed.sh read   bridge@<host>    [git-ref]   # /opt/west-bridge-read
+sh deploy/verify-deployed.sh sealed <admin>@<host>   [git-ref]   # /opt/waggle-sealed
+sh deploy/verify-deployed.sh read   bridge@<host>    [git-ref]   # /opt/waggle-read
 ```
 
 It hashes each shipped file on the box and compares it to the git blob it should match at
@@ -176,7 +176,7 @@ journal is only public event ids, nothing sensitive), on its own timer just ahea
 tripwire tick:
 
 ```
-rsync -az bridge@<box>:/opt/west-bridge/data/send-journal.log /opt/waggle/data/send-journal.log
+rsync -az bridge@<box>:/opt/waggle-sealed/data/send-journal.log /opt/waggle/data/send-journal.log
 ```
 
 Then install the units (edit `WorkingDirectory`/`User`/paths in the unit files to match this
@@ -196,7 +196,7 @@ On macOS (no systemd) run the same script from a `launchd` job or `cron` on the 
 
 Weaker (dies with the box it polices), but better than nothing while an off-host watcher is
 being stood up. Point `WorkingDirectory` at the sealed tree's checkout and
-`SEND_JOURNAL_PATH` at `/opt/west-bridge/data/send-journal.log` directly (grant the runtime
+`SEND_JOURNAL_PATH` at `/opt/waggle-sealed/data/send-journal.log` directly (grant the runtime
 user group-read on it), and update `ReadWritePaths` to that same tree's `data/` so the
 alarm log stays writable. Everything else is identical. Note the weakness is not just that
 the watcher dies with the box — the box also writes the journal it is judged against, so a

--- a/deploy/bridge-user.sh
+++ b/deploy/bridge-user.sh
@@ -10,7 +10,7 @@
 # verify-first step (see deploy/README.md: an admin user must be login-verified first,
 # or the sealed unit becomes unmanageable).
 set -eu
-echo "== west-bridge: bridge user bring-up on $(hostname) =="
+echo "== waggle: bridge user bring-up on $(hostname) =="
 
 DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 
@@ -25,10 +25,10 @@ esac
 # 2) User + tree -------------------------------------------------------------------------
 echo "-- user + tree --"
 id bridge >/dev/null 2>&1 || useradd -r -m -s /bin/bash bridge
-mkdir -p /opt/west-bridge-read/data
-chown -R bridge:bridge /opt/west-bridge-read
-chmod 750 /opt/west-bridge-read
-echo "  bridge user + /opt/west-bridge-read ready"
+mkdir -p /opt/waggle-read/data
+chown -R bridge:bridge /opt/waggle-read
+chmod 750 /opt/waggle-read
+echo "  bridge user + /opt/waggle-read ready"
 
 # 3) restrict-prefixed authorized_keys ---------------------------------------------------
 # 'restrict' kills pty/agent/port/X11 forwarding; command execution still works, which is
@@ -43,7 +43,7 @@ chmod 600 "$BHOME/.ssh/authorized_keys"
 echo "  installed (append; nothing overwritten)"
 
 # 4) Scoped sudo — exact unit commands only, validated before install --------------------
-echo "-- sudoers (scoped to west-bridge-read.service) --"
+echo "-- sudoers (scoped to waggle-read.service) --"
 visudo -cf "$DIR/sudoers-bridge"
 install -m 440 "$DIR/sudoers-bridge" /etc/sudoers.d/bridge
 echo "  /etc/sudoers.d/bridge installed"
@@ -54,15 +54,15 @@ echo "  bridge added to systemd-journal group"
 
 # 6) Unit install ------------------------------------------------------------------------
 echo "-- systemd unit --"
-install -m 644 "$DIR/west-bridge-read.service" /etc/systemd/system/west-bridge-read.service
+install -m 644 "$DIR/waggle-read.service" /etc/systemd/system/waggle-read.service
 systemctl daemon-reload
-echo "  west-bridge-read.service installed (not started — config/.env first)"
+echo "  waggle-read.service installed (not started — config/.env first)"
 
 echo
 echo "== bridge-user DONE =="
 echo "NEXT (see deploy/README.md for the full cutover order):"
-echo "  1) Create /opt/west-bridge-read/.env (bridge:bridge, 0600):"
+echo "  1) Create /opt/waggle-read/.env (bridge:bridge, 0600):"
 echo "       SEALED_LANES=off  FORWARD_MODE=dryrun  BUZZ_RELAY_URL=...  BUZZ_PRIVATE_KEY=...  BUZZ_AUTH_TAG=..."
-echo "  2) Create /opt/west-bridge-read/config.json — ONLY the \"public\" block."
+echo "  2) Create /opt/waggle-read/config.json — ONLY the \"public\" block."
 echo "  3) From the Mac:  sh deploy/deploy.sh read bridge@<host>"
 echo "  4) Verify dryrun in the journal, then flip FORWARD_MODE=buzz at cutover."

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 # Push-style deploy from the Mac — the reproducible replacement for hand-typed ssh steps.
 #
-#   sh deploy/deploy.sh read   bridge@<host>     # public read lane -> /opt/west-bridge-read
-#   sh deploy/deploy.sh sealed <admin>@<host>    # sealed lanes     -> /opt/west-bridge
+#   sh deploy/deploy.sh read   bridge@<host>     # public read lane -> /opt/waggle-read
+#   sh deploy/deploy.sh sealed <admin>@<host>    # sealed lanes     -> /opt/waggle-sealed
 #
 # Ships code ONLY: config.json, .env, and data/ are never touched (rsync has no --delete,
 # and none of those paths are in the ship list). Refuses to restart a tree whose config is
@@ -12,14 +12,14 @@ set -eu
 TARGET="${1:-}"
 DEST="${2:-}"
 case "$TARGET" in
-  read)   TREE=/opt/west-bridge-read; UNIT=west-bridge-read.service ;;
-  sealed) TREE=/opt/west-bridge;      UNIT=west-bridge.service ;;
+  read)   TREE=/opt/waggle-read; UNIT=waggle-read.service ;;
+  sealed) TREE=/opt/waggle-sealed;      UNIT=waggle-sealed.service ;;
   *) echo "usage: sh deploy/deploy.sh read|sealed user@host"; exit 1 ;;
 esac
 [ -n "$DEST" ] || { echo "usage: sh deploy/deploy.sh $TARGET user@host"; exit 1; }
 
 DIR=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
-echo "== west-bridge deploy: $TARGET -> $DEST:$TREE =="
+echo "== waggle deploy: $TARGET -> $DEST:$TREE =="
 
 echo "-- preflight --"
 ssh "$DEST" "[ -f $TREE/config.json ]" || {

--- a/deploy/migrate-rename.sh
+++ b/deploy/migrate-rename.sh
@@ -1,0 +1,60 @@
+#!/bin/sh
+# migrate-rename.sh — retire the old service name on a running host, in one deliberate pass.
+#
+#   sudo sh deploy/migrate-rename.sh
+#
+# A half-finished rename is worse than none: it leaves two names for one thing AND a deploy that
+# no longer works. So this does the whole move or stops, and verifies at each step rather than
+# assuming. It is idempotent — running it twice is a no-op.
+#
+# Order matters. The units are stopped before the trees move, because a running process holding
+# a working directory that vanishes underneath it fails in ways that are tedious to read.
+set -eu
+
+OLD_S=west-bridge.service;      NEW_S=waggle-sealed.service
+OLD_R=west-bridge-read.service; NEW_R=waggle-read.service
+OLD_ST=/opt/west-bridge;        NEW_ST=/opt/waggle-sealed
+OLD_RT=/opt/west-bridge-read;   NEW_RT=/opt/waggle-read
+UD=/etc/systemd/system
+
+say() { printf '  %s\n' "$*"; }
+[ "$(id -u)" -eq 0 ] || { echo "run as root"; exit 1; }
+
+if [ ! -d "$OLD_ST" ] && [ ! -d "$OLD_RT" ]; then say "already migrated — nothing to do"; exit 0; fi
+
+say "stopping both lanes"
+systemctl stop "$OLD_S" "$OLD_R" 2>/dev/null || true
+
+say "moving trees (config, .env and data move with them — they are not re-created)"
+[ -d "$OLD_ST" ] && [ ! -d "$NEW_ST" ] && mv "$OLD_ST" "$NEW_ST" && say "  $OLD_ST -> $NEW_ST"
+[ -d "$OLD_RT" ] && [ ! -d "$NEW_RT" ] && mv "$OLD_RT" "$NEW_RT" && say "  $OLD_RT -> $NEW_RT"
+
+say "installing the renamed units"
+install -m 0644 -o root -g root "$(dirname "$0")/waggle-sealed.service" "$UD/$NEW_S"
+install -m 0644 -o root -g root "$(dirname "$0")/waggle-read.service"   "$UD/$NEW_R"
+
+say "retiring the old units"
+systemctl disable "$OLD_S" "$OLD_R" 2>/dev/null || true
+rm -f "$UD/$OLD_S" "$UD/$OLD_R"
+
+# The bridge user's sudo rule names the units explicitly — a rename that misses it silently
+# removes that user's ability to restart its own service, which only surfaces on the next deploy.
+if [ -f /etc/sudoers.d/bridge ]; then
+  say "updating the scoped sudo rule to the new unit names"
+  sed -i "s/$OLD_R/$NEW_R/g; s/$OLD_S/$NEW_S/g" /etc/sudoers.d/bridge
+  visudo -cf /etc/sudoers.d/bridge >/dev/null || { echo "  sudoers check FAILED — restoring nothing, fix by hand"; exit 1; }
+fi
+
+systemctl daemon-reload
+say "starting the renamed lanes"
+systemctl enable --now "$NEW_S" "$NEW_R" >/dev/null 2>&1 || true
+sleep 3
+
+FAIL=0
+for u in "$NEW_S" "$NEW_R"; do
+  st=$(systemctl is-active "$u" || true)
+  say "$u: $st"
+  [ "$st" = active ] || FAIL=1
+done
+[ "$FAIL" -eq 0 ] || { echo "  ✗ a lane did not come back — check: journalctl -u $NEW_S -u $NEW_R -n 50"; exit 1; }
+say "done. Old names are gone; both lanes are running under the new ones."

--- a/deploy/sudoers-bridge
+++ b/deploy/sudoers-bridge
@@ -2,4 +2,4 @@
 # EXACT commands only, no wildcards — the bridge user can manage its own unit and nothing
 # else. Journal access comes from the systemd-journal group, NOT a sudoed journalctl
 # (argument wildcards on journalctl are an escape hatch).
-bridge ALL=(root) NOPASSWD: /usr/bin/systemctl start west-bridge-read.service, /usr/bin/systemctl stop west-bridge-read.service, /usr/bin/systemctl restart west-bridge-read.service, /usr/bin/systemctl status west-bridge-read.service
+bridge ALL=(root) NOPASSWD: /usr/bin/systemctl start waggle-read.service, /usr/bin/systemctl stop waggle-read.service, /usr/bin/systemctl restart waggle-read.service, /usr/bin/systemctl status waggle-read.service

--- a/deploy/verify-deployed.sh
+++ b/deploy/verify-deployed.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 # deploy/verify-deployed.sh — post-deploy drift check (issue #33).
 #
-#   sh deploy/verify-deployed.sh read   bridge@<host>  [git-ref]   # /opt/west-bridge-read
-#   sh deploy/verify-deployed.sh sealed <admin>@<host> [git-ref]   # /opt/west-bridge
+#   sh deploy/verify-deployed.sh read   bridge@<host>  [git-ref]   # /opt/waggle-read
+#   sh deploy/verify-deployed.sh sealed <admin>@<host> [git-ref]   # /opt/waggle-sealed
 #   sh deploy/verify-deployed.sh read   /local/tree     [git-ref]  # a local tree (used by the test)
 #
 # deploy.sh SHIPS code but nothing confirms afterwards that what is running is what was
@@ -21,8 +21,8 @@ set -eu
 TARGET="${1:-}"; DEST="${2:-}"; REF="${3:-HEAD}"
 usage() { echo "usage: sh deploy/verify-deployed.sh read|sealed <user@host | /local/tree> [git-ref]"; }
 case "$TARGET" in
-  read)   TREE=/opt/west-bridge-read ;;
-  sealed) TREE=/opt/west-bridge ;;
+  read)   TREE=/opt/waggle-read ;;
+  sealed) TREE=/opt/waggle-sealed ;;
   *) usage; exit 2 ;;
 esac
 [ -n "$DEST" ] || { usage; exit 2; }

--- a/deploy/waggle-read.service
+++ b/deploy/waggle-read.service
@@ -1,7 +1,7 @@
 # Public read-lane unit — the ONLY lane terminating untrusted network input, so it runs
 # under the dedicated non-root 'bridge' user (D1) with systemd sandboxing, in its own tree.
 #
-# /opt/west-bridge-read/.env (bridge:bridge, 0600) must set:
+# /opt/waggle-read/.env (bridge:bridge, 0600) must set:
 #   SEALED_LANES=off           # this instance runs the public lane ONLY (sealed lanes are
 #                              # per-process-deduped — two instances running them = double delivery)
 #   FORWARD_MODE=dryrun        # flip to 'buzz' only at cutover (see deploy/README.md)
@@ -16,15 +16,15 @@ Wants=network-online.target
 [Service]
 User=bridge
 Group=bridge
-WorkingDirectory=/opt/west-bridge-read
+WorkingDirectory=/opt/waggle-read
 ExecStart=/usr/bin/node src/bridge.mjs
-EnvironmentFile=/opt/west-bridge-read/.env
+EnvironmentFile=/opt/waggle-read/.env
 Environment=PATH=/usr/local/bin:/usr/bin:/bin
 Restart=always
 RestartSec=5
 NoNewPrivileges=yes
 ProtectSystem=strict
-ReadWritePaths=/opt/west-bridge-read/data
+ReadWritePaths=/opt/waggle-read/data
 ProtectHome=yes
 PrivateTmp=yes
 

--- a/deploy/waggle-sealed.service
+++ b/deploy/waggle-sealed.service
@@ -2,16 +2,16 @@
 # Runs as root today; migrating it off root is out of scope for Phase 1 (see deploy/README.md).
 # Its config.json must have NO "public" block — boot log must read:
 #   "public read lane: inactive (no cfg.public.inbox)"
-# The read lane runs separately as west-bridge-read.service under the 'bridge' user.
+# The read lane runs separately as waggle-read.service under the 'bridge' user.
 [Unit]
 Description=West Bridge — sealed lanes (Armada DMs + Concord planes → Buzz inboxes)
 After=network-online.target
 Wants=network-online.target
 
 [Service]
-WorkingDirectory=/opt/west-bridge
+WorkingDirectory=/opt/waggle-sealed
 ExecStart=/usr/bin/node src/bridge.mjs
-EnvironmentFile=/opt/west-bridge/.env
+EnvironmentFile=/opt/waggle-sealed/.env
 Environment=PATH=/usr/local/bin:/usr/bin:/bin
 Restart=always
 RestartSec=5

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "west-bridge",
+  "name": "waggle",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "west-bridge",
+      "name": "waggle",
       "version": "1.0.0",
       "dependencies": {
         "@noble/curves": "^1.9.7",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "west-bridge",
+  "name": "waggle",
   "version": "1.0.0",
   "private": true,
   "type": "module",

--- a/tools/serve-console.mjs
+++ b/tools/serve-console.mjs
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+// serve-console.mjs — serve the console from THIS machine, and only this machine.
+//
+//   npm run console      →  http://127.0.0.1:8080/console/
+//
+// Bound to loopback on purpose. The console's whole promise is "here is exactly what you are
+// about to sign" — and that promise is only worth anything if you trust whoever served the
+// page. Hosted anywhere else, the JavaScript that shows you the event is chosen by the host,
+// so a substituted page could display one thing and hand your signer another. Served from
+// your own machine, nobody else gets a vote.
+import { createServer } from 'node:http'
+import { readFile } from 'node:fs/promises'
+import { extname, join, normalize, dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const PORT = Number(process.env.PORT || 8080)
+const TYPES = { '.html': 'text/html; charset=utf-8', '.mjs': 'text/javascript; charset=utf-8',
+  '.js': 'text/javascript; charset=utf-8', '.css': 'text/css', '.json': 'application/json', '.svg': 'image/svg+xml' }
+
+createServer(async (req, res) => {
+  let url = (req.url || '/').split('?')[0]
+  if (url === '/' || url === '/console' || url === '/console/') url = '/console/index.html'
+  // Refuse to climb out of the repo, however the path is spelled.
+  const rel = normalize(decodeURIComponent(url)).replace(/^(\.\.[/\\])+/, '')
+  const file = join(ROOT, rel)
+  if (!file.startsWith(ROOT)) { res.writeHead(403); return res.end('forbidden') }
+  try {
+    const body = await readFile(file)
+    res.writeHead(200, { 'Content-Type': TYPES[extname(file)] || 'application/octet-stream', 'Cache-Control': 'no-store' })
+    res.end(body)
+  } catch { res.writeHead(404); res.end('not found') }
+}).listen(PORT, '127.0.0.1', () => {
+  console.log(`\n  waggle console  →  http://127.0.0.1:${PORT}/console/\n`)
+  console.log('  Bound to loopback: served from this machine only, so nobody else chooses the')
+  console.log('  JavaScript that shows you what you are about to sign. Ctrl-C when finished.\n')
+})


### PR DESCRIPTION
Closes #62.

The project is **waggle**. Internally it was still `west-bridge` in unit names, deployment paths, the package name and the runbook. That split was a deliberate call at rename time — keep the internal name for deployed-unit continuity — and has since become a tax paid by everyone who reads this for the first time.

The tell: the file describing waggle's own detection tooling was named after the old project.

**Units** are now `waggle-sealed` and `waggle-read` — symmetric and self-describing, so `systemctl status` tells you which lane is which without consulting a document. **Trees** follow at `/opt/waggle-sealed` and `/opt/waggle-read`.

**`deploy/migrate-rename.sh`** does the host move in one pass, because a half-finished rename is worse than none — it leaves two names *and* a broken deploy. Units stop before trees move; the scoped sudo rule is rewritten and re-validated; it refuses to report success unless both lanes come back active. Idempotent.

That sudo rule is the piece most likely to be missed: it names the units explicitly, so skipping it silently removes the bridge user's ability to restart its own service — surfacing only at the next deploy.

**`docs/SPEC_EXTERNAL.md` is deliberately untouched.** It is generated; hand-editing it would fork a generated file. It clears on the next regeneration from the internal source.

**Migrated live and verified, not assumed:** both lanes active and streaming · the tripwire unit's own paths corrected and its next run clean (21 journaled, 0 unaccounted) · `deploy.sh` and `verify-deployed.sh` both working against the new names · no old unit left registered · 7/7 suites green.

Drafted with assistance from [Claude Code](https://claude.com/claude-code)