### PR TITLE
README for an outside reader; lowercase waggle wordmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,114 +1,148 @@
-# waggle — the Nostr ↔ Buzz Bridge
+# waggle — the Nostr ↔ Buzz bridge
 
-**Two-way interop between a walled [Buzz](https://block.github.io/buzz/) community and
-the open Nostr network — non-custodial, quarantine-gated, running in production.**
+**Two-way interop between a walled [Buzz](https://block.github.io/buzz/) community and the open
+Nostr network — non-custodial, quarantine-gated, running in production.**
 
-Public posts from community members federate outward under their own keys; the open
-network's replies come back through a default-closed quarantine with in-channel,
-one-word approvals. Sealed lanes carry end-to-end-encrypted DM and group traffic
-untouched. The bridge holds exactly one private key — its own posting identity — and
-no member's.
+A private community is valuable *because* it is walled. But the wall costs its members reach: they
+cannot speak to the open network as themselves, and it cannot reach them at all. Every usual answer
+gives something real away — open the community and the reason it worked is gone; mirror it through
+a bot and every member's voice becomes the bot's; hand a service your keys and sovereignty is over.
 
-- **Spec:** [docs/SPEC_EXTERNAL.md](docs/SPEC_EXTERNAL.md) — architecture, safety
-  gates, moderation model, ToS posture, roadmap. Generated from an internal source
-  of truth; never hand-edited.
-- **Trust boundaries:** [docs/CONCORD_CONSUMER.md](docs/CONCORD_CONSUMER.md) — the
-  Concord consumer, why the bridge never unwraps, and the invite provenance checks;
-  [docs/DM_TRUST_ALLOWLIST.md](docs/DM_TRUST_ALLOWLIST.md) — which senders an agent acts
-  on, honoured today rather than enforced.
-- **Status:** all four proof rungs green — out door (cold read-back), in-door pipe,
-  round-trip through quarantine, third-party ingestion.
-- **Built on:** NIP-01/10/17/59/65, NIP-09 deletion propagation, and draft
-  [NIP-DA (#2411)](https://github.com/nostr-protocol/nips/pull/2411) for the
-  grant-based admission tier — this repo is its working reference consumer.
-- **License:** MIT.
+waggle treats that as a **routing** problem rather than a permissions one. The wall stays up, and
+the door is per-message and consensual in both directions.
 
-*(Internal service name: `waggle` — it predates the public name and stays for
-deployed-unit continuity.)*
+You add **one dedicated agent** to your community. It carries the crossing, and everything it does
+it does as that agent, in your channels, where you can watch it.
 
-
-Non-custodial subscriber that pushes external Nostr events into per-agent Buzz
-inboxes, so agents stop polling "the West" (Armada / NIP-DA / Concord planes) by
-hand. **v1 forwards Armada NIP-17 DMs only.**
-
-- **Owner:** the read-lane engineer (bridge manager). Crypto / agent-side unwrap: the outbox engineer.
-- **Design:** `../../PLANS/WEST_BRIDGE_SCOPING.md`
+---
 
 ## What it does
 
-Holds an open `REQ {kinds:[1059], #p:[agent npubs]}` across the Armada relays.
-Each matching gift-wrap is forwarded — **still sealed** — into the recipient
-agent's Buzz inbox channel with an `@mention`, which wakes that agent's session.
-The agent unwraps with its own in-runtime key.
+| Lane | Direction | What crosses |
+|---|---|---|
+| **Out door** | community → open | A member opts a post outward; it publishes **under their own key**. The bridge routes, it does not author. |
+| **In door** | open → community | Replies arrive in a **default-closed quarantine** and enter only when a human releases them with one word in-channel. |
+| **Sealed lanes** | both | End-to-end encrypted direct and group traffic, carried by envelope and derived address — **never opened**. |
+| **Return lane** | community → guest | A mention reaches an admitted outsider as a sealed DM. The community relay will not serve an external key, so the bridge is the only party that can. |
 
-**It never holds a recipient agent's nsec, and never unwraps.** It routes on the public
-outer `p`-tag only. Its sole secret is its own Buzz posting identity
-(`BUZZ_PRIVATE_KEY`) — a real, operated key, which is why that identity is kept lean and
-disposable and why its signing is watched.
+It holds **exactly one private key — its own posting identity** — and no member's. That identity is
+deliberately lean and re-mintable, so a compromise costs a re-mint rather than a person's voice. A
+bounded loss, not no loss, which is why detection and rotation carry the security story rather than
+encryption at rest.
 
-## Two things it needs before it can go live
+## Status
 
-1. **Bridge Buzz identity** — its own posting account: `BUZZ_PRIVATE_KEY`,
-   `BUZZ_RELAY_URL`, `BUZZ_AUTH_TAG`. Not any agent's key.
-2. **Three inbox channels** — one per agent, with
-   each agent added as a member so the harness routes. Put the channel UUIDs into
-   `config.json`.
+| | |
+|---|---|
+| ✅ **Out door** | a member's note federated, confirmed by cold read-back on more than one relay |
+| ✅ **In door** | caught, deduplicated across relays, delivered as one channel post |
+| ✅ **Round trip** | a public reply came back *through the quarantine* and was released by a human |
+| ✅ **Cold-stranger walk-in** | a key minted moments earlier, with no grant and no history, held at the gate |
+| ✅ **Granted participants** | signed, revocable grants admit an outside identity; revocation applies without a restart |
+| ✅ **Return leg** | a mention carried out to a guest whose key cannot read the community relay |
+| ✅ **Tamper detection** | proven by drill — an unjournalled post by the poster key alarms; a journalled one does not |
 
-## Setup
+No claim above rests on a relay's acceptance. Cold read-back only.
+
+## Quick start
 
 ```sh
-npm install
-cp config.example.json config.json      # then fill the real inbox UUIDs
-export BUZZ_RELAY_URL=...  BUZZ_PRIVATE_KEY=...  BUZZ_AUTH_TAG=...
-npm run dryrun                            # log-only; proves subscribe+route without posting
-npm start                                 # FORWARD_MODE=buzz — actually delivers
+git clone https://github.com/JAFairweather/waggle && cd waggle
+npm ci
+node tools/waggle-init.mjs        # guided setup — prompts only for what is missing
+npm test                          # the safety gates, exercised
 ```
 
-## Config
+`waggle-init --check` reports readiness and changes nothing. Full walkthrough:
+**[docs/GETTING_STARTED.md](docs/GETTING_STARTED.md)**.
 
-`config.json` (git-ignored) holds `relays` and `recipients` (name + npub hex +
-inbox UUID). See `config.example.json`.
+Two things the setup will not do, deliberately: it never asks an agent for its own key — the
+administrator seats credentials directly — and it never takes a secret as a command argument.
 
-## Env
+## Tools
+
+| | |
+|---|---|
+| `tools/waggle-init.mjs` | guided operator setup and an honest readiness check |
+| `tools/participant-init.mjs` | onboard an outside participant, and **verify the loop closes** |
+| `tools/grant-setup.sh` | issue tasking grants interactively — one signer approval for the batch |
+| `tools/grant.mjs` | the grant pen: issue `440`, revoke `441`, list by subject |
+| `tools/approve.mjs` | release a quarantined message from the command line |
+| `tools/tripwire.mjs` | out-of-process detection of signing the bridge never did |
+| `tools/mint-auth-tag.mjs` | mint an owner attestation locally; the owner key never leaves your machine |
+| `console/` | see who is admitted and by whose signature — `npm run console`, bound to loopback |
+
+The console is served from your own machine on purpose. Its whole promise is *"here is exactly what
+you are about to sign"*, and that promise is only worth something if you control the page making it.
+
+## Configuration
+
+`config.json` (git-ignored) holds the relay set, the channels messages land in, the watch tiers, the
+approvers and grantors, and the rate caps. It carries **no secrets** — those live in `.env`, mode
+`0600`. Start from `config.example.json`, or let `waggle-init` fill it.
 
 | Var | Default | Meaning |
-|-----|---------|---------|
+|---|---|---|
 | `FORWARD_MODE` | `buzz` | `buzz` delivers; `dryrun` logs only |
-| `SINCE_SECS` | `172800` (48h) | startup lookback. **Keep ≥48h** — NIP-59 backdates gift-wrap `created_at` up to ~48h, so a `since=now` sub silently drops fresh DMs. |
-| `SEEN_CAP` | `100000` | max ids retained in the durable dedup store |
-| `CONFIG_PATH` | `./config.json` | config location |
-| `SEEN_PATH` | `./data/seen-ids.log` | durable dedup store |
-| `SEALED_LANES` | `on` | `off` runs the public read lane ONLY — required on a second instance, since dedup is per-process and two instances routing sealed lanes double-deliver |
-| `PUB_WATERMARK_PATH` | `./data/pub-watermark` | A3: persisted public-lane resume point |
-| `POSTED_MAP_PATH` | `./data/posted-map.log` | A7: orig event id → our Buzz copy, for NIP-09 withdrawal |
-| `DEL_SINCE_SECS` | `172800` (48h) | A7: kind:5 lookback (longer than the watermark on purpose — a delete issued during downtime must not be missed) |
-
-## Durability
-
-Forwarded event ids are appended to `data/seen-ids.log` and re-hydrated on boot,
-so a restart (or a `SINCE` backfill) never re-delivers a DM already pushed.
-Pruned to the most-recent `SEEN_CAP` ids on boot.
+| `SEALED_LANES` | `on` | `off` runs the public read lane only — required on a second instance, since dedup is per-process |
+| `SINCE_SECS` | `172800` (48h) | startup lookback. **Keep ≥48h**: NIP-59 backdates a gift-wrap's `created_at` by up to two days, so a `since=now` subscription silently drops fresh messages |
+| `DEL_SINCE_SECS` | `172800` | deletion lookback — longer than the watermark on purpose, since a delete issued during downtime must not be missed |
+| `SEEN_CAP` | `100000` | ids retained in the durable dedup store |
 
 ## Deploy
 
-Everything lives in [`deploy/`](deploy/README.md): checked-in systemd units for both
-instances (sealed lanes as `waggle-sealed.service`, public read lane as
-`waggle-read.service` under the non-root `bridge` user), the `bridge-user.sh`
-provisioning script, the push-style `deploy.sh`, the nftables firewall, and the full
-migration runbook (cutover order, data-dir seeding, root-SSH-disable-last warning).
-The relay reconnect loop is in-process; systemd only covers a full crash.
+Everything is in **[`deploy/`](deploy/README.md)**: systemd units for both lanes
+(`waggle-sealed.service`, and `waggle-read.service` under a non-root user), a provisioning script,
+a push-style `deploy.sh`, an nftables ruleset, and the migration runbook.
+
+Two habits worth taking from it. The firewall permits **NTP egress** on purpose — a dropped clock
+silently corrupts every time-based gate. And `deploy/verify-deployed.sh` compares what is *running*
+against what git says, because a stale build is invisible while every status surface reads healthy.
 
 ## Tests
 
-`npm test` — drives the REAL exported routing functions with synthetic events, no
-sockets, no production state: `tests/a1_quarantine.mjs` (quarantine gate) and
-`tests/a7_deletion.mjs` (NIP-09 deletion propagation, real signatures in wire form).
+`npm test` runs seven suites against the **real** exported functions with synthetic events — no
+sockets, no production state:
 
-## Roadmap
+quarantine gating · deletion propagation · sealed-lane rate caps · grant admission · message
+rendering · deployed-build verification · the return lane
 
-- **v1 (here):** Armada NIP-17 DMs.
-- **v2:** NIP-DA grants (`kinds:[30440]`) — turns `grant_check` from a poll into
-  push-on-change.
-- **v3:** Concord community planes — filter by `authors:[derived plane pubkeys]`;
-  the plane pubkeys are derived once inside a trusted runtime and handed to the
-  bridge as public filter data. `community_root` never touches the bridge.
+The rendering suite is the one to read if you are reviewing. It tests what the bridge **refuses**,
+not only what it does: a hostile note tries to ping the approver, mint an `APPROVED BY` heading,
+break out of its quote and open a code fence — and must come out inert *and still readable*, because
+a guard the approver cannot read through is a guard that stops them approving anything.
+
+## Documentation
+
+- **[docs/SPEC_EXTERNAL.md](docs/SPEC_EXTERNAL.md)** — architecture, safety gates, moderation model,
+  terms posture, roadmap. Generated from an internal source of truth; never hand-edited.
+- **[docs/GETTING_STARTED.md](docs/GETTING_STARTED.md)** — standing one up, end to end.
+- **[docs/CONCORD_CONSUMER.md](docs/CONCORD_CONSUMER.md)** — the group-chat consumer and its trust
+  boundary: the bridge routes by derived plane address and never unwraps; a *participant* holds the
+  invite and decrypts in its own runtime.
+- **[docs/DM_TRUST_ALLOWLIST.md](docs/DM_TRUST_ALLOWLIST.md)** — which senders an agent acts on, why
+  listening is not obeying, and the residual cost attack that cannot be gated away.
+- **[SECURITY.md](SECURITY.md)** — private reporting, what is in scope, and what is *not* a
+  vulnerability.
+
+## Built on
+
+NIP-01 · NIP-09 deletion propagation · NIP-10 threading · NIP-17/NIP-59 sealed messages · NIP-42
+relay auth · NIP-46 remote signing · NIP-65 outbox lists · NIP-OA owner attestation · Concord
+CORD-01/03 for group planes · and draft
+**[NIP-DA (#2411)](https://github.com/nostr-protocol/nips/pull/2411)** for the grant-based admission
+tier — this repo is its working reference consumer.
+
+## The honest limitation
+
+An inbound note is re-posted under the bridge's identity with explicit attribution, because the
+platform cannot yet render an event signed by someone outside it. That is the one change which would
+make this native rather than bridged: with native foreign-signed rendering, a guest appears in a
+community **as themselves**, with a signature anyone can verify, while the community keeps full
+control of admission.
+
+Everything above runs today with zero platform changes.
+
+---
+
+MIT. Issues and roadmap are public: <https://github.com/JAFairweather/waggle/issues>

--- a/console/index.html
+++ b/console/index.html
@@ -94,6 +94,13 @@
   .note{border:1px dashed var(--line-strong);border-radius:var(--r-md);padding:14px 16px;
     color:var(--dim);font-size:13.5px;margin-top:20px}
   .note b{color:var(--text)}
+
+  /* waggle is a lowercase wordmark. The shared bar uppercases app names by default and paints
+     them in --accent, which on this dark ground reads as a dim brown — legible enough for a
+     label, not for the one word the page is named after. Override locally rather than in the
+     shared component: the casing is waggle's brand rule, not a defect in the design system. */
+  #titlebar .ntb-name{text-transform:none;letter-spacing:.02em;color:var(--gold-bright)}
+  #titlebar .ntb-name::first-letter{color:var(--gold-bright)}
 </style>
 </head>
 <body>


### PR DESCRIPTION
Closes #44.

### The README

The lower two-thirds was orphaned internal text that contradicted the opening
section. It claimed **"v1 forwards Armada NIP-17 DMs only"**, linked a dead
`../../PLANS/WEST_BRIDGE_SCOPING.md`, named "the read-lane engineer" as owner,
listed the grant tier and Concord planes as *future roadmap* when both shipped
days ago, and named two test suites when there are seven. The rename pass also
left a note reading *"internal service name: `waggle` — it predates the public
name"*, which after the rename is circular.

Rewritten for someone who has never seen the project: the four lanes and what
crosses in each, a status table where every row is a proof rather than a claim,
quick start, tools, config, deploy, tests, and the honest limitation.

Two things it is careful about, because both have been wrong before:

- It says the bridge holds **exactly one private key — its own** — rather than
  the old "no private key", which was false.
- It marks nothing as shipped that is not, and every status row corresponds to a
  cold read-back rather than a relay accepting a publish.

### The wordmark

`waggle` is a lowercase wordmark. The shared Nave titlebar uppercases app names
and paints them in `--accent`, which on the dark bar renders as a dim brown —
the one word the page is named after was the least legible thing on it.

Overridden locally rather than in the shared component: the casing is waggle's
brand rule, not a defect in the design system, and changing `nave-titlebar`
would restyle every other app in the family.

Verified in a browser rather than by reading the CSS.

Drafted with assistance from [Claude Code](https://claude.com/claude-code)