### PR TITLE
deploy: unit descriptions say waggle, not West Bridge (finish #62 rename)

### DIFF
--- a/deploy/waggle-read.service
+++ b/deploy/waggle-read.service
@@ -9,7 +9,7 @@
 # Its config.json carries ONLY the "public" block (recipients/relays not required).
 # The buzz CLI must be executable by 'bridge' on the PATH below.
 [Unit]
-Description=West Bridge — public kind:1 read lane (quarantine-gated)
+Description=waggle — public kind:1 read lane (quarantine-gated)
 After=network-online.target
 Wants=network-online.target
 

--- a/deploy/waggle-sealed.service
+++ b/deploy/waggle-sealed.service
@@ -4,7 +4,7 @@
 #   "public read lane: inactive (no cfg.public.inbox)"
 # The read lane runs separately as waggle-read.service under the 'bridge' user.
 [Unit]
-Description=West Bridge — sealed lanes (Armada DMs + Concord planes → Buzz inboxes)
+Description=waggle — sealed lanes (Armada DMs + Concord planes → Buzz inboxes)
 After=network-online.target
 Wants=network-online.target
 


### PR DESCRIPTION
Originating channel: connector (`73f80d38-3245-41a9-814c-8ad364686944`). Flagged by waggle (Claude) as the last visible loose end of the #62 rename.

## Drift
#62 renamed the units to `waggle-sealed`/`waggle-read` and the trees to `/opt/waggle-{sealed,read}`, but both unit `Description=` lines still read **"West Bridge — …"**. On the host, `systemctl status` shows a unit named `waggle-*` that describes itself as West Bridge.

## Change
Two lines, `Description=West Bridge — …` → `Description=waggle — …` (lowercase per house rule). Cosmetic — display text only. The host's `ExecStart`, `WorkingDirectory`, `EnvironmentFile` are already correct; both lanes verify **21/21 against `origin/main` (b181488)** over live ssh.

## Verified (this branch, live box)
```
sealed @ /opt/waggle-sealed vs origin/main (b181488): OK 21/21 match
read   @ /opt/waggle-read   vs origin/main (b181488): OK 21/21 match
npm test: all suites pass (a1, a7, lane2_caps, nipda_admission, render_states, deploy_verify, return_lane)
```

## Host apply
The unit files on the box already run correctly; only the display string changes. Applying it needs root (`daemon-reload` after the file update) — a low-priority sudo task, not mine to run from the scoped `neil` account.

## Deliberately not bundled
`src/bridge.mjs` still prints `West Bridge v1` in its boot banner (L1076) and header comment (L1). Same drift, but changing it **rebuilds the runtime** (both lanes would then need a redeploy or verify-deployed.sh reports drift) and is a naming-intent call — keep "West Bridge v1" as a heritage/version marker, or rename to waggle. Raising it rather than deciding it unilaterally.

Co-Authored-By: Neil (West Bridge) <neil@nave.pub>