### PR TITLE
tripwire: union every lane's journal, and never all-clear a half-synced one

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "start": "node src/bridge.mjs",
     "dryrun": "FORWARD_MODE=dryrun node src/bridge.mjs",
-    "test": "node tests/a1_quarantine.mjs && node tests/a7_deletion.mjs && node tests/lane2_caps.mjs && node tests/nipda_admission.mjs && node tests/render_states.mjs && node tests/deploy_verify.mjs && node tests/return_lane.mjs",
+    "test": "node tests/a1_quarantine.mjs && node tests/a7_deletion.mjs && node tests/lane2_caps.mjs && node tests/nipda_admission.mjs && node tests/render_states.mjs && node tests/deploy_verify.mjs && node tests/return_lane.mjs && node tests/tripwire_union.mjs",
     "console": "node tools/serve-console.mjs"
   },
   "dependencies": {

--- a/tests/tripwire_union.mjs
+++ b/tests/tripwire_union.mjs
@@ -1,0 +1,73 @@
+// tripwire_union.mjs — the tripwire must diff against the UNION of every lane's send journal,
+// and must refuse to issue an all-clear when part of that union is missing (#87).
+//
+// Why this test exists: one poster identity signs from TWO deployments with separate data dirs
+// (the public read lane, and the sealed + return lanes). Diffing against a single tree reads the
+// other lane's legitimate sends as theft — a false alarm on day one. And a detector that cries
+// wolf gets muted, which is the same end state as having no detector at all.
+//
+// Runs the real tool against fixture journals. No relays, no production state.
+
+import { spawnSync } from 'node:child_process'
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { resolve, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const TOOL = resolve(HERE, '..', 'tools', 'tripwire.mjs')
+// A valid poster npub is required to get past argument validation; it signs nothing here.
+const POSTER = 'npub1s36nypljc6h88tey0kshf688eyd8myu636ctfs4e3d2w54nhsmnqfhaent'
+
+let failures = 0
+const check = (name, cond, detail = '') => {
+  if (cond) return console.log(`  ok   ${name}`)
+  failures++
+  console.log(`  FAIL ${name}${detail ? ` — ${detail}` : ''}`)
+}
+
+// Run the tool; return {code, out}. A window of 1 minute keeps the relay fetch trivial.
+//
+// spawnSync, not execFileSync: the per-journal accounting is written to STDERR, and execFileSync
+// hands back only stdout on success — so a passing run looked like it had produced no summary at
+// all. Both streams are evidence here.
+function run(journals) {
+  const args = ['--since-min', '1']
+  for (const j of journals) args.push('--journal', j)
+  const r = spawnSync('node', [TOOL, ...args],
+    { env: { ...process.env, POSTER, ALARM_NSEC: '', ALARM_TO: '' }, encoding: 'utf8' })
+  return { code: r.status, out: (r.stdout || '') + (r.stderr || '') }
+}
+
+const dir = mkdtempSync(resolve(tmpdir(), 'waggle-tripwire-'))
+try {
+  mkdirSync(resolve(dir, 'read'), { recursive: true })
+  mkdirSync(resolve(dir, 'sealed'), { recursive: true })
+  const readJ = resolve(dir, 'read', 'send-journal.log')
+  const sealedJ = resolve(dir, 'sealed', 'send-journal.log')
+  const id = (c) => c.repeat(64)
+  writeFileSync(readJ, JSON.stringify({ id: id('a'), kind: 9, lane: 'public' }) + '\n')
+  writeFileSync(sealedJ, JSON.stringify({ id: id('b'), kind: 9, lane: 'sealed' }) + '\n')
+
+  console.log('tripwire union (#87)')
+
+  const both = run([readJ, sealedJ])
+  check('unions every lane it is given', /2 journaled across 2\/2 lane\(s\)/.test(both.out),
+    both.out.split('\n').find(l => l.includes('journaled')) || 'no summary line')
+  check('a complete union can report OK', both.code === 0, `exit ${both.code}`)
+
+  // The property that matters: a missing lane journal must NOT become an all-clear.
+  const half = run([readJ, resolve(dir, 'absent', 'send-journal.log')])
+  check('a half-synced union does not exit clean', half.code === 3, `exit ${half.code}`)
+  check('it says INCONCLUSIVE, not OK', /INCONCLUSIVE/.test(half.out) && !/^OK/m.test(half.out))
+  check('it names the missing journal', /absent/.test(half.out))
+
+  // Comma-separated form is accepted, since that is how a systemd unit will pass it.
+  const csv = run([`${readJ},${sealedJ}`])
+  check('accepts comma-separated journals', /2\/2 lane\(s\)/.test(csv.out))
+} finally {
+  rmSync(dir, { recursive: true, force: true })
+}
+
+if (failures) { console.log(`\n${failures} check(s) failed`); process.exit(1) }
+console.log('\nall checks passed')

--- a/tools/tripwire.mjs
+++ b/tools/tripwire.mjs
@@ -51,7 +51,23 @@ if (process.env.ALARM_NSEC) {
 
 const sinceMin = Number(arg('--since-min', 120))
 const since = Math.floor(Date.now() / 1000) - sinceMin * 60
-const JOURNAL = arg('--journal', process.env.SEND_JOURNAL_PATH || resolve(ROOT, 'data', 'send-journal.log'))
+// ONE identity, MANY trees. The read lane and the sealed/return lanes run from separate
+// deployments with separate data dirs, and both sign as the same poster key. Diffing against a
+// single tree's journal therefore reads the OTHER lane's legitimate sends as theft — a false
+// alarm on day one (#87). So the journal is the UNION of every lane's log.
+//
+// Accepts --journal repeatedly, and comma/colon-separated values in either --journal or
+// SEND_JOURNAL_PATH.
+function journalPaths() {
+  const raw = []
+  for (let i = 2; i < process.argv.length - 1; i++) {
+    if (process.argv[i] === '--journal') raw.push(process.argv[i + 1])
+  }
+  if (!raw.length && process.env.SEND_JOURNAL_PATH) raw.push(process.env.SEND_JOURNAL_PATH)
+  const split = raw.flatMap(s => String(s).split(/[,:]/)).map(s => s.trim()).filter(Boolean)
+  return split.length ? split : [resolve(ROOT, 'data', 'send-journal.log')]
+}
+const JOURNALS = journalPaths()
 const ALARMS = resolve(ROOT, 'data', 'tripwire-alarms.log')
 
 function loadRelays() {
@@ -62,13 +78,26 @@ function loadRelays() {
   return [...out]
 }
 
+// Returns the union, plus the paths that were not there. A MISSING journal is not an empty one:
+// it means part of this identity's legitimate output is unaccounted for, so "no anomalies" would
+// be a conclusion the evidence cannot support. The caller reports INCONCLUSIVE rather than clean
+// — being unable to check is not the same as being fine.
 function loadJournal() {
   const ids = new Set()
-  if (!existsSync(JOURNAL)) { console.error(`tripwire: WARNING — no journal at ${JOURNAL}; every post will look unauthorized. Point --journal at the bridge's send-journal.`); return ids }
-  for (const line of readFileSync(JOURNAL, 'utf8').split('\n').filter(Boolean)) {
-    try { const r = JSON.parse(line); if (r.id) ids.add(r.id) } catch { /* skip */ }
+  const missing = []
+  for (const path of JOURNALS) {
+    if (!existsSync(path)) {
+      console.error(`tripwire: WARNING — no journal at ${path}. This lane's legitimate sends will look unauthorized.`)
+      missing.push(path)
+      continue
+    }
+    let n = 0
+    for (const line of readFileSync(path, 'utf8').split('\n').filter(Boolean)) {
+      try { const r = JSON.parse(line); if (r.id) { ids.add(r.id); n++ } } catch { /* skip */ }
+    }
+    console.error(`tripwire: journal ${path} — ${n} entries`)
   }
-  return ids
+  return { ids, missing }
 }
 
 // Fetch recent events authored by the poster across the relay set.
@@ -101,14 +130,21 @@ async function alarmDM(text) {
 }
 
 // --- run ---
-const journal = loadJournal()
+const { ids: journal, missing } = loadJournal()
 const events = await fetchPosterEvents()
 const anomalies = events.filter(e => !journal.has(e.id))
 const iso = (s) => new Date(s * 1000).toISOString()
 
-console.error(`tripwire: poster ${posterHex.slice(0, 12)}… · window ${sinceMin}m · ${events.length} on-relay event(s) · ${journal.size} journaled · ${anomalies.length} unaccounted`)
+console.error(`tripwire: poster ${posterHex.slice(0, 12)}… · window ${sinceMin}m · ${events.length} on-relay event(s) · ${journal.size} journaled across ${JOURNALS.length - missing.length}/${JOURNALS.length} lane(s) · ${anomalies.length} unaccounted`)
 
 if (!anomalies.length) {
+  // A half-synced union cannot produce an all-clear. With a lane's journal absent, "nothing
+  // unaccounted" only means nothing was found in the part we could see, and reporting that as OK
+  // is precisely the shape of check that passes because it examined nothing.
+  if (missing.length) {
+    console.log(`INCONCLUSIVE — no anomalies found, but ${missing.length} of ${JOURNALS.length} lane journal(s) were missing:\n  ${missing.join('\n  ')}\nFix the sync before trusting this result. This is NOT an all-clear.`)
+    process.exit(3)
+  }
   console.log('OK — every on-relay post by the poster key was emitted by our process.')
   process.exit(0)
 }


### PR DESCRIPTION
Closes #87. Pre-arm blocker — this had to land before the alarm DM is armed.

### The false alarm

One poster identity signs from **two** deployments with separate data dirs (the
public read lane; the sealed + return lanes). The watcher diffed against a single
tree's journal, so every legitimate send from the other lane read as
**unaccounted** — an alarm on day one, for normal operation.

A detector that cries wolf gets muted, which ends in the same place as no
detector at all.

`--journal` is now repeatable and accepts comma/colon-separated values (how a
systemd unit will pass it), and the journal is the union of all of them.

### The half-synced case, which matters more

If a lane's journal is **missing**, the tool no longer reports OK. It reports
**INCONCLUSIVE** and exits **3**.

A missing journal is not an empty one — it means part of this identity's
legitimate output is unaccounted for, so *"no anomalies"* is a conclusion the
evidence cannot support. Being unable to check is not the same as being fine, and
a check that passes because it examined nothing is exactly the failure shape this
repo keeps catching.

| state | exit |
|---|---|
| complete union, nothing unaccounted | 0 — OK |
| any lane journal missing | **3 — INCONCLUSIVE** |
| unaccounted events | 2 — alarm |

### Tests

`tests/tripwire_union.mjs` — 6 checks against the **real tool** with fixture
journals, no relays and no production state. Wired into `npm test` (now 8 suites,
all green).

It earned its keep on the first run: the per-lane accounting goes to **stderr**,
and the harness initially used `execFileSync`, which returns only stdout on
success — so a passing run looked like it had produced no summary at all. The
test failed, the tool was fine, and the harness was wrong. Now captures both
streams.

Drafted with assistance from [Claude Code](https://claude.com/claude-code)