### PR TITLE
tripwire: make the detection drill repeatable, and prove both controls

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "start": "node src/bridge.mjs",
     "dryrun": "FORWARD_MODE=dryrun node src/bridge.mjs",
-    "test": "node tests/a1_quarantine.mjs && node tests/a7_deletion.mjs && node tests/lane2_caps.mjs && node tests/nipda_admission.mjs && node tests/render_states.mjs && node tests/deploy_verify.mjs && node tests/return_lane.mjs && node tests/tripwire_union.mjs",
+    "test": "node tests/a1_quarantine.mjs && node tests/a7_deletion.mjs && node tests/lane2_caps.mjs && node tests/nipda_admission.mjs && node tests/render_states.mjs && node tests/deploy_verify.mjs && node tests/return_lane.mjs && node tests/tripwire_union.mjs && node tests/tripwire_detection.mjs",
     "console": "node tools/serve-console.mjs"
   },
   "dependencies": {

--- a/tests/tripwire_detection.mjs
+++ b/tests/tripwire_detection.mjs
@@ -1,0 +1,89 @@
+// tripwire_detection.mjs — the drill (#35). A detector that has never fired is not a detector,
+// it is an untested assumption on a schedule.
+//
+// Proves BOTH controls against the real tool, offline:
+//
+//   positive — an on-relay event absent from the journal  -> alarm, exit 2, logged
+//   negative — the same event, journaled                  -> clean, exit 0
+//
+// Both halves matter. An alarm that never fires and one that always fires fail identically, and
+// only the pair distinguishes "detects theft" from "shouts at everything".
+//
+// Events are injected with --events-from, which substitutes the wire and nothing else: the diff,
+// the alarm log and the exit codes are the same code a live run executes. A drill that exercised
+// a parallel path would prove nothing about the path that matters.
+
+import { spawnSync } from 'node:child_process'
+import { mkdtempSync, writeFileSync, readFileSync, existsSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { resolve, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const ROOT = resolve(HERE, '..')
+const TOOL = resolve(ROOT, 'tools', 'tripwire.mjs')
+const POSTER = 'npub1s36nypljc6h88tey0kshf688eyd8myu636ctfs4e3d2w54nhsmnqfhaent'
+// Written per-run into the temp dir. The real log at data/tripwire-alarms.log is evidence an
+// operator is meant to trust; a test must not leave fake alarms in it.
+let ALARMS
+
+let failures = 0
+const check = (name, cond, detail = '') => {
+  if (cond) return console.log(`  ok   ${name}`)
+  failures++
+  console.log(`  FAIL ${name}${detail ? ` — ${detail}` : ''}`)
+}
+
+function run(journal, eventsFile) {
+  const r = spawnSync('node', [TOOL, '--since-min', '60', '--journal', journal, '--events-from', eventsFile],
+    { env: { ...process.env, POSTER, ALARM_NSEC: '', ALARM_TO: '', ALARM_LOG_PATH: ALARMS }, encoding: 'utf8' })
+  return { code: r.status, out: (r.stdout || '') + (r.stderr || '') }
+}
+
+const dir = mkdtempSync(resolve(tmpdir(), 'waggle-drill-'))
+ALARMS = resolve(dir, 'tripwire-alarms.log')
+try {
+  const stolenId = 'd'.repeat(64)
+  const ourId = 'e'.repeat(64)
+  const at = Math.floor(Date.now() / 1000) - 60
+
+  // Two events on the wire under the poster key: one we emitted, one we did not.
+  const eventsFile = resolve(dir, 'events.jsonl')
+  writeFileSync(eventsFile, [
+    JSON.stringify({ id: ourId, kind: 9, created_at: at, tags: [['h', 'channel']], content: 'ours' }),
+    JSON.stringify({ id: stolenId, kind: 1, created_at: at, tags: [], content: 'signed by something else' }),
+  ].join('\n') + '\n')
+
+  console.log('tripwire detection drill (#35)')
+
+  // --- positive control: the unjournalled event must alarm ---
+  const partial = resolve(dir, 'partial.log')
+  writeFileSync(partial, JSON.stringify({ id: ourId, kind: 9 }) + '\n')
+
+  const before = existsSync(ALARMS) ? readFileSync(ALARMS, 'utf8').length : 0
+  const pos = run(partial, eventsFile)
+  check('unjournalled event alarms (exit 2)', pos.code === 2, `exit ${pos.code}`)
+  check('it names the unaccounted event', pos.out.includes(stolenId.slice(0, 16)))
+  check('it does NOT flag the journalled one', !pos.out.includes(ourId.slice(0, 16)))
+  const after = existsSync(ALARMS) ? readFileSync(ALARMS, 'utf8').length : 0
+  check('the alarm is recorded to disk', after > before, 'tripwire-alarms.log did not grow')
+
+  // --- negative control: journal it, and the alarm must go quiet ---
+  const full = resolve(dir, 'full.log')
+  writeFileSync(full, [
+    JSON.stringify({ id: ourId, kind: 9 }),
+    JSON.stringify({ id: stolenId, kind: 1 }),
+  ].join('\n') + '\n')
+
+  const neg = run(full, eventsFile)
+  check('the same events, fully journalled, are clean (exit 0)', neg.code === 0, `exit ${neg.code}`)
+  check('it reports OK', /^OK/m.test(neg.out))
+
+  // A substituted run must never be mistakable for a live one in a log.
+  check('a drill run announces that it is a drill', /DRILL/.test(pos.out))
+} finally {
+  rmSync(dir, { recursive: true, force: true })
+}
+
+if (failures) { console.log(`\n${failures} check(s) failed`); process.exit(1) }
+console.log('\nall checks passed')

--- a/tools/tripwire.mjs
+++ b/tools/tripwire.mjs
@@ -68,7 +68,10 @@ function journalPaths() {
   return split.length ? split : [resolve(ROOT, 'data', 'send-journal.log')]
 }
 const JOURNALS = journalPaths()
-const ALARMS = resolve(ROOT, 'data', 'tripwire-alarms.log')
+// Overridable so a drill can write somewhere disposable. A test that appends to the real alarm
+// log leaves fake alarms in the record an operator is meant to trust — and the suite's own rule
+// is that it touches no production state.
+const ALARMS = process.env.ALARM_LOG_PATH || resolve(ROOT, 'data', 'tripwire-alarms.log')
 
 function loadRelays() {
   const out = new Set()
@@ -131,7 +134,21 @@ async function alarmDM(text) {
 
 // --- run ---
 const { ids: journal, missing } = loadJournal()
-const events = await fetchPosterEvents()
+
+// --events-from <file> substitutes the WIRE, never the judgement. It replaces only where events
+// come from; the diff against the journal, the alarm log, the DM and the exit codes stay the code
+// a real run uses. That is the point — a drill exercising a parallel path proves nothing about
+// the path that matters. Opt-in, and announced loudly, so a substituted run can never be mistaken
+// for a live one when someone reads the log later.
+const EVENTS_FROM = arg('--events-from', null)
+let events
+if (EVENTS_FROM) {
+  console.error(`tripwire: DRILL — events read from ${EVENTS_FROM}, NOT from the relays. This run says nothing about live state.`)
+  events = readFileSync(EVENTS_FROM, 'utf8').split('\n').filter(Boolean).map(l => JSON.parse(l))
+} else {
+  events = await fetchPosterEvents()
+}
+
 const anomalies = events.filter(e => !journal.has(e.id))
 const iso = (s) => new Date(s * 1000).toISOString()
 


### PR DESCRIPTION
Closes #35. `npm test` now 9 suites, green.

> A detector that has never fired is not a detector — it is an untested
> assumption on a schedule.

The drill was run by hand once against a disposable identity, then lived only in
a diary entry. This makes it repeatable, offline, and part of the suite.

### Both controls

| | |
|---|---|
| **positive** — on-relay event absent from the journal | alarm, **exit 2**, written to the alarm log |
| **negative** — the same events, fully journalled | clean, **exit 0** |

Only the pair distinguishes *"detects theft"* from *"shouts at everything"*. The
positive control additionally asserts the alarm **names the unaccounted event and
does not name the journalled one** — so a tool that flagged everything would fail.

### `--events-from` substitutes the wire, not the judgement

The diff against the journal, the alarm log, the DM and the exit codes stay the
code a live run executes. A drill exercising a parallel path proves nothing about
the path that matters.

It announces itself loudly — `DRILL — events read from …, NOT from the relays` —
so a substituted run can't be mistaken for a live one by someone reading the log
later. The test asserts that announcement too.

### One thing caught before it landed

The first version appended to the **real** `data/tripwire-alarms.log`, which would
put fake alarms in the record an operator is meant to trust. `ALARM_LOG_PATH` now
makes it overridable and the drill writes to a temp dir, so the suite keeps its
rule of touching no production state.

Drafted with assistance from [Claude Code](https://claude.com/claude-code)