### PR TITLE
waggle-init: name the destination channel, and point proof steps at real tools

### DIFF
--- a/tools/waggle-init.mjs
+++ b/tools/waggle-init.mjs
@@ -104,8 +104,29 @@ const checks = [
   ['public.grantors', Array.isArray(P.grantors) && P.grantors.length && !isPlaceholder(P.grantors[0]), 'whose signed grants admit an outside participant'],
   ['public.watch_events', Array.isArray(P.watch_events) && P.watch_events.length && !isPlaceholder(P.watch_events[0]), 'notes whose replies you want to receive'],
 ]
+// A configured channel is a UUID, and a UUID confirms nothing to a human. "public.inbox ✓" next
+// to an unreadable id is exactly the kind of green tick that gets trusted without being checked —
+// and pointing the bridge at the wrong channel is silent until members see traffic they did not
+// expect. So resolve the name and show it. Best-effort: needs the CLI and credentials, and when
+// it cannot resolve we say so rather than implying the id was validated.
+function channelLabel(uuid) {
+  if (!hasBuzz) return `${uuid} ${c.dim}(name unresolved — buzz CLI not on PATH)${c.off}`
+  try {
+    const out = execFileSync('buzz', ['channels', 'get', '--channel', uuid], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] })
+    const name = JSON.parse(out)?.name
+    return name ? `${c.ok}#${name}${c.off} ${c.dim}(${uuid.slice(0, 8)}…)${c.off}` : uuid
+  } catch {
+    return `${uuid} ${c.dim}(name unresolved — no credentials here, or the channel is not visible to you)${c.off}`
+  }
+}
+
 let gaps = 0
-for (const [k, ok, why] of checks) { if (ok) good(k); else { todo(`${k} — ${why}`); gaps++ } }
+for (const [k, ok, why] of checks) {
+  if (!ok) { todo(`${k} — ${why}`); gaps++; continue }
+  if (k === 'public.inbox') good(`${k} → messages land in ${channelLabel(P.inbox)}`)
+  else if (k === 'public.staging_inbox') good(`${k} → quarantine waits in ${channelLabel(P.staging_inbox)}`)
+  else good(k)
+}
 
 // --- interactive fill ---------------------------------------------------------------------------
 if (!CHECK_ONLY && (gaps || !cfgExists)) {
@@ -165,10 +186,13 @@ todo('Apply the firewall:                  deploy/nave-fw.nft')
 note('it permits NTP egress on purpose — a dropped clock silently corrupts every time-based gate')
 
 head('After it runs — the steps that prove it, rather than assume it')
-todo('Confirm the clock is synchronised on the host')
+todo('Prove the firewall loaded and the clock is synced:  sudo deploy/verify-firewall.sh')
+note('applying is not loading — a correct ruleset once sat on a box for a day without')
+note('entering the kernel. Exit 3 means INCONCLUSIVE, which is not an all-clear.')
 todo('Confirm the deployed build matches git:  sh deploy/verify-deployed.sh')
 todo('Schedule the tripwire, then make it fire once on purpose')
 note('a detector that has never fired is not a detector, it is an assumption with a timer')
+note('npm test rehearses both controls offline; the live drill is still worth doing once')
 todo('Publish the agent relay list:        node tools/publish_relay_list.mjs')
 todo('Admit a participant, if you want one: sh tools/grant-setup.sh')
 


### PR DESCRIPTION
Refs #53 (the installer's remaining scope is larger than this).

### The destination channel was a green tick over a UUID

`public.inbox ✓` next to an unreadable id is exactly the kind of confirmation
that gets trusted without being checked — and pointing the bridge at the **wrong**
channel is silent until members see traffic they didn't expect. The issue calls
this *"the knob an operator asks about first"*, and it was the one thing the check
couldn't actually answer.

Now resolved through `buzz channels get` and shown by name:

```
✓ public.inbox → messages land in #connector (73f80d38…)
```

**Best-effort by design.** It needs the CLI and credentials; where it can't
resolve, it says `name unresolved` rather than implying the id was validated. An
unverified id must not be dressed up as a verified one.

Verified both ways: unresolved on a machine without credentials, and resolving to
`#connector` where they exist (confirmed the CLI really returns a `name` field
rather than assuming the shape).

### The proof steps described tools that now exist

*"Confirm the clock is synchronised on the host"* → `sudo deploy/verify-firewall.sh`,
with the reason inline (**applying is not loading**) and the warning that **exit 3
means INCONCLUSIVE, not an all-clear**. The tripwire step now notes that
`npm test` rehearses both controls offline, while the live drill is still worth
doing once.

Drafted with assistance from [Claude Code](https://claude.com/claude-code)