### PR TITLE
ci: run npm test on PRs and pushes to main (#38)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,46 @@
+name: CI
+
+# Run the test suite on every PR and on pushes to main (issue #38). The four
+# suites — quarantine gating, deletion propagation, lane-2 rate caps, grant
+# admission — plus render/deploy-verify/return-lane are side-effect-free (temp
+# dirs, stubbed sends), so they are safe to run unattended. A visible green
+# check replaces "whoever remembered to run it locally", and is part of the
+# credibility story for a public repo.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: npm test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        # A real .git checkout is required: tests/deploy_verify.mjs drives
+        # `git archive HEAD` / `git cat-file` to build its fixture. The default
+        # shallow depth is fine — HEAD is present.
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22' # matches the deployed runtime; package.json engines is >=20
+          cache: npm
+
+      - name: Install from lockfile
+        run: npm ci --no-audit --no-fund
+
+      - name: Provide a config for the suite
+        # config.json is gitignored — per-box routing policy lives on the host
+        # (issue #104), not in git. The committed example carries the schema the
+        # suite needs; a1 grounds in it, the others write their own temp configs.
+        run: cp config.example.json config.json
+
+      - name: Test
+        run: npm test


### PR DESCRIPTION
Closes #38. Originating channel: connector (`73f80d38-3245-41a9-814c-8ad364686944`).

## Why
Seven suites exist and nothing ran them — the safety gates were protected only by whoever remembered to run `npm test` locally. Tonight's silent-failure incident (a config path aimed at a directory the #62 rename had deleted; the failure **printed nothing at all**) is exactly what a required check turns loud. And for a public repo, a visible green check is part of the credibility story.

## What
`.github/workflows/ci.yml` — on PRs and pushes to `main`:
1. `actions/checkout@v4` — a **real** `.git`, which `tests/deploy_verify.mjs` needs (`git archive HEAD`).
2. `actions/setup-node@v4`, Node 22 (matches the deployed runtime; `engines` is `>=20`), npm cache.
3. `npm ci` from the lockfile.
4. `cp config.example.json config.json` — the real `config.json` is gitignored (per-box routing lives on the host, #104); the committed example carries the schema the suite needs.
5. `npm test`.

`concurrency` cancels superseded runs on the same ref.

## Validated
Clean-room `git clone` reproducing the exact steps — `npm ci` OK, `npm test` **exit 0** (all of a1_quarantine, a7_deletion, lane2_caps, nipda_admission, render_states, deploy_verify, return_lane). The first check on this PR is the deliverable itself: **#38's verify is "a pull request shows the suite running and passing."**

## Note
I found the `config.json`-is-gitignored wrinkle the tests depend on while wiring this — it intersects #104 (live config not in the repo). CI sidesteps it with the example config; #104 remains its own reconciliation question.

Co-Authored-By: Neil (West Bridge) <neil@nave.pub>