### PR TITLE
verify-config: surface the return-lane keys the repo cannot hold (#104)

### DIFF
--- a/deploy/verify-config.sh
+++ b/deploy/verify-config.sh
@@ -62,6 +62,38 @@ if missing_keys:
     print("  note     keys in config.example.json but not live: %s" % ", ".join(sorted(missing_keys)))
     print("           (not necessarily wrong — but confirm each is deliberate)")
 
+# ── return lane (mentions out to admitted guests): scan_authors + return_lane[].authors ──
+# These are the same failure class as watch_authors, but they never fail this check: each has a
+# valid empty state — scan_authors absent FLOORS to approvers+grantors+trusted_repliers, and a
+# return_lane entry with no authors shares the bridge key and defers echo-skip to the per-event
+# registry. What the repo cannot hold is a box-side WIDENING: set an explicit scan_authors or bind
+# an agent's own key on the box, and a rebuild from the example drops it silently — the gate
+# narrows to the floor, or echo-skip regresses, with no error and nothing at runtime to notice.
+# The generic shape-diff above cannot see return_lane[].authors at all (it is nested). So surface
+# both here — counts, never values — so a human confirms the live gate is the one they intend.
+scan_channels = live.get("scan_channels") or []
+return_lane   = live.get("return_lane") or []
+if scan_channels or return_lane:
+    print()
+    print("return lane (out to admitted guests) — live policy the repo cannot hold:")
+
+    sa = live.get("scan_authors")
+    if isinstance(sa, list) and sa:
+        print("  ok       scan_authors   %d explicit signer(s) — box-side policy a rebuild would drop" % len(sa))
+    else:
+        low = lambda xs: {str(x).lower() for x in (xs or [])}
+        floor = low(live.get("approvers")) | low(live.get("grantors") or live.get("approvers")) | low(live.get("trusted_repliers"))
+        armed = " — scan is ARMED" if scan_channels else ""
+        print("  ok       scan_authors   absent%s; trigger gate FLOORS to approvers+grantors+trusted_repliers (%d)" % (armed, len(floor)))
+        print("           (an explicit box-side widening would be lost here silently; confirm the floor is the intent)")
+
+    if return_lane:
+        bound = sum(1 for r in return_lane if isinstance(r, dict) and r.get("authors"))
+        print("  ok       return_lane    %d delivery target(s), %d with a bound echo-skip author" % (len(return_lane), bound))
+        if bound:
+            print("           (%d author-binding(s) are live policy off-repo — a rebuild drops them and" % bound)
+            print("            echo-skip falls back to the per-event registry; confirm each is deliberate)")
+
 print()
 if fail:
     print("FAILED — the bridge will start and route less than you think.")


### PR DESCRIPTION
Refs #104. Closes the arm-gate for #114 (durability-guard-present before feature-live). Disjoint from #114: this touches only `deploy/verify-config.sh`.

## The gap

#114 makes `scan_authors` and `return_lane[].authors` **live routing policy**. They join `watch_authors` in the class #104 is about: state `config.json` holds, the public repo cannot, and nothing reconciles — so a box-side widening drops **silently** on a rebuild from `config.example.json`. The gate narrows to its floor, or echo-skip regresses, with no error and nothing at runtime to notice.

`verify-config.sh` (#109) is the detector for that class, but it did not cover these two, and it structurally *couldn't* cover one of them:

- **`scan_authors`** — absent is valid (the bridge FLOORS to `approvers+grantors+trusted_repliers`), so it can't use the REQUIRED path. The silent case is an *explicit* box-side set narrowing to the floor on rebuild — which fires **no** runtime warning (the boot WARN at `bridge.mjs` only fires when even the floor is empty, impossible while `approvers` is populated).
- **`return_lane[].authors`** — **nested** inside the `return_lane` array, so the existing top-level shape-diff never reaches it. Absent is valid too (shares the bridge key, defers echo-skip to the registry).

## The change

A drift-visibility section, in the script's existing idiom — counts, never values, "confirm this is deliberate." It reports whether `scan_authors` is an explicit box-side set or the floor (and whether the scan is armed), and how many `return_lane` targets carry a bound echo-skip author, flagging each as policy a rebuild would drop. It **never** introduces a false fail: both keys have valid empty states, so exit codes (`0` complete / `2` required-empty / `3` inconclusive) are unchanged.

Detection, not prevention — option (2) of #104. Being *unable* to drift (option 1: a versioned non-secret config layer deploy renders from) remains the durable answer; flagged for a separate decision, not built here.

## Verification

Exercised against synthetic configs for every branch — explicit `scan_authors`, absent-and-armed (floor), the live-box shape (return lane present, scan not armed, no bound authors), and a bound-author target — plus the negative controls from CLAUDE.md discipline: `watch_authors: []` still exits **2**, an unreadable path still exits **3**. Grounded against the live read-lane config first (counts only): today `return_lane`=1 target/0 bound, `scan_authors`/`scan_channels` absent — the section renders it clean, as it should.

Drafted with assistance from [Claude Code](https://claude.com/claude-code)