### PR TITLE
Presentation follows trust, for refs too: a granted agent can wake the room (#94)

### DIFF
--- a/src/bridge.mjs
+++ b/src/bridge.mjs
@@ -636,8 +636,23 @@ export function renderQuarantined({ body, mention = '', name, npub, when, claim 
 // flowing text, no code bubble, no gutter. A8 (native foreign-signed rendering) is what finally
 // puts the participant's OWN avatar and name on it; until then this is a bridge-authored
 // message that reads as cleanly as a repost can.
-export function renderReleased({ body, name, npubShort }) {
-  return `**${name || npubShort}**  ·  \`${npubShort}\`  ·  _via waggle_\n\n${defuseRefs(body)}`
+// `liveRefs` decides whether the body's @mentions survive (#94). Presentation follows trust, and
+// defuseMarkup already states the rule this completes: "a vouched identity keeps its formatting."
+// That exception was implemented for markup and never for refs, so EVERY reposted body had its
+// mentions killed — a signed, revocably-granted participant's included. The cost was not
+// cosmetic: an admitted agent could be carried into the room and still not wake a single
+// colleague, which is the entire point of being admitted. That is what pushed operators onto a
+// path that signs as the bridge instead. #94 diagnosed it exactly and was closed on a screenshot
+// taken from that other path, where defuseRefs never runs.
+//
+// DEFAULT FALSE — fail closed. Only a live NIP-DA grant (signed, scoped, revocable by a 441)
+// buys live refs. A mirrored feed does not: `watch_authors` streams an author's ENTIRE public
+// feed inward, so honouring refs there would let any watched note summon the room. Nor does a
+// standing follow (reply-trust is strictly narrower than admission), nor content a human released
+// from quarantine — approving a stranger's note means "this may be published", never "this may
+// summon people".
+export function renderReleased({ body, name, npubShort, liveRefs = false }) {
+  return `**${name || npubShort}**  ·  \`${npubShort}\`  ·  _via waggle_\n\n${liveRefs ? body : defuseRefs(body)}`
 }
 
 // Repost a PLAINTEXT public note into a Buzz channel. `dest` is the community inbox for a
@@ -671,9 +686,14 @@ async function forwardPublic(ev, why, dest, quarantine) {
   try { npub = nip19.npubEncode(ev.pubkey) } catch { npub = null }
   // Heavily contracted npub for the attribution line — enough to recognize/verify, not a wall.
   const npubShort = npub ? `${npub.slice(0, 10)}…${npub.slice(-5)}` : (ev.pubkey || '?').slice(0, 12) + '…'
+  // #94: only a live NIP-DA grant earns live @mentions. grantSet is exactly the signed-and-
+  // revocable set (`processGrantEvent`), so a 441 removes the ability to summon the room in the
+  // same act that removes admission — no second switch to forget. Every other reason a note
+  // reaches here (mirrored feed, standing follow, human-released quarantine) stays defused.
+  const liveRefs = !quarantine && !!ev.pubkey && grantSet.has(String(ev.pubkey).toLowerCase())
   const content = quarantine
     ? renderQuarantined({ body, mention, name, npub: npub || ev.pubkey, when, claim, why, id: ev.id })
-    : renderReleased({ body, name, npubShort })
+    : renderReleased({ body, name, npubShort, liveRefs })
   // Test seam: exercise the full buzz-mode path (markSeen/watermark/posted-map) without a
   // network send. The synthetic buzz id (orig id reversed — still 64 hex, still unique)
   // exercises the same capture shape the live path records.

--- a/tests/render_states.mjs
+++ b/tests/render_states.mjs
@@ -49,14 +49,26 @@ ok('the approver is pinged', q.startsWith('@jafairweather '))
 ok('the actions are offered', /approve/.test(q) && /waggle-approve abc123/.test(q))
 ok('no code fence in the quarantine render', !q.includes('```'))
 
-// A vouched identity reads as an ordinary message — but still cannot ping.
+// A vouched identity reads as an ordinary message. Refs stay defused UNLESS the author holds a
+// live grant (#94), and the default is closed so a caller that forgets the flag cannot summon anyone.
 const r = renderReleased({ body: 'Hello @jafairweather — nostr:npub1x and **bold** stays.', name: 'Claude', npubShort: 'npub10zz…kf56w' })
-console.log('--- released render ---\n' + r.replace(/​/g, '·') + '\n')
+console.log('--- released render (ungranted) ---\n' + r.replace(/​/g, '·') + '\n')
 ok('released text is not quoted or fenced', !r.includes('> ') && !r.includes('```'))
-ok('released mentions are still defused', !/@[\w]/.test(r.replace(/@​/g, '')))
-ok('released nostr: refs are still defused', !/nostr:(?!​)/i.test(r))
+ok('an UNGRANTED author still cannot ping', !/@[\w]/.test(r.replace(/@​/g, '')))
+ok('an UNGRANTED author\'s nostr: refs stay defused', !/nostr:(?!​)/i.test(r))
 ok('released keeps its own formatting', r.includes('**bold**'))
 ok('released names the author and route', r.includes('Claude') && r.includes('via waggle'))
+ok('defusing is the DEFAULT — omitting liveRefs must never open it',
+  renderReleased({ body: 'ping @jafairweather', name: 'x', npubShort: 'y' }).includes('@​'))
+
+// #94: a GRANTED participant keeps live mentions, or admission buys nothing — it can be carried
+// into the room and still wake nobody. The absence of this assertion is what made the bypass rational.
+const g = renderReleased({ body: 'Hello @jafairweather — nostr:npub1x and **bold** stays.', name: 'Claude', npubShort: 'npub10zz…kf56w', liveRefs: true })
+console.log('--- released render (granted) ---\n' + g.replace(/​/g, '·') + '\n')
+ok('a GRANTED author CAN ping', /@jafairweather/.test(g) && !g.includes('@​'))
+ok('a granted author\'s nostr: ref is left intact', /nostr:npub1x/.test(g))
+ok('a granted render still names the author and route', g.includes('Claude') && g.includes('via waggle'))
+ok('granted and ungranted differ ONLY in the refs', defuseRefs(g) === r)
 
 // Helpers behave on the edges.
 ok('empty body does not throw', typeof renderQuarantined({ body: '', name: null, npub: 'n', when: 'w', why: 'y', id: 'i' }) === 'string')


### PR DESCRIPTION
Closes #94, reopened with the reproduction its closing comment asked for.

## The bug

`defuseMarkup` already states the governing rule — *"Quarantined text only — a vouched identity keeps its formatting."* That exception was implemented for markup and **never for refs**, so `renderReleased` defused every reposted body. A signed, scoped, revocably-**granted** participant could be carried into the channel and still be unable to wake a single colleague — which is most of what admission is for.

Reproduced on the wire before touching anything. `ef6c8fd2` in `#waggle-test`:

```
**Claude**  ·  `npub10zzka…kf56w`  ·  _via waggle_

@​Kerouac @​Dennis — new assignment, tracked as waggle#92.
```

Four `​`. Both are channel members. Neither was woken; that assignment reached nobody.

## Why it is upstream of something worse

With the sanctioned lane unable to raise anyone, the only way to reach a colleague was to compose locally and post via the `buzz` CLI under the bridge's own key — signing as the bridge, with a hand-typed byline that imitates this function's output minus the npub and minus the sanitiser. Fixing the render removes the reason that path looked rational. A control that forbade the bypass without restoring the lane would just have moved the pressure somewhere else.

## The change

`renderReleased` gains `liveRefs`, **default false** — a caller that forgets the flag cannot summon anyone. `forwardPublic` sets it only from `grantSet`, the signed and 441-revocable admission set:

- **mirrored feed** (`watch_authors`) — no. It streams an author's *entire* public feed inward; honouring refs there would let any watched note summon the room.
- **standing follow** (`trusted_repliers`) — no. Reply-trust is strictly narrower than admission.
- **human-released quarantine** — no. Approving a stranger's note means *"this may be published"*, never *"this may summon people"*.

Revocation removes the ability to ping in the same act that removes admission — no second switch to forget.

## Tests

`tests/render_states.mjs` previously asserted *"released mentions are still defused"* — the bug encoded as a guarantee. Replaced with the trust distinction, plus a default-closed assertion and an equivalence check that granted and ungranted output differ **only** in the refs. Ten suites green, exit 0.

Not addressed here, deliberately: `@claude` resolves to no channel member at all, on any path, because the agent is not a member. That is the wall, not this bug — the return lane and `scan_channels` are its answer.

Drafted with assistance from [Claude Code](https://claude.com/claude-code)
