### PR TITLE
return-lane: #5 no-miss — persisted scan cursor + pagination, with negative control

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -31,7 +31,7 @@
     "scan_channels": ["<channel name or UUID of a WORKING channel to scan for @mentions/replies to a return-lane agent; NEVER the staging_inbox; omit => scan nothing>"],
     "scan_authors": ["<hex pubkey allowed to TRIGGER a return-lane carry (signer gate); omit => floors to approvers+grantors+trusted_repliers; bridge key is always excluded; live routing policy, held durable off-repo>"],
     "return_lane": [
-      { "npub_hex": "<64-hex delivery key of an admitted agent — where its sealed mentions are addressed>", "mention": "<@name that reaches it in channel>", "authors": ["<64-hex Buzz-side key that signs THIS agent's own in-channel posts; drives echo-skip only while unique to one entry; omit if it shares the bridge key>"] }
+      { "npub_hex": "<64-hex delivery key of an admitted agent — where its sealed mentions are addressed>", "mention": "<@name that reaches it in channel>", "authors": ["<64-hex Buzz-side key that signs THIS agent's own in-channel posts; drives echo-skip only while unique to one entry; omit if it shares the bridge key. Bind a key here ONLY if it signs exactly one agent's posts: the guard keys off config-entry count, not actual signing multiplicity, so pinning the de-facto-shared bridge key to a single entry silently defeats it (a cross-mention would be dropped as echo)>"] }
     ],
     "trusted_repliers": [],
     "muted_authors": []

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "start": "node src/bridge.mjs",
     "dryrun": "FORWARD_MODE=dryrun node src/bridge.mjs",
-    "test": "node tests/a1_quarantine.mjs && node tests/a7_deletion.mjs && node tests/lane2_caps.mjs && node tests/nipda_admission.mjs && node tests/render_states.mjs && node tests/deploy_verify.mjs && node tests/return_lane.mjs && node tests/return_lane_scan.mjs && node tests/tripwire_union.mjs && node tests/tripwire_detection.mjs",
+    "test": "node tests/a1_quarantine.mjs && node tests/a7_deletion.mjs && node tests/lane2_caps.mjs && node tests/nipda_admission.mjs && node tests/render_states.mjs && node tests/deploy_verify.mjs && node tests/return_lane.mjs && node tests/return_lane_scan.mjs && node tests/return_lane_nomiss.mjs && node tests/tripwire_union.mjs && node tests/tripwire_detection.mjs",
     "console": "node tools/serve-console.mjs"
   },
   "dependencies": {

--- a/src/bridge.mjs
+++ b/src/bridge.mjs
@@ -1086,6 +1086,74 @@ function pollCommands() {
   })
 }
 
+// A5-scan: NO-MISS ACROSS DOWNTIME (#5). A blind newest-page read (`--limit N`, no since) drops
+// any mention buried past the N newest during an outage, and dedup can never recover a message that
+// was never scanned — durable rlSeen closes the re-SEND half, not the MISS half. So the scan is
+// anchored to a PERSISTED per-channel cursor (same A3 shape as pub-watermark): each poll reads from
+// (cursor - overlap) forward and PAGINATES with --before until the backlog is drained, so --limit
+// can never truncate it. The cursor advances only after a full, clean drain — a read/parse failure
+// leaves it untouched so the next poll re-reads (a failed carry is never a silent skip). The overlap
+// re-read is a no-op under durable rlSeen (per source × recipient), never a re-carry. On first boot
+// (no cursor) it floors to a bounded lookback, matching the DM lane's 48h + id-dedup philosophy.
+const SCAN_WATERMARK_PATH = process.env.SCAN_WATERMARK_PATH || resolve(ROOT, 'data', 'scan-watermark.json')
+const SCAN_WATERMARK_OVERLAP = Number(process.env.SCAN_WATERMARK_OVERLAP || 120)
+const SCAN_BOOTSTRAP_SECS = Number(process.env.SCAN_BOOTSTRAP_SECS || 172800) // 48h, matches DM lane
+const SCAN_PAGE_LIMIT = Number(process.env.SCAN_PAGE_LIMIT || 200)
+function loadScanCursors() {
+  try { const o = JSON.parse(readFileSync(SCAN_WATERMARK_PATH, 'utf8')); return (o && typeof o === 'object') ? o : {} }
+  catch { return {} }
+}
+let scanCursors = loadScanCursors()
+function scanSince(ch) {
+  const c = Number(scanCursors[ch] || 0)
+  return c > 0 ? c - SCAN_WATERMARK_OVERLAP : Math.floor(Date.now() / 1000) - SCAN_BOOTSTRAP_SECS
+}
+function bumpScanCursor(ch, ts) {
+  if (!Number.isFinite(ts) || ts <= 0 || ts <= Number(scanCursors[ch] || 0)) return
+  scanCursors[ch] = ts
+  try { mkdirSync(dirname(SCAN_WATERMARK_PATH), { recursive: true }); writeFileSync(SCAN_WATERMARK_PATH, JSON.stringify(scanCursors)) }
+  catch (e) { err(`scan watermark: write failed: ${e.message}`) }
+}
+
+// Default page fetch: shell out to `buzz messages get`. Injectable (fetchPage) so the paging /
+// no-miss logic is drivable by a test with synthetic pages — the scan test drives scanReturnLane
+// directly; this lets #5 drive the window and pagination the same way, no socket.
+function scanFetchPage(ch, floor, before, cb) {
+  const args = ['messages', 'get', '--channel', ch, '--limit', String(SCAN_PAGE_LIMIT), '--since', String(floor)]
+  if (before) args.push('--before', String(before))
+  execFile('buzz', args, (e, so) => {
+    if (e) return cb(e)
+    let msgs
+    try { msgs = JSON.parse(String(so).slice(String(so).indexOf('['))) } catch { return cb(new Error('unparseable read')) }
+    cb(null, msgs)
+  })
+}
+
+// Drain one scan channel: page back from newest to the cursor floor, then route the whole set once
+// and advance the cursor to the newest created_at seen. Pages are unioned by id (not appended) so a
+// --before boundary that re-includes a same-timestamp message never double-counts, and a page that
+// adds zero new ids terminates the walk (guards against a same-created_at cluster larger than the
+// page). Nothing routes and the cursor does not move if a page read fails.
+function scanChannel(ch, fetchPage = scanFetchPage) {
+  const floor = scanSince(ch)
+  const acc = []
+  const seenIds = new Set()
+  const page = (before) => {
+    fetchPage(ch, floor, before, (e, msgs) => {
+      if (e) return err(`scan: read failed for ${String(ch).slice(0, 8)}…: ${e.message}`) // no cursor advance — next poll retries
+      let added = 0
+      for (const m of (msgs || [])) { if (m && m.id && !seenIds.has(m.id)) { seenIds.add(m.id); acc.push(m); added++ } }
+      const oldest = (msgs || []).reduce((mn, x) => Math.min(mn, Number(x && x.created_at) || Infinity), Infinity)
+      // A full page still above the floor may be truncating the backlog — walk back. Stop once a
+      // page yields nothing new, so a same-timestamp cluster can never spin forever.
+      if (added > 0 && (msgs || []).length >= SCAN_PAGE_LIMIT && Number.isFinite(oldest) && oldest > floor) return page(oldest)
+      scanReturnLane(acc, { authors: PUB.scanAuthors })
+      bumpScanCursor(ch, acc.reduce((mx, x) => Math.max(mx, Number(x && x.created_at) || 0), 0))
+    })
+  }
+  page(null)
+}
+
 // The WORKING-channel scan, deliberately separate from pollCommands. It carries out return-lane
 // mentions/replies from the configured scan channel(s) under the scan_authors signer gate — and it
 // NEVER calls handleCommand: a #connector post is not a signed console command, and only staging
@@ -1095,14 +1163,7 @@ function pollCommands() {
 // regardless of which poll saw it first, and durable across a restart.
 function pollScanChannels() {
   if (!PUB.scanChannels.length) return
-  for (const ch of PUB.scanChannels) {
-    execFile('buzz', ['messages', 'get', '--channel', ch, '--limit', '30'], (e, so) => {
-      if (e) return err(`scan: read failed for ${String(ch).slice(0, 8)}…: ${e.message}`)
-      let msgs
-      try { msgs = JSON.parse(String(so).slice(String(so).indexOf('['))) } catch { return err(`scan: unparseable read for ${String(ch).slice(0, 8)}…`) }
-      scanReturnLane(msgs, { authors: PUB.scanAuthors })
-    })
-  }
+  for (const ch of PUB.scanChannels) scanChannel(ch)
 }
 
 // --- relay connections ------------------------------------------------------
@@ -1256,7 +1317,7 @@ function connectPublic(url) {
 // Exported so a harness can drive the REAL routing functions (not a copy) with synthetic
 // events in dryrun, without opening any relay socket. Set WB_NO_BOOT=1 to import without
 // booting the live subscriber. No effect on normal `node src/bridge.mjs` runs.
-export { returnLaneSend, scanReturnLane, pollScanChannels, agentAuthoredBy, rlSeen, rlKey, loadRlSeen, markRlSeen, route, routePublic, routeDelete, processGrantEvent, grantSet, forwardPublic, clampCreated, rateOk, bumpPubWatermark, loadPubWatermark, markSeen, seen, PUB, postedMap, recordPosted, parseBuzzEventId, resolveChannels }
+export { returnLaneSend, scanReturnLane, pollScanChannels, scanChannel, scanSince, bumpScanCursor, loadScanCursors, agentAuthoredBy, rlSeen, rlKey, loadRlSeen, markRlSeen, route, routePublic, routeDelete, processGrantEvent, grantSet, forwardPublic, clampCreated, rateOk, bumpPubWatermark, loadPubWatermark, markSeen, seen, PUB, postedMap, recordPosted, parseBuzzEventId, resolveChannels }
 
 // --- boot -------------------------------------------------------------------
 if (!process.env.WB_NO_BOOT) {

--- a/tests/return_lane_nomiss.mjs
+++ b/tests/return_lane_nomiss.mjs
@@ -1,0 +1,137 @@
+// Return-lane NO-MISS ACROSS DOWNTIME (#5) — the arming gate.
+//
+// return_lane_scan.mjs proves the gate/fan-out/echo shape on a set of messages HANDED to
+// scanReturnLane. It never exercises how that set is GATHERED. The hazard #5 names lives entirely
+// in the gathering: pollScanChannels used to read the 30 newest scan-channel messages with no
+// since-watermark, so an outage long enough to bury a mention past the newest page dropped it
+// silently — and durable rlSeen can never recover a message that was never scanned (it closes the
+// re-SEND half, not the MISS half). This proves the fix, driving the real scanChannel() through its
+// injected page-fetch seam so the window + pagination are exercised without a relay socket:
+//
+//   • NEGATIVE CONTROL — a single newest-page read (the old blind `--limit`) MISSES a mention
+//     buried past the page. The hazard is real, reproduced through the same seam.
+//   • NO-MISS — scanChannel paginates with --before back to the cursor floor and carries the
+//     buried mention anyway.
+//   • ATOMic DRAIN — a page read that fails mid-walk carries NOTHING and leaves the cursor
+//     unmoved, so the next poll re-reads (a failed read is never a silent skip past the backlog).
+//   • CURSOR — first boot floors to the bounded lookback (no cursor yet); a clean drain advances
+//     the persisted cursor to the newest created_at seen.
+//   • OVERLAP is a no-op — the cursor-minus-overlap re-read re-scans an already-carried mention,
+//     and durable rlSeen suppresses the re-carry (overlap buys no-miss, never a double-send).
+//
+//   node tests/return_lane_nomiss.mjs
+
+import { mkdtempSync, writeFileSync, readFileSync, existsSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { resolve } from 'node:path'
+import { getPublicKey, generateSecretKey } from 'nostr-tools/pure'
+
+const dir = mkdtempSync(resolve(tmpdir(), 'wb-nomiss-'))
+const bridgeSk = generateSecretKey()
+const claude = getPublicKey(generateSecretKey())
+const crew = getPublicKey(generateSecretKey())
+
+writeFileSync(resolve(dir, 'config.json'), JSON.stringify({
+  relays: [], recipients: [],
+  public: {
+    relays: ['wss://example.invalid'], inbox: 'chan', staging_inbox: 'chan',
+    watch_authors: [], watch_events: [], approvers: [], grantors: [],
+    scan_authors: [crew],
+    scan_channels: ['scanchan'],
+    return_lane: [{ npub_hex: claude, mention: 'claude', authors: [] }],
+  },
+}, null, 2))
+
+process.env.CONFIG_PATH = resolve(dir, 'config.json')
+process.env.SEND_JOURNAL_PATH = resolve(dir, 'send-journal.log')
+process.env.SEEN_PATH = resolve(dir, 'seen.log')
+process.env.POSTED_MAP_PATH = resolve(dir, 'posted.log')
+process.env.RLSEEN_PATH = resolve(dir, 'return-lane-seen.log')
+process.env.SCAN_WATERMARK_PATH = resolve(dir, 'scan-watermark.json')
+process.env.SCAN_PAGE_LIMIT = '3'          // tiny page so a 7-message backlog forces pagination
+process.env.SCAN_WATERMARK_OVERLAP = '5'   // overlap in seconds; re-reads must be no-ops
+process.env.SCAN_BOOTSTRAP_SECS = '172800' // 48h first-boot floor, matches the DM lane
+process.env.BUZZ_PRIVATE_KEY = Buffer.from(bridgeSk).toString('hex')
+process.env.FORWARD_MODE = 'buzz'
+process.env.WB_STUB_SEND = '1'
+process.env.WB_NO_BOOT = '1'
+
+const { scanChannel, scanSince, loadScanCursors } = await import('../src/bridge.mjs')
+
+let fails = 0
+const ok = (n, c) => { console.log(`${c ? 'ok  ' : 'FAIL'} — ${n}`); if (!c) fails++ }
+const journal = () => existsSync(process.env.SEND_JOURNAL_PATH)
+  ? readFileSync(process.env.SEND_JOURNAL_PATH, 'utf8').split('\n').filter(Boolean).map(JSON.parse) : []
+const short = k => k.slice(0, 12)
+
+// --- synthetic backlog: 7 crew messages inside the 48h window, newest-first ids m1..m7 -----------
+// The OLDEST (buried) and one RECENT message both mention @claude; the rest are non-mention noise.
+const now = Math.floor(Date.now() / 1000)
+const store = []
+for (let i = 7; i >= 1; i--) {                 // created_at now-7 (oldest) .. now-1 (newest)
+  let content = `just chatter ${i}`
+  if (i === 7) content = 'heads up @claude — buried under the backlog'
+  if (i === 2) content = '@claude one more recent thing'
+  store.push({ id: `m${i}`, pubkey: crew, content, created_at: now - i, tags: [] })
+}
+const BURIED = `m7`, RECENT = `m2`
+
+// A relay-shaped page fetch honouring `--since floor`, `--before`, `--limit 3`, newest-first.
+// `failOn` makes the Nth call error, to model a mid-drain read failure.
+function makeFetch(failOn = 0) {
+  let calls = 0
+  return (ch, floor, before, cb) => {
+    calls++
+    if (failOn && calls === failOn) return cb(new Error('synthetic read failure'))
+    let rows = store.filter(m => m.created_at >= floor)
+    if (before) rows = rows.filter(m => m.created_at < before)
+    rows = rows.sort((a, b) => b.created_at - a.created_at).slice(0, 3)
+    cb(null, rows)
+  }
+}
+
+// --- first boot: bounded lookback, no cursor yet -------------------------------------------------
+ok('first boot has NO persisted cursor', loadScanCursors().scanchan === undefined)
+ok('first-boot floor is the 48h lookback, not "newest only"',
+  Math.abs(scanSince('scanchan') - (now - 172800)) <= 2)
+
+// --- NEGATIVE CONTROL: the old blind newest-page read MISSES the buried mention -------------------
+let firstPage
+makeFetch()('scanchan', now - 172800, null, (_e, rows) => { firstPage = rows })
+ok('the newest page does not even contain the buried mention (hazard reproduced)',
+  !firstPage.some(m => m.id === BURIED))
+
+// --- ATOMIC DRAIN: a read that fails mid-walk carries nothing and never advances the cursor -------
+// Page 1 succeeds (3 msgs, none a mention), page 2 errors → acc is dropped, cursor untouched.
+let before = journal().length
+scanChannel('failchan', makeFetch(2))
+ok('a mid-drain read failure carries NOTHING', journal().length === before)
+ok('a failed drain never advances the cursor (next poll re-reads)', loadScanCursors().failchan === undefined)
+
+// --- NO-MISS: a clean paginated drain carries the buried mention despite the page limit -----------
+before = journal().length
+scanChannel('scanchan', makeFetch())
+let carried = journal().slice(before)
+const toBuried = carried.filter(e => e.to === short(claude))
+ok('the buried mention is delivered (no-miss across the backlog)',
+  toBuried.length === 2)                        // buried m7 + recent m2, both @claude, one carry each
+ok('the buried and recent mentions BOTH carried, nothing else did', carried.length === 2)
+
+// --- CURSOR: a clean drain advances the persisted cursor to the newest created_at seen ------------
+ok('the cursor advanced to the newest message', loadScanCursors().scanchan === now - 1)
+ok('the next poll now reads from cursor-minus-overlap, not the 48h floor',
+  scanSince('scanchan') === (now - 1) - 5)
+
+// --- OVERLAP is a no-op: the re-read re-scans an already-carried mention, rlSeen suppresses it -----
+// scanSince is now (now-1)-5 = now-6, so the re-read window includes the RECENT mention (now-2).
+before = journal().length
+scanChannel('scanchan', makeFetch())
+ok('the overlap re-read carries nothing new (durable rlSeen suppresses the re-send)',
+  journal().length === before)
+ok('the recent mention was inside the overlap window (the re-read really did re-scan it)',
+  scanSince('scanchan') <= (now - 2))
+
+console.log(fails
+  ? `\nRETURN LANE NO-MISS FAIL — ${fails}`
+  : '\nRETURN LANE NO-MISS PASS — hazard reproduced, paginated no-miss, atomic drain, cursor + overlap')
+process.exit(fails ? 1 : 0)


### PR DESCRIPTION
Follow-up to #114 (connector scan), now rebased onto post-#114 main after that squash-merged.

**What:** the return lane cannot miss a mention that arrives outside the re-read overlap window.
- Persisted scan **cursor** + `--before` pagination, so a scan resumes exactly where the last one stopped instead of only re-reading a fixed recent window.
- Atomic drain: the cursor advances only after carries are recorded, so a crash mid-scan re-scans rather than skips.
- **#5 no-miss negative control** (`tests/return_lane_nomiss.mjs`): reproduces the drop hazard, then proves the paginated cursor closes it. This is an arming-gate test — it fails if the no-miss guarantee regresses.

**Verification:** full suite green (11 suites) on the rebased tip `316cf95`.

Base of the stack; the #116 silence-alarm seam (`mydude/return-lane-alarm`) sits on top of this and opens once this merges — kept separate to avoid re-orphaning under squash.