### PR TITLE
return-lane: #116 silence-alarm seam — per-relay OK count, persist-on-landed, loud 0/N

### DIFF
--- a/src/bridge.mjs
+++ b/src/bridge.mjs
@@ -950,6 +950,14 @@ function loadRlSeen() {
   for (const k of kept) rlSeen.add(k)
   log(`return lane: loaded ${rlSeen.size} carried (source×recipient) keys from ${RLSEEN_PATH}${lines.length > kept.length ? ` (pruned ${lines.length - kept.length})` : ''}`)
 }
+// Persist-on-landed split (finding #2). addRlSeen suppresses a double-carry WITHIN a scan/overlap
+// immediately, in memory; the DURABLE append happens only once the seal actually reached a relay —
+// markRlSeen, called on ≥1 accept. A silent 0/N is rolled back with dropRlSeen so #5's overlap
+// re-read re-carries it, and — because it never reached disk — a restart (loadRlSeen) re-carries it
+// too. The earlier commit-before-send would instead durably suppress a mention that was never
+// delivered: #1's own durability then made the loss permanent and invisible.
+function addRlSeen(key) { rlSeen.add(key) }
+function dropRlSeen(key) { rlSeen.delete(key) }
 function markRlSeen(key) {
   rlSeen.add(key)
   try { mkdirSync(dirname(RLSEEN_PATH), { recursive: true }); appendFileSync(RLSEEN_PATH, key + '\n') }
@@ -971,15 +979,35 @@ function rlDropOnce(id) {
   return true
 }
 
-// Returns true iff the seal was built, journaled and dispatched without throwing — the caller
-// commits dedup only then (finding #3). A false return (no key, or a seal/journal throw) leaves
-// the message un-marked so the next poll retries it, rather than committing rlSeen and losing the
-// mention forever. Relay-level delivery confirmation (a wrap dispatched to only dead sockets still
-// returns true) is deliberately out of scope here — that is the send-side no-miss follow-up (#117:
-// bounded retry queue, capped attempts/TTL, give-up alarm). This fix closes the swallowed-throw
-// path; #117 closes the dead-relay path. At-least-once on a notification lane beats at-most-once.
-function returnLaneSend(toHex, text, meta) {
-  if (!BRIDGE_SK) { err('return lane: no bridge key to seal with — skipping'); return false }
+// Publish a wrap to the public relays, resolving to the count that returned OK-true. Per-relay OK is
+// the ONLY landing signal: a relay 503s or drops silently, and an explicit ["OK", id, false]
+// rejection used to read byte-identical to an accept (the loop counted any inbound frame). Finding
+// #2. Injectable (the `publish` seam on returnLaneSend) so the send-failure control can drive a
+// chosen accept-count with no socket — the same shape #5's scanChannel(fetchPage) uses. WB_STUB_SEND
+// keeps the socket-free tests honest: it means "assume it landed on every configured relay", so the
+// crypto still runs but the count is positive, never a spurious 0/N.
+function publishWrapToRelays(wrap) {
+  return new Promise((resolve) => {
+    if (process.env.WB_STUB_SEND) return resolve(PUB.relays.length || 1)
+    const relays = PUB.relays || []
+    if (!relays.length) return resolve(0)
+    let settled = 0, accepted = 0, done = false
+    const finish = () => { if (!done) { done = true; resolve(accepted) } }
+    const t = setTimeout(finish, 10000)                    // a relay that opens but never OKs is bounded here
+    const tally = () => { if (++settled >= relays.length) { clearTimeout(t); finish() } }
+    for (const url of relays) {
+      let w, counted = false
+      const one = (ok) => { if (counted) return; counted = true; if (ok) accepted++; try { w && w.close() } catch { /* */ } tally() }
+      try { w = new WebSocket(url) } catch { tally(); continue }
+      w.on('open', () => w.send(JSON.stringify(['EVENT', wrap])))
+      w.on('message', d => { try { const m = JSON.parse(d.toString()); if (m[0] === 'OK' && m[1] === wrap.id) one(!!m[2]) } catch { /* non-OK frame */ } })
+      w.on('error', () => one(false))
+    }
+  })
+}
+
+async function returnLaneSend(toHex, text, meta, publish = publishWrapToRelays) {
+  if (!BRIDGE_SK) { err('return lane: no bridge key to seal with — skipping'); return 0 }
   const now = Math.floor(Date.now() / 1000)
   // NIP-59 backdating: randomise wrap and seal timestamps into the past so an observer cannot
   // correlate a channel message with a delivery by timing alone.
@@ -992,25 +1020,19 @@ function returnLaneSend(toHex, text, meta) {
     const wsk = generateSecretKey()
     const wrap = finalizeEvent({ kind: 1059, created_at: fuzzed(), tags: [['p', toHex]],
       content: nip44.encrypt(JSON.stringify(seal), nip44.getConversationKey(wsk, toHex)) }, wsk)
-    // Test seam: exercise sealing and journaling without opening a socket, the same shape the
-    // public lane uses. The crypto still runs — a stub that skipped it would prove nothing.
-    if (!process.env.WB_STUB_SEND) {
-      for (const url of PUB.relays) {
-        try {
-          const w = new WebSocket(url)
-          const t = setTimeout(() => { try { w.close() } catch { /* */ } }, 10000)
-          w.on('open', () => w.send(JSON.stringify(['EVENT', wrap])))
-          w.on('message', () => { clearTimeout(t); try { w.close() } catch { /* */ } })
-          w.on('error', () => clearTimeout(t))
-        } catch { /* dead relay */ }
-      }
-    }
-    // Journaled even though the wrap's author is ephemeral and so can never trip the tripwire:
-    // "it happens not to alarm" is a weaker property than "it is written down".
-    journalSend(wrap.id, { kind: 1059, lane: 'return', to: toHex.slice(0, 12), ...meta })
-    log(`RETURN -> ${toHex.slice(0, 12)}…: sealed ${String(text).length}B (wrap ${wrap.id.slice(0, 12)}…)`)
-    return true
-  } catch (e) { err(`return lane: seal/send failed: ${e.message}`); return false }
+    const relays = (PUB.relays || []).length
+    const accepted = await publish(wrap)
+    // Journal stamped with the accept-count so the durable record is landed-reality, not intent: a
+    // 0/N carry is written accepted:0, never a false "sent". The wrap's author is ephemeral and can
+    // never trip the tripwire, so this record is a written-down intent — worth making a truthful one;
+    // a landed carry (accepted ≥ 1) IS on a relay and so must be journaled for the tripwire.
+    journalSend(wrap.id, { kind: 1059, lane: 'return', to: toHex.slice(0, 12), accepted, relays, ...meta })
+    if (accepted < 1)
+      err(`RETURN 0/${relays} -> ${toHex.slice(0, 12)}…: seal reached NO relay — NOT marked sent, will re-carry (wrap ${wrap.id.slice(0, 12)}…)`)
+    else
+      log(`RETURN ${accepted}/${relays} -> ${toHex.slice(0, 12)}…: sealed ${String(text).length}B (wrap ${wrap.id.slice(0, 12)}…)`)
+    return accepted
+  } catch (e) { err(`return lane: seal/send failed: ${e.message}`); return 0 }
 }
 
 // Which return-lane recipient (delivery npub) a given bridge-posted Buzz event was authored FOR,
@@ -1047,7 +1069,7 @@ function agentAuthoredBy(buzzId) {
 // recipient's own key. Nothing here starts a session, evaluates, or acts on the body — this lane
 // only ever moves bytes to an address. The one place a body could reach a prompt is the action
 // layer, where the wake is content-free and the body is read-plane data (design §5).
-function scanReturnLane(msgs, opts = {}) {
+async function scanReturnLane(msgs, opts = {}) {
   if (!PUB.returnLane.length || !BRIDGE_SK) return
   const gateActive = opts.authors !== undefined            // an explicit (even empty) gate is default-closed
   const gate = gateActive ? new Set(opts.authors || []) : null
@@ -1079,17 +1101,17 @@ function scanReturnLane(msgs, opts = {}) {
         new RegExp('@' + r.mention.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '(?![\\w-])', 'i').test(body)
       const repliedTo = parents.some(pid => agentAuthoredBy(pid) === r.npub_hex)
       if (!mentioned && !repliedTo) continue
-      // Commit-AFTER-send (finding #3): mark seen only once the seal succeeded. A seal/journal
-      // throw leaves the key un-marked so the next poll retries, instead of committing dedup and
-      // dropping the mention forever. A crash between send and mark re-delivers (at-least-once) —
-      // the correct failure for a notification lane whose design says silence must not look calm.
-      const sent = returnLaneSend(r.npub_hex,
+      addRlSeen(key)                                       // in-memory now: no double-carry within this scan/overlap
+      const accepted = await returnLaneSend(r.npub_hex,
         `📥 **${r.mention}** — you were ${repliedTo && !mentioned ? 'replied to' : 'mentioned'} in the community.\n\n> ` +
         body.replace(/\r/g, '').split('\n').join('\n> ') +
         `\n\n_carried out by waggle's return lane. Replying to this message reaches nobody; ` +
         `post from your own key and the bridge brings it back in._`,
-        { src: m.id, why: repliedTo && !mentioned ? 'reply' : 'mention' })
-      if (sent) markRlSeen(key)
+        { src: m.id, why: repliedTo && !mentioned ? 'reply' : 'mention' }, opts.publish)
+      // Persist-on-landed: durable dedup only once the seal reached a relay. A silent 0/N is rolled
+      // back so the overlap re-read (and a restart) re-carry it — a rare re-carry beats a lost mention.
+      if (accepted >= 1) markRlSeen(key)
+      else dropRlSeen(key)
     }
   }
 }
@@ -1101,7 +1123,7 @@ function pollCommands() {
     let msgs
     try { msgs = JSON.parse(String(so).slice(String(so).indexOf('['))) } catch { return err('commands: unparseable staging read') }
     for (const m of msgs) { if ((m.created_at || 0) >= cmdCursor - 300) handleCommand(m).catch(er => err(`commands: ${er.message}`)) }
-    scanReturnLane(msgs)
+    scanReturnLane(msgs).catch(er => err(`return lane: staging carry failed: ${er.message}`))
     cmdCursor = Math.floor(Date.now() / 1000)
   })
 }
@@ -1158,20 +1180,27 @@ function scanChannel(ch, fetchPage = scanFetchPage) {
   const floor = scanSince(ch)
   const acc = []
   const seenIds = new Set()
-  const page = (before) => {
-    fetchPage(ch, floor, before, (e, msgs) => {
-      if (e) return err(`scan: read failed for ${String(ch).slice(0, 8)}…: ${e.message}`) // no cursor advance — next poll retries
-      let added = 0
-      for (const m of (msgs || [])) { if (m && m.id && !seenIds.has(m.id)) { seenIds.add(m.id); acc.push(m); added++ } }
-      const oldest = (msgs || []).reduce((mn, x) => Math.min(mn, Number(x && x.created_at) || Infinity), Infinity)
-      // A full page still above the floor may be truncating the backlog — walk back. Stop once a
-      // page yields nothing new, so a same-timestamp cluster can never spin forever.
-      if (added > 0 && (msgs || []).length >= SCAN_PAGE_LIMIT && Number.isFinite(oldest) && oldest > floor) return page(oldest)
-      scanReturnLane(acc, { authors: PUB.scanAuthors })
-      bumpScanCursor(ch, acc.reduce((mx, x) => Math.max(mx, Number(x && x.created_at) || 0), 0))
-    })
-  }
-  page(null)
+  // Returns a Promise that settles once the whole drain — including the async carry-out — completes,
+  // so a caller (and a test) can await the sends actually landing. Resolves (never rejects) on a read
+  // failure too, leaving the cursor unmoved.
+  return new Promise((resolve) => {
+    const page = (before) => {
+      fetchPage(ch, floor, before, async (e, msgs) => {
+        if (e) { err(`scan: read failed for ${String(ch).slice(0, 8)}…: ${e.message}`); return resolve() } // no cursor advance — next poll retries
+        let added = 0
+        for (const m of (msgs || [])) { if (m && m.id && !seenIds.has(m.id)) { seenIds.add(m.id); acc.push(m); added++ } }
+        const oldest = (msgs || []).reduce((mn, x) => Math.min(mn, Number(x && x.created_at) || Infinity), Infinity)
+        // A full page still above the floor may be truncating the backlog — walk back. Stop once a
+        // page yields nothing new, so a same-timestamp cluster can never spin forever.
+        if (added > 0 && (msgs || []).length >= SCAN_PAGE_LIMIT && Number.isFinite(oldest) && oldest > floor) return page(oldest)
+        try { await scanReturnLane(acc, { authors: PUB.scanAuthors }) }
+        catch (er) { err(`scan: return-lane carry failed for ${String(ch).slice(0, 8)}…: ${er.message}`) }
+        bumpScanCursor(ch, acc.reduce((mx, x) => Math.max(mx, Number(x && x.created_at) || 0), 0))
+        resolve()
+      })
+    }
+    page(null)
+  })
 }
 
 // The WORKING-channel scan, deliberately separate from pollCommands. It carries out return-lane
@@ -1181,9 +1210,11 @@ function scanChannel(ch, fetchPage = scanFetchPage) {
 // being interpreted as approval verbs. Dedup is rlSeen (shared with the staging path), keyed per
 // (source × recipient), so a message carried to a recipient once is never carried to them again —
 // regardless of which poll saw it first, and durable across a restart.
-function pollScanChannels() {
+async function pollScanChannels() {
   if (!PUB.scanChannels.length) return
-  for (const ch of PUB.scanChannels) scanChannel(ch)
+  for (const ch of PUB.scanChannels) {
+    try { await scanChannel(ch) } catch (e) { err(`scan: poll failed for ${String(ch).slice(0, 8)}…: ${e.message}`) }
+  }
 }
 
 // --- relay connections ------------------------------------------------------
@@ -1337,7 +1368,7 @@ function connectPublic(url) {
 // Exported so a harness can drive the REAL routing functions (not a copy) with synthetic
 // events in dryrun, without opening any relay socket. Set WB_NO_BOOT=1 to import without
 // booting the live subscriber. No effect on normal `node src/bridge.mjs` runs.
-export { returnLaneSend, scanReturnLane, pollScanChannels, scanChannel, scanSince, bumpScanCursor, loadScanCursors, agentAuthoredBy, rlSeen, rlKey, loadRlSeen, markRlSeen, route, routePublic, routeDelete, processGrantEvent, grantSet, forwardPublic, clampCreated, rateOk, bumpPubWatermark, loadPubWatermark, markSeen, seen, PUB, postedMap, recordPosted, parseBuzzEventId, resolveChannels }
+export { returnLaneSend, publishWrapToRelays, scanReturnLane, pollScanChannels, scanChannel, scanSince, bumpScanCursor, loadScanCursors, agentAuthoredBy, rlSeen, rlKey, loadRlSeen, markRlSeen, addRlSeen, dropRlSeen, route, routePublic, routeDelete, processGrantEvent, grantSet, forwardPublic, clampCreated, rateOk, bumpPubWatermark, loadPubWatermark, markSeen, seen, PUB, postedMap, recordPosted, parseBuzzEventId, resolveChannels }
 
 // --- boot -------------------------------------------------------------------
 if (!process.env.WB_NO_BOOT) {
@@ -1371,7 +1402,8 @@ if (!process.env.WB_NO_BOOT) {
       // Silence-is-not-calm: a configured scan with an empty gate routes NOTHING, so say so loudly
       // rather than let it look like "no mentions." Set scan_authors (or declare approvers/grantors).
       if (!PUB.scanAuthors.length) err('WARN: scan_channels configured but scan_authors gate is EMPTY — default-closed, NO mentions will route until the crew roster is set.')
-      pollScanChannels(); setInterval(pollScanChannels, 15000)
+      pollScanChannels().catch(e => err(`scan: initial poll failed: ${e.message}`))
+      setInterval(() => pollScanChannels().catch(e => err(`scan: poll failed: ${e.message}`)), 15000)
     }
     })
   } else {

--- a/src/bridge.mjs
+++ b/src/bridge.mjs
@@ -1195,6 +1195,12 @@ function scanChannel(ch, fetchPage = scanFetchPage) {
         if (added > 0 && (msgs || []).length >= SCAN_PAGE_LIMIT && Number.isFinite(oldest) && oldest > floor) return page(oldest)
         try { await scanReturnLane(acc, { authors: PUB.scanAuthors }) }
         catch (er) { err(`scan: return-lane carry failed for ${String(ch).slice(0, 8)}…: ${er.message}`) }
+        // The cursor advances regardless of any 0/N carry above (a dropped rlSeen key re-carries only
+        // while it stays inside the overlap window, and each such attempt is itself a loud 0/N). So the
+        // return-lane guarantee is: NO SILENT LOSS — loud, bounded retries within the overlap window;
+        // a carry is lost only after an outage sustained long enough to age it past the window. That
+        // send-side no-miss (retry independent of the cursor) is the pending-set follow-up, #117 — NOT
+        // a cursor-hold, which would pin the lane on one dead recipient and stall it for everyone.
         bumpScanCursor(ch, acc.reduce((mx, x) => Math.max(mx, Number(x && x.created_at) || 0), 0))
         resolve()
       })

--- a/tests/return_lane.mjs
+++ b/tests/return_lane.mjs
@@ -43,35 +43,35 @@ const journal = () => existsSync(process.env.SEND_JOURNAL_PATH)
 
 ok('config parsed one return-lane participant', PUB.returnLane.length === 1 && PUB.returnLane[0].mention === 'claude')
 
-scanReturnLane([{ id: 'm1', pubkey: stranger, content: 'nothing to do with anyone' }])
+await scanReturnLane([{ id: 'm1', pubkey: stranger, content: 'nothing to do with anyone' }])
 ok('a message mentioning nobody is not carried out', journal().length === 0)
 
-scanReturnLane([{ id: 'm2', pubkey: stranger, content: 'hey @claude can you look at this' }])
+await scanReturnLane([{ id: 'm2', pubkey: stranger, content: 'hey @claude can you look at this' }])
 const afterMention = journal()
 ok('a mention IS carried out', afterMention.length === 1)
 ok('it is journaled as the return lane', afterMention[0]?.lane === 'return')
 ok('it is addressed to the participant', afterMention[0]?.to === participant.slice(0, 12))
 ok('it is a gift-wrap', afterMention[0]?.kind === 1059)
 
-scanReturnLane([{ id: 'm2', pubkey: stranger, content: 'hey @claude can you look at this' }])
+await scanReturnLane([{ id: 'm2', pubkey: stranger, content: 'hey @claude can you look at this' }])
 ok('the same message is not carried twice', journal().length === 1)
 
-scanReturnLane([{ id: 'm3', pubkey: participant, content: 'this is @claude speaking' }])
+await scanReturnLane([{ id: 'm3', pubkey: participant, content: 'this is @claude speaking' }])
 ok("a participant's own words are not echoed back to them", journal().length === 1)
 
-scanReturnLane([{ id: 'm4', pubkey: stranger, content: 'ask @CLAUDE about it' }])
+await scanReturnLane([{ id: 'm4', pubkey: stranger, content: 'ask @CLAUDE about it' }])
 ok('the mention match is case-insensitive', journal().length === 2)
 
 // The hazard a substring match would create: a different person whose name merely starts with
 // this one. Carrying a private message to the wrong recipient is the worst thing this lane can
 // do, and it would do it silently.
-scanReturnLane([{ id: 'm5', pubkey: stranger, content: 'ask @claudex instead' }])
+await scanReturnLane([{ id: 'm5', pubkey: stranger, content: 'ask @claudex instead' }])
 ok('a longer name starting with the mention does NOT match', journal().length === 2)
 
-scanReturnLane([{ id: 'm6', pubkey: stranger, content: 'thanks @claude!' }])
+await scanReturnLane([{ id: 'm6', pubkey: stranger, content: 'thanks @claude!' }])
 ok('a mention followed by punctuation still matches', journal().length === 3)
 
-scanReturnLane([{ id: 'm7', pubkey: stranger, content: '@claude' }])
+await scanReturnLane([{ id: 'm7', pubkey: stranger, content: '@claude' }])
 ok('a mention alone on the line matches', journal().length === 4)
 
 console.log(fails ? `\nRETURN LANE FAIL — ${fails}` : '\nRETURN LANE PASS — carries mentions out, and nothing else')

--- a/tests/return_lane_nomiss.mjs
+++ b/tests/return_lane_nomiss.mjs
@@ -104,13 +104,13 @@ ok('the newest page does not even contain the buried mention (hazard reproduced)
 // --- ATOMIC DRAIN: a read that fails mid-walk carries nothing and never advances the cursor -------
 // Page 1 succeeds (3 msgs, none a mention), page 2 errors → acc is dropped, cursor untouched.
 let before = journal().length
-scanChannel('failchan', makeFetch(2))
+await scanChannel('failchan', makeFetch(2))
 ok('a mid-drain read failure carries NOTHING', journal().length === before)
 ok('a failed drain never advances the cursor (next poll re-reads)', loadScanCursors().failchan === undefined)
 
 // --- NO-MISS: a clean paginated drain carries the buried mention despite the page limit -----------
 before = journal().length
-scanChannel('scanchan', makeFetch())
+await scanChannel('scanchan', makeFetch())
 let carried = journal().slice(before)
 const toBuried = carried.filter(e => e.to === short(claude))
 ok('the buried mention is delivered (no-miss across the backlog)',
@@ -125,7 +125,7 @@ ok('the next poll now reads from cursor-minus-overlap, not the 48h floor',
 // --- OVERLAP is a no-op: the re-read re-scans an already-carried mention, rlSeen suppresses it -----
 // scanSince is now (now-1)-5 = now-6, so the re-read window includes the RECENT mention (now-2).
 before = journal().length
-scanChannel('scanchan', makeFetch())
+await scanChannel('scanchan', makeFetch())
 ok('the overlap re-read carries nothing new (durable rlSeen suppresses the re-send)',
   journal().length === before)
 ok('the recent mention was inside the overlap window (the re-read really did re-scan it)',

--- a/tests/return_lane_scan.mjs
+++ b/tests/return_lane_scan.mjs
@@ -66,10 +66,10 @@ const journal = () => existsSync(process.env.SEND_JOURNAL_PATH)
   ? readFileSync(process.env.SEND_JOURNAL_PATH, 'utf8').split('\n').filter(Boolean).map(JSON.parse) : []
 // Run a scan and return only the journal entries it produced.
 let cursor = 0
-function scanDelta(msgs, opts) {
+async function scanDelta(msgs, opts) {
   const before = journal().length
-  if (opts === undefined) scanReturnLane(msgs)
-  else scanReturnLane(msgs, opts)
+  if (opts === undefined) await scanReturnLane(msgs)
+  else await scanReturnLane(msgs, opts)
   const j = journal()
   cursor = j.length
   return j.slice(before)
@@ -86,52 +86,52 @@ ok('sharedSigner is flagged ambiguous', PUB.sharedAuthorKeys.has(sharedSigner))
 ok('claudeSigner is NOT ambiguous (unique)', !PUB.sharedAuthorKeys.has(claudeSigner))
 
 // --- signer gate ------------------------------------------------------------
-let d = scanDelta([{ id: 'g1', pubkey: outsider, content: 'hey @claude look' }], { authors: PUB.scanAuthors })
+let d = await scanDelta([{ id: 'g1', pubkey: outsider, content: 'hey @claude look' }], { authors: PUB.scanAuthors })
 ok('an outsider signer is gated out (no carry)', d.length === 0)
 
-d = scanDelta([{ id: 'g2', pubkey: crew, content: 'hey @claude look' }], { authors: PUB.scanAuthors })
+d = await scanDelta([{ id: 'g2', pubkey: crew, content: 'hey @claude look' }], { authors: PUB.scanAuthors })
 ok('a crew signer passes the gate', d.length === 1 && toOf(d[0]) === short(claude))
 ok('a gated carry is labelled a mention', d[0]?.why === 'mention')
 
-d = scanDelta([{ id: 'g3', pubkey: crew, content: 'hey @claude look' }], { authors: [] })
+d = await scanDelta([{ id: 'g3', pubkey: crew, content: 'hey @claude look' }], { authors: [] })
 ok('an explicitly-empty gate is default-closed', d.length === 0)
 
 // --- p-tag detection (no @name in body) -------------------------------------
-d = scanDelta([{ id: 'p1', pubkey: crew, content: 'hello everyone', tags: [['p', claude]] }])
+d = await scanDelta([{ id: 'p1', pubkey: crew, content: 'hello everyone', tags: [['p', claude]] }])
 ok('a resolved p-tag delivers even with no @name text', d.length === 1 && toOf(d[0]) === short(claude))
 
 // --- finding #4: one message fans out to EVERY match, each exactly once ------
-d = scanDelta([{ id: 'f1', pubkey: crew, content: 'ping @claude and @dennis together' }])
+d = await scanDelta([{ id: 'f1', pubkey: crew, content: 'ping @claude and @dennis together' }])
 const fanTargets = d.map(toOf).sort()
 ok('"@claude @dennis" reaches BOTH recipients', d.length === 2 &&
   fanTargets[0] === [short(claude), short(dennis)].sort()[0] &&
   fanTargets[1] === [short(claude), short(dennis)].sort()[1])
-d = scanDelta([{ id: 'f1', pubkey: crew, content: 'ping @claude and @dennis together' }])
+d = await scanDelta([{ id: 'f1', pubkey: crew, content: 'ping @claude and @dennis together' }])
 ok('re-scanning the same message carries nothing new (per-recipient dedup)', d.length === 0)
 
 // --- echo: unique bound author is the agent's own voice ---------------------
-d = scanDelta([{ id: 'e1', pubkey: claudeSigner, content: 'this is @claude speaking' }])
+d = await scanDelta([{ id: 'e1', pubkey: claudeSigner, content: 'this is @claude speaking' }])
 ok('a unique bound author is echo-skipped', d.length === 0)
 
 // --- echo GUARD: a shared author must NOT be skipped (else cross-mentions drop)
-d = scanDelta([{ id: 'e2', pubkey: sharedSigner, content: 'over to @dennis please' }])
+d = await scanDelta([{ id: 'e2', pubkey: sharedSigner, content: 'over to @dennis please' }])
 ok('a SHARED author is NOT skipped — the mention still delivers', d.length === 1 && toOf(d[0]) === short(dennis))
 
 // --- echo: per-event registry (the bridge posted this event FOR claude) -----
 recordPosted({ id: 'orig-r1', author: claude, buzz: 'reg1', dest: 'chan', q: false, ts: 0, agent: claude })
-d = scanDelta([{ id: 'reg1', pubkey: crew, content: 'echo of @claude own words' }])
+d = await scanDelta([{ id: 'reg1', pubkey: crew, content: 'echo of @claude own words' }])
 ok('a registry-attributed event is echo-skipped', d.length === 0)
 
 // --- reply-to-agent via the registry, no body mention needed ----------------
 recordPosted({ id: 'orig-p', author: claude, buzz: 'parenta', dest: 'chan', q: false, ts: 0, agent: claude })
-d = scanDelta([{ id: 'rep1', pubkey: crew, content: 'good point, agreed', tags: [['e', 'parenta', '', 'reply']] }])
+d = await scanDelta([{ id: 'rep1', pubkey: crew, content: 'good point, agreed', tags: [['e', 'parenta', '', 'reply']] }])
 ok('a reply to an agent-authored post is carried', d.length === 1 && toOf(d[0]) === short(claude))
 ok('it is labelled a reply, not a mention', d[0]?.why === 'reply')
-d = scanDelta([{ id: 'rep1', pubkey: crew, content: 'good point, agreed', tags: [['e', 'parenta', '', 'reply']] }])
+d = await scanDelta([{ id: 'rep1', pubkey: crew, content: 'good point, agreed', tags: [['e', 'parenta', '', 'reply']] }])
 ok('the same reply is not carried twice', d.length === 0)
 
 // --- reply to the thread ROOT (not the reply-marked parent) must NOT route ---
-d = scanDelta([{ id: 'rep2', pubkey: crew, content: 'unrelated thread post', tags: [['e', 'parenta', '', 'root']] }])
+d = await scanDelta([{ id: 'rep2', pubkey: crew, content: 'unrelated thread post', tags: [['e', 'parenta', '', 'root']] }])
 ok('a root-tag to an agent post does NOT route (only reply-marked parents)', d.length === 0)
 
 console.log(fails ? `\nRETURN LANE SCAN FAIL — ${fails}` : '\nRETURN LANE SCAN PASS — gate, p-tag, fan-out, echo (3 forms + shared guard), reply-detection')


### PR DESCRIPTION
#116 silence-alarm seam, rebased onto post-#119 main. Base of my return-lane work is now fully in main (#114 connector scan, #119 #5 no-miss); this is the last bridge.mjs piece before arming.

**Problem:** a return-lane carry that reaches **0 relays** read byte-identical to success — `returnLaneSend` journaled + logged unconditionally and the send loop swallowed every failure. Combined with #1 durable dedup + #5 overlap suppression, a silent 0/N was marked-seen and lost forever, invisibly. That defeats the whole compose (#1+#5) and violates the design invariant that silence must never look calm.

**Fix (persist-on-landed):**
- `publishWrapToRelays` resolves to the count of relays that returned **OK-true** (an explicit `["OK",id,false]` no longer reads as an accept); injectable `publish` seam for socket-free control.
- `returnLaneSend` is async, returns the accept-count, journals `{accepted,relays}` (landed-reality, not intent), and is **loud on 0/N** (`RETURN 0/N … NOT marked sent`).
- dedup split: `addRlSeen` (in-memory, within-scan) / `markRlSeen` (disk, on accept ≥1) / `dropRlSeen` (0/N rollback) → a silent 0/N is not-on-disk + not-in-Set, so the overlap re-read **and** a restart re-carry it.

**Rebase note:** the branch predated #114's post-review finding-fixes; this rebase is a clean **union** — main's `rlDropOnce` (finding #2), lowercase keys (finding #4), bridge-key parse filter (finding #1) and #94 `liveRefs` are layered on top; the #116 accept-count logic is byte-identical to the pre-rebase branch (audited by diff). Full suite green (11 files) on tip `38ef2ac`.

**Merge order:** this seam must land **before** Dennis's paired #2 negative control (`dennis/item2-alarm`), which asserts against this API. Send-side no-miss past the overlap window stays as follow-up **#117**.