### PR TITLE
feat(relay-lane): an admitted agent speaks without speaking publicly (#122)

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -29,6 +29,9 @@
     "approvers": ["<hex pubkey allowed to reply approve|watch|mute|reject on a quarantined post>"],
     "grantors": ["<hex pubkey whose signed NIP-DA 440/441 admit or revoke a granted participant; defaults to approvers>"],
     "scan_channels": ["<channel name or UUID of a WORKING channel to scan for @mentions/replies to a return-lane agent; NEVER the staging_inbox; omit => scan nothing>"],
+    "relay_channels": ["<channel name or UUID an admitted agent may inject into by sealing a kind:14 request (relay tag = this channel) to waggle's OWN key; DEFAULT EMPTY, never implicitly inbox; an unlisted destination is dropped and the sender is acked ok:false; conveys no capability beyond the public lane except destination selection, which this allowlist gates>"],
+    "relay_decrypt_budget": 120,
+    "relay_max_wrap_bytes": 65536,
     "scan_authors": ["<hex pubkey allowed to TRIGGER a return-lane carry (signer gate); omit => floors to approvers+grantors+trusted_repliers; bridge key is always excluded; live routing policy, held durable off-repo>"],
     "return_lane": [
       { "npub_hex": "<64-hex delivery key of an admitted agent — where its sealed mentions are addressed>", "mention": "<@name that reaches it in channel>", "authors": ["<64-hex Buzz-side key that signs THIS agent's own in-channel posts; drives echo-skip only while unique to one entry; omit if it shares the bridge key. Bind a key here ONLY if it signs exactly one agent's posts: the guard keys off config-entry count, not actual signing multiplicity, so pinning the de-facto-shared bridge key to a single entry silently defeats it (a cross-mention would be dropped as echo)>"] }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "start": "node src/bridge.mjs",
     "dryrun": "FORWARD_MODE=dryrun node src/bridge.mjs",
-    "test": "node tests/a1_quarantine.mjs && node tests/a7_deletion.mjs && node tests/lane2_caps.mjs && node tests/nipda_admission.mjs && node tests/render_states.mjs && node tests/deploy_verify.mjs && node tests/return_lane.mjs && node tests/return_lane_scan.mjs && node tests/return_lane_nomiss.mjs && node tests/tripwire_union.mjs && node tests/tripwire_detection.mjs",
+    "test": "node tests/a1_quarantine.mjs && node tests/a7_deletion.mjs && node tests/lane2_caps.mjs && node tests/nipda_admission.mjs && node tests/render_states.mjs && node tests/deploy_verify.mjs && node tests/return_lane.mjs && node tests/return_lane_scan.mjs && node tests/return_lane_nomiss.mjs && node tests/relay_ingress.mjs && node tests/tripwire_union.mjs && node tests/tripwire_detection.mjs",
     "console": "node tools/serve-console.mjs"
   },
   "dependencies": {

--- a/src/bridge.mjs
+++ b/src/bridge.mjs
@@ -5,10 +5,12 @@
 // event into that agent's Buzz inbox so the buzz-acp harness wakes the agent to
 // unwrap it with its own in-runtime key.
 //
-// NON-CUSTODIAL: this process holds NO agent nsec and NEVER unwraps. It routes on
-// the public outer `p` tag only, and needs only its own Buzz posting identity
-// (BUZZ_PRIVATE_KEY) to post into the inbox channels. Safe on a server that holds
-// no agent keys.
+// NON-CUSTODIAL: this process holds NO agent nsec and never unwraps mail CARRIED FOR OTHERS —
+// a DM between two members, a Concord plane wrap — those it routes on the public outer `p` tag
+// only. It DOES unwrap gift-wraps addressed to its OWN key (the relay lane, DESIGN_RELAY_INGRESS
+// §2): opening your own mail is not opening someone else's. It needs its own Buzz posting identity
+// (BUZZ_PRIVATE_KEY) to post into channels, plus its own Nostr key (BRIDGE key) to open relay-lane
+// requests sealed to it. Safe on a server that holds no OTHER party's keys.
 //
 // Promoted from the .scratch prototype (the outbox engineer, 2026-07-24) by the read-lane engineer:
 //   - config externalized to config.json (relays + recipients + inbox UUIDs)
@@ -51,6 +53,11 @@ const SEEN_CAP = Number(process.env.SEEN_CAP || 100000)
 // carries out to every matching recipient exactly once and never re-delivers across a restart.
 const RLSEEN_PATH = process.env.RLSEEN_PATH || resolve(ROOT, 'data', 'return-lane-seen.log')
 const RLSEEN_CAP = Number(process.env.RLSEEN_CAP || 100000)
+// Relay-lane dedup store (DESIGN_RELAY_INGRESS §6): wraps addressed to waggle's OWN key that it
+// unwraps and relays into a channel. Its own append-only capped file — checked BEFORE decryption
+// (replay protection; a fresh-wrap flood misses here by design, the decrypt budget bounds that).
+const RELAYSEEN_PATH = process.env.RELAYSEEN_PATH || resolve(ROOT, 'data', 'relay-lane-seen.log')
+const RELAYSEEN_CAP = Number(process.env.RELAYSEEN_CAP || 100000)
 const FORWARD_MODE = process.env.FORWARD_MODE || 'buzz'
 // SEALED_LANES=off runs the PUBLIC read lane ONLY — no DM lane, no Concord channel lane. Use this
 // on a SECOND instance (e.g. a local read-lane host) when another instance already owns the sealed
@@ -213,6 +220,17 @@ const PUB = cfg.public ? {
   // working-channel traffic must never reach handleCommand (a #connector post is not a console
   // command). A name or a UUID; unresolvable names are fatal in buzz mode.
   scanChannels: (cfg.public.scan_channels || []).map(v => String(v || '')).filter(Boolean),
+  // Relay lane (DESIGN_RELAY_INGRESS): channels an admitted agent may inject into by sealing a
+  // request to waggle's OWN key, instead of publishing a public kind:1 first. DEFAULT EMPTY, and
+  // NEVER implicitly inbox — an unlisted destination is dropped loudly. Resolved at boot like
+  // inbox/staging. Conveys no capability beyond the public lane EXCEPT destination selection, which
+  // is exactly what this allowlist gates (§3).
+  relayChannels: (cfg.public.relay_channels || []).map(v => String(v || '')).filter(Boolean),
+  // §7 flood mitigations. The decrypt budget is the ONE load-bearing one: unwrapping is decryption
+  // work on UNAUTHENTICATED input (the outer wrap is ephemeral-signed, so sender limiting is
+  // useless pre-decrypt). Per-minute global cap; exhaustion drops pre-decrypt and UNACKABLY.
+  relayDecryptBudget: Number(cfg.public.relay_decrypt_budget != null ? cfg.public.relay_decrypt_budget : 120),
+  relayMaxWrapBytes: Number(cfg.public.relay_max_wrap_bytes != null ? cfg.public.relay_max_wrap_bytes : 65536),
   // Signer gate on the scan carry-out — filled below, after approvers/grantors are known.
   scanAuthors: [],
   // Keys whose signed 440/441 events the bridge honors for admission. Defaults to the
@@ -257,7 +275,7 @@ if (PUB) {
 // as intent ("waggle-test") instead of hex. Unresolvable names are fatal in buzz mode.
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 function resolveChannels(cb) {
-  const pending = PUB ? [PUB.inbox, PUB.staging, ...PUB.scanChannels].filter(v => v && !UUID_RE.test(v)) : []
+  const pending = PUB ? [PUB.inbox, PUB.staging, ...PUB.scanChannels, ...PUB.relayChannels].filter(v => v && !UUID_RE.test(v)) : []
   if (!pending.length) return cb()
   if (FORWARD_MODE !== 'buzz') { err(`WARN: channel name(s) ${pending.join(', ')} left unresolved in ${FORWARD_MODE} mode`); return cb() }
   execFile('buzz', ['channels', 'list'], (e, so) => {
@@ -278,6 +296,7 @@ function resolveChannels(cb) {
     PUB.inbox = one(PUB.inbox, 'inbox')
     PUB.staging = one(PUB.staging, 'staging_inbox')
     PUB.scanChannels = PUB.scanChannels.map((v, i) => one(v, `scan_channel[${i}]`))
+    PUB.relayChannels = PUB.relayChannels.map((v, i) => one(v, `relay_channel[${i}]`))
     cb()
   })
 }
@@ -306,6 +325,23 @@ function loadSeen() {
 function markSeen(id) {
   seen.add(id)
   try { appendFileSync(SEEN_PATH, id + '\n') } catch (e) { err(`dedup: append failed for ${id}: ${e.message}`) }
+}
+
+// Relay-lane dedup — same append-only, capped lifecycle as seen-ids, a SEPARATE file. Marked on any
+// DETERMINISTIC outcome (posted, a reject, or a decrypt/verify failure that will never become
+// valid) so a relay re-serving that wrap is cheap; NOT marked on a transient budget drop, which may
+// succeed on retry. A wrap id here is never mixed into `seen` — the two stores never collide.
+const relaySeen = new Set()
+function loadRelaySeen() {
+  if (!existsSync(RELAYSEEN_PATH)) { mkdirSync(dirname(RELAYSEEN_PATH), { recursive: true }); return }
+  const lines = readFileSync(RELAYSEEN_PATH, 'utf8').split('\n').filter(Boolean)
+  const kept = lines.slice(-RELAYSEEN_CAP)
+  for (const id of kept) relaySeen.add(id)
+  log(`relay-lane dedup: loaded ${relaySeen.size} seen wrap ids from ${RELAYSEEN_PATH}${lines.length > kept.length ? ` (pruned ${lines.length - kept.length})` : ''}`)
+}
+function markRelaySeen(id) {
+  relaySeen.add(id)
+  try { appendFileSync(RELAYSEEN_PATH, id + '\n') } catch (e) { err(`relay-lane dedup: append failed for ${id}: ${e.message}`) }
 }
 
 // A7 posted-map: append-only JSONL, same lifecycle as seen-ids. One {id, author, buzz,
@@ -524,6 +560,10 @@ function route(ev) {
   }
 
   const ps = (ev.tags || []).filter(t => t[0] === 'p').map(t => t[1])
+  // Relay lane (DESIGN_RELAY_INGRESS): a wrap p-tagged to waggle's OWN key is mail for us to open,
+  // not a lane we carry for an agent — handled before the forward path, since our key is not in
+  // TARGETS. Fully inert while relay_channels is empty (default-closed).
+  if (BRIDGE_PK && PUB && PUB.relayChannels && PUB.relayChannels.length && ps.includes(BRIDGE_PK)) return handleRelayIngress(ev)
   const hits = ps.filter(p => TARGETS.includes(p))
   if (!hits.length) return // not for us; do NOT record — keep the dedup store to real deliveries
   // Record dedup ONLY for a genuinely committed delivery: buzz mode into at least
@@ -563,6 +603,37 @@ function rateOk(ev, dest, nowMs) {
   if (perR.length >= PUB.replierPerMin) { err(`PUBLIC drop[rate]: replier cap ${PUB.replierPerMin}/min for ${ev.pubkey.slice(0, 12)}… — ${ev.id.slice(0, 12)}…`); return false }
   lane.push(nowMs); perCh.push(nowMs); rlChannel.set(dest, perCh); perR.push(nowMs); rlReplier.set(ev.pubkey, perR)
   return true
+}
+
+// Relay-lane rate caps (DESIGN_RELAY_INGRESS MUST-FIX 2). rateOk above keys the replier cap on
+// ev.pubkey; on a gift wrap that is the EPHEMERAL key, fresh per wrap, so per-sender limiting there
+// is a no-op. The relay lane re-keys on the AUTHENTICATED seal.pubkey and so is POST-DECRYPT only —
+// a flood is bounded before this by the decrypt budget, not here. Separate counter maps so neither
+// lane starves the other. Same PUB.* caps as the public lane (§3: reuse, no new cap).
+const relayRlLane = []
+const relayRlChannel = new Map()
+const relayRlSender = new Map()
+function relayRateOk(sender, dest, nowMs) {
+  const lane = slide(relayRlLane, nowMs, 3600_000)
+  if (lane.length >= PUB.lanePerHour) { err(`RELAY drop[rate]: lane cap ${PUB.lanePerHour}/h — ${sender.slice(0, 12)}…`); return false }
+  const perCh = slide(relayRlChannel.get(dest) || [], nowMs, 60_000)
+  if (perCh.length >= PUB.channelPerMin) { err(`RELAY drop[rate]: channel cap ${PUB.channelPerMin}/min for ${dest} — ${sender.slice(0, 12)}…`); return false }
+  const perS = slide(relayRlSender.get(sender) || [], nowMs, 60_000)
+  if (perS.length >= PUB.replierPerMin) { err(`RELAY drop[rate]: sender cap ${PUB.replierPerMin}/min for ${sender.slice(0, 12)}…`); return false }
+  lane.push(nowMs); perCh.push(nowMs); relayRlChannel.set(dest, perCh); perS.push(nowMs); relayRlSender.set(sender, perS)
+  return true
+}
+
+// §7 decrypt-budget window + the pre-decrypt drop counter. The counter is LOUD by design: it is the
+// number the #116 silence/accept-count alarm watches, so a flood spikes a monitored signal rather
+// than a dead integer. The wire INTO the alarm lands once #116/#121 is in main (that seam does not
+// exist here yet); the counter and its accessor exist now so the alarm can subscribe without a
+// second edit to this path. `notRelay` is deliberately EXCLUDED from the flood total below — a
+// well-formed DM to waggle that simply isn't a relay request is not an attack signal.
+const relayDecWin = []
+const relayDropCounts = { budget: 0, size: 0, decrypt: 0, verify: 0, mismatch: 0, notRelay: 0 }
+function relayDropTotalPreAuth() {
+  return relayDropCounts.budget + relayDropCounts.size + relayDropCounts.decrypt + relayDropCounts.verify + relayDropCounts.mismatch
 }
 
 // Friendly names: best-effort kind:0 lookup on the public relays, cached with a TTL. A
@@ -1013,6 +1084,111 @@ function returnLaneSend(toHex, text, meta) {
   } catch (e) { err(`return lane: seal/send failed: ${e.message}`); return false }
 }
 
+// --- relay lane: an admitted agent speaks without speaking publicly (DESIGN_RELAY_INGRESS) ------
+// A gift-wrap addressed to waggle's OWN key. waggle opens ITS OWN mail (not a lane it carries for
+// others), proves the sender off the SIGNED seal, checks the same grantSet the public lane does,
+// renders with the same renderReleased, and posts kind:9 as the roster member it already is — then
+// seals an ack back, because the sender is not a member and cannot cold-read-back (§5).
+function relayDrop(reason, id, deterministic = true) {
+  // Pre-auth drop: UNACKABLE by construction (no verified seal.pubkey), so counted, never echoed
+  // (no payload in the log — §7). A deterministic drop marks seen (a replay is then cheap); a
+  // transient budget drop does NOT, so a re-served wrap may still succeed within a later window.
+  if (relayDropCounts[reason] !== undefined) relayDropCounts[reason]++
+  err(`RELAY drop[${reason}]: wrap ${String(id).slice(0, 12)}… (pre-auth, unackable)`)
+  if (deterministic) markRelaySeen(id)
+}
+function relayReject(sender, id, reason, wantCh) {
+  // Post-auth reject: the sender IS proven, so the refusal is ACKED — a drop and a silence must not
+  // look the same (§5). Marked seen: the decision is deterministic for this wrap id.
+  err(`RELAY reject: ${reason} — sender ${sender.slice(0, 12)}… -> '${wantCh}' (wrap ${String(id).slice(0, 12)}…)`)
+  markRelaySeen(id)
+  returnLaneSend(sender, JSON.stringify({ ok: false, reason, channel: wantCh, ts: Math.floor(Date.now() / 1000) }), { lane: 'relay-ack' })
+}
+function resolveRelayDest(wantCh) {
+  // Allowlist check against the resolved relay_channels (UUIDs at boot). DEFAULT EMPTY → nothing
+  // passes. Accepts a UUID already in the set (a name would have been resolved to one at boot).
+  const w = String(wantCh || '').toLowerCase()
+  for (const c of (PUB.relayChannels || [])) if (String(c).toLowerCase() === w) return c
+  return null
+}
+async function postRelay(ev, sender, dest, wantCh, body) {
+  // Render identically to the public lane; a granted sender earns live @mentions (#118). Attribution
+  // is the sender's own name + npub — this identity said this, and waggle carried it (§4).
+  let name = null
+  if (!process.env.WB_STUB_SEND) { try { name = await fetchProfileName(sender) } catch { name = null } }
+  let npub = null
+  try { npub = nip19.npubEncode(sender) } catch { npub = null }
+  const npubShort = npub ? `${npub.slice(0, 10)}…${npub.slice(-5)}` : sender.slice(0, 12) + '…'
+  const content = renderReleased({ body, name, npubShort, liveRefs: true })
+  const nowSec = Math.floor(Date.now() / 1000)
+  const ackOk = (buzzId) => returnLaneSend(sender, JSON.stringify({ ok: true, channel: dest, buzz_event_id: buzzId || null, ts: nowSec }), { lane: 'relay-ack' })
+  if (FORWARD_MODE !== 'buzz') {
+    log(`RELAY[dryrun] -> ${dest}: from ${sender.slice(0, 12)}… (${Buffer.byteLength(body)}B) :: ${JSON.stringify(body.slice(0, 80))}`)
+    return
+  }
+  if (process.env.WB_STUB_SEND) {
+    const fakeId = ev.id.split('').reverse().join('')
+    markRelaySeen(ev.id) // commit-after-"send"
+    recordPosted({ id: ev.id, author: sender, buzz: fakeId, dest, q: false, ts: nowSec, agent: sender })
+    journalSend(fakeId, { kind: 9, dest, lane: 'relay' })
+    ackOk(fakeId)
+    log(`RELAY[stub] -> ${dest}: from ${sender.slice(0, 12)}…`)
+    return
+  }
+  execFile('buzz', ['messages', 'send', '--channel', dest, '--content', content], (e, so, se) => {
+    // A channel waggle is not a member of fails HERE with a distinct RELAY[buzz] ERR — it can never
+    // masquerade as a §7 drop, and it is NOT marked seen, so it retries rather than dropping.
+    if (e) { err(`RELAY[buzz] ERR -> ${dest}: ${se || e.message} — NOT marked seen, will retry`); return }
+    // commit-AFTER-send (#114 finding-3): mark the wrap carried only once the kind:9 posted, so a
+    // transient failure retries. Residual: a crash after this post but before the mark re-posts on
+    // restart — kind:9 has no idempotency key, so the dup-on-crash residual stands (§6).
+    const buzzId = parseBuzzEventId(so)
+    markRelaySeen(ev.id)
+    recordPosted({ id: ev.id, author: sender, buzz: buzzId, dest, q: false, ts: nowSec, agent: sender })
+    journalSend(buzzId, { kind: 9, dest, lane: 'relay' })
+    ackOk(buzzId)
+    log(`RELAY[buzz] ok -> ${dest}: from ${sender.slice(0, 12)}… (wrap ${ev.id.slice(0, 12)}…)`)
+  })
+}
+function handleRelayIngress(ev) {
+  if (!BRIDGE_SK || !PUB) return
+  const nowMs = Date.now()
+  if (relaySeen.has(ev.id)) return                                          // §6 dedup BEFORE decrypt
+  const wrapBytes = Buffer.byteLength(JSON.stringify(ev))
+  if (wrapBytes > PUB.relayMaxWrapBytes) return relayDrop('size', ev.id)     // §7 hard cap, cheap
+  slide(relayDecWin, nowMs, 60_000)
+  if (relayDecWin.length >= PUB.relayDecryptBudget) return relayDrop('budget', ev.id, false) // §7, transient
+  relayDecWin.push(nowMs)
+  // ---- expensive step: decryption of UNAUTHENTICATED input (the §7 DoS surface) ----
+  let seal
+  try { seal = JSON.parse(nip44.decrypt(ev.content, nip44.getConversationKey(BRIDGE_SK, ev.pubkey))) }
+  catch { return relayDrop('decrypt', ev.id) }
+  let ok = false
+  try { ok = verifyEvent(seal) } catch { ok = false }
+  if (!ok || seal.kind !== 13) return relayDrop('verify', ev.id)            // authorship proof (§2.4)
+  let rumor
+  try { rumor = JSON.parse(nip44.decrypt(seal.content, nip44.getConversationKey(BRIDGE_SK, seal.pubkey))) }
+  catch { return relayDrop('decrypt', ev.id) }
+  if (!rumor || String(rumor.pubkey) !== String(seal.pubkey)) return relayDrop('mismatch', ev.id) // bind unsigned rumor
+  // ---- the sender is now AUTHENTICATED: every drop below is ACKED ----
+  const sender = String(seal.pubkey).toLowerCase()
+  const relayTag = (rumor.tags || []).find(t => t[0] === 'relay' && t[1])
+  // Routing discriminator: kind:14 + a well-formed `relay` tag IS this lane. Its absence is not an
+  // error — it is a real DM to waggle, which has no handler here; leave it silent, do not ack it as
+  // a failed relay request, and do not count it as a flood signal.
+  if (rumor.kind !== 14 || !relayTag) { relayDropCounts.notRelay++; markRelaySeen(ev.id); return }
+  const wantCh = String(relayTag[1])
+  const dest = resolveRelayDest(wantCh)
+  if (!dest) return relayReject(sender, ev.id, 'channel not allowlisted', wantCh)
+  if (!grantSet.has(sender)) return relayReject(sender, ev.id, 'not admitted', wantCh)
+  const body = String(rumor.content || '')
+  const bytes = Buffer.byteLength(body)
+  if (!bytes) return relayReject(sender, ev.id, 'empty body', wantCh)
+  if (bytes > PUB.maxContentBytes) return relayReject(sender, ev.id, `over ${PUB.maxContentBytes}B cap`, wantCh)
+  if (!relayRateOk(sender, dest, nowMs)) return relayReject(sender, ev.id, 'rate cap', wantCh)
+  postRelay(ev, sender, dest, wantCh, body)
+}
+
 // Which return-lane recipient (delivery npub) a given bridge-posted Buzz event was authored FOR,
 // or null. This is the agent-authored registry read: reply-to-agent and echo-skip both key on it,
 // never on the shared bridge signing key. Empty until the registry is fed (a repost of the agent's
@@ -1201,6 +1377,11 @@ function connect(url) {
       if (PLANE_AUTHORS.length) {
         ws.send(JSON.stringify(['REQ', 'wc', { kinds: [1059], authors: PLANE_AUTHORS, since: CHANNEL_SINCE }]))
       }
+      // Relay lane: 1059 wraps p-tagged to waggle's OWN key — requests it opens itself. Separate REQ
+      // so a relay serving one filter still serves the others. Only when relay_channels is set.
+      if (BRIDGE_PK && PUB && PUB.relayChannels && PUB.relayChannels.length) {
+        ws.send(JSON.stringify(['REQ', 'wr', { kinds: [1059], '#p': [BRIDGE_PK], since: SINCE }]))
+      }
     })
     ws.on('message', d => {
       let m
@@ -1337,13 +1518,14 @@ function connectPublic(url) {
 // Exported so a harness can drive the REAL routing functions (not a copy) with synthetic
 // events in dryrun, without opening any relay socket. Set WB_NO_BOOT=1 to import without
 // booting the live subscriber. No effect on normal `node src/bridge.mjs` runs.
-export { returnLaneSend, scanReturnLane, pollScanChannels, scanChannel, scanSince, bumpScanCursor, loadScanCursors, agentAuthoredBy, rlSeen, rlKey, loadRlSeen, markRlSeen, route, routePublic, routeDelete, processGrantEvent, grantSet, forwardPublic, clampCreated, rateOk, bumpPubWatermark, loadPubWatermark, markSeen, seen, PUB, postedMap, recordPosted, parseBuzzEventId, resolveChannels }
+export { returnLaneSend, scanReturnLane, pollScanChannels, scanChannel, scanSince, bumpScanCursor, loadScanCursors, agentAuthoredBy, rlSeen, rlKey, loadRlSeen, markRlSeen, route, routePublic, routeDelete, processGrantEvent, grantSet, forwardPublic, clampCreated, rateOk, bumpPubWatermark, loadPubWatermark, markSeen, seen, PUB, postedMap, recordPosted, parseBuzzEventId, resolveChannels, handleRelayIngress, relaySeen, markRelaySeen, loadRelaySeen, relayRateOk, resolveRelayDest, relayDropTotalPreAuth, relayDropCounts }
 
 // --- boot -------------------------------------------------------------------
 if (!process.env.WB_NO_BOOT) {
   loadSeen()
   loadPostedMap()
   loadRlSeen()
+  loadRelaySeen()
   log(`waggle — mode=${FORWARD_MODE}, ${TARGETS.length} recipients, ${RELAYS.length} relays, ${PLANE_AUTHORS.length} channel plane(s), dm-since=${SINCE} (${SINCE_SECS}s), chan-since=${CHANNEL_SINCE} (${CHANNEL_SINCE_SECS}s)`)
   if (!SEALED_LANES) {
     log('sealed lanes: DISABLED (SEALED_LANES=off) — DM + Concord channel routing OFF; running PUBLIC read lane only')
@@ -1361,6 +1543,8 @@ if (!process.env.WB_NO_BOOT) {
     log(`public read lane -> inbox ${PUB.inbox}: ${PUB.relays.length} relay(s), ${PUB.authors.length} watched author(s), ${PUB.events.length} watched note(s), pub-since=${PUB.since} (${PUB_SINCE_SECS}s), watermark=${pubWatermark || 'none'}`)
     log(`  gates: staging=${PUB.staging || 'HOLD (none)'} · backfill<=${PUB.backfillLimit} · maxContent=${PUB.maxContentBytes}B · rate ${PUB.replierPerMin}/replier/min ${PUB.channelPerMin}/chan/min ${PUB.lanePerHour}/lane/h · deletes ${PUB.deletesPerHour}/h (A7)`)
     if (PUB.grantors.length) log(`  admission: ${PUB.grantors.length} grantor key(s); NIP-DA kinds ${NIPDA.grant}/${NIPDA.revocation}/${NIPDA.index}`)
+    if (PUB.relayChannels.length && BRIDGE_SK) log(`  relay lane: ${PUB.relayChannels.length} allowlisted channel(s); decrypt budget ${PUB.relayDecryptBudget}/min, wrap cap ${PUB.relayMaxWrapBytes}B — a channel waggle has not joined fails as RELAY[buzz] ERR, never a silent §7 drop`)
+    else if (PUB.relayChannels.length && !BRIDGE_SK) err('WARN: relay_channels configured but no BRIDGE key to open sealed requests — relay lane INERT.')
     PUB.relays.forEach(connectPublic)
     if (PUB.staging && PUB.approvers.length && FORWARD_MODE === 'buzz') {
       log(`approval console: watching staging for commands from ${PUB.approvers.length} approver(s)`)

--- a/tests/relay_ingress.mjs
+++ b/tests/relay_ingress.mjs
@@ -1,0 +1,225 @@
+// Relay lane (DESIGN_RELAY_INGRESS, #122/#123) — an admitted agent seals a request to waggle's OWN
+// key and waggle relays it into an allowlisted channel as the member it already is, then seals an
+// ack back. This proves the parts the design and Dennis's review turn on:
+//
+//   • authorship proof: verifyEvent(seal) + rumor.pubkey === seal.pubkey (§2.4) — a bad signature
+//     or a rumor claiming a different author is dropped PRE-AUTH (counted, unackable, no post),
+//   • the gates fail closed: unlisted destination and ungranted signer are ACKED ok:false (§5),
+//   • MUST-FIX 2: the per-sender rate cap keys on the AUTHENTICATED seal.pubkey, not the ephemeral
+//     wrap key, so it actually bites,
+//   • §7 flood surface: a hard wrap-size cap and the global decrypt budget both drop PRE-AUTH and
+//     UNACKABLY, and bump the loud pre-auth drop counter the #116 alarm watches,
+//   • §6 dedup-before-decrypt on the wrap id, and the routing discriminator (kind:14 + relay tag).
+//
+//   node tests/relay_ingress.mjs
+
+import { mkdtempSync, writeFileSync, readFileSync, existsSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { resolve } from 'node:path'
+import { getPublicKey, generateSecretKey, finalizeEvent, getEventHash } from 'nostr-tools/pure'
+import * as nip44 from 'nostr-tools/nip44'
+
+const dir = mkdtempSync(resolve(tmpdir(), 'wb-relay-'))
+const bridgeSk = generateSecretKey()
+const bridgePk = getPublicKey(bridgeSk)
+const CHAN = 'a8186b53-537d-46ad-a7e7-b6486c58970e' // an allowlisted destination (already a UUID)
+const OTHER = 'ffffffff-0000-0000-0000-000000000000' // NOT allowlisted
+
+writeFileSync(resolve(dir, 'config.json'), JSON.stringify({
+  relays: [], recipients: [],
+  public: {
+    relays: ['wss://example.invalid'], inbox: 'chan', staging_inbox: 'chan',
+    watch_authors: [], watch_events: [], approvers: [], grantors: [],
+    scan_authors: [], scan_channels: [],
+    relay_channels: [CHAN],
+    replier_per_min: 5, channel_per_min: 20, lane_per_hour: 200, max_content_bytes: 16384,
+    return_lane: [],
+  },
+}, null, 2))
+
+process.env.CONFIG_PATH = resolve(dir, 'config.json')
+process.env.SEND_JOURNAL_PATH = resolve(dir, 'send-journal.log')
+process.env.SEEN_PATH = resolve(dir, 'seen.log')
+process.env.POSTED_MAP_PATH = resolve(dir, 'posted.log')
+process.env.RLSEEN_PATH = resolve(dir, 'return-lane-seen.log')
+process.env.RELAYSEEN_PATH = resolve(dir, 'relay-lane-seen.log')
+process.env.BUZZ_PRIVATE_KEY = Buffer.from(bridgeSk).toString('hex')
+process.env.FORWARD_MODE = 'buzz'
+process.env.WB_STUB_SEND = '1'
+process.env.WB_NO_BOOT = '1'
+
+const bridge = await import('../src/bridge.mjs')
+const { handleRelayIngress, route, grantSet, relaySeen, relayDropCounts, relayDropTotalPreAuth, resolveRelayDest, PUB } = bridge
+
+let fails = 0
+const ok = (n, c) => { console.log(`${c ? 'ok  ' : 'FAIL'} — ${n}`); if (!c) fails++ }
+const tick = () => new Promise(r => setImmediate(r))
+const journal = () => existsSync(process.env.SEND_JOURNAL_PATH)
+  ? readFileSync(process.env.SEND_JOURNAL_PATH, 'utf8').split('\n').filter(Boolean).map(JSON.parse) : []
+let jbase = 0
+const delta = () => { const j = journal(); const d = j.slice(jbase); jbase = j.length; return d }
+const relayPost = d => d.find(e => e.kind === 9 && e.lane === 'relay')
+const ack = d => d.find(e => e.kind === 1059 && e.lane === 'relay-ack')
+
+// Build a 1059 gift-wrap addressed to waggle's key: rumor (kind:14, relay tag) → seal (13, signed
+// by the sender) → wrap (1059, signed by a throwaway). Mirrors returnLaneSend's construction.
+function wrapFor(senderSk, { body = 'hello team', channel = CHAN, kind = 14, tags, rumorPubkey, breakSig = false } = {}) {
+  const senderPk = getPublicKey(senderSk)
+  const now = Math.floor(Date.now() / 1000)
+  const rumor = { kind, pubkey: rumorPubkey || senderPk, created_at: now,
+    tags: tags !== undefined ? tags : [['relay', channel]], content: body }
+  rumor.id = getEventHash(rumor)
+  const seal = finalizeEvent({ kind: 13, created_at: now, tags: [],
+    content: nip44.encrypt(JSON.stringify(rumor), nip44.getConversationKey(senderSk, bridgePk)) }, senderSk)
+  if (breakSig) seal.sig = seal.sig.replace(/.$/, c => (c === '0' ? '1' : '0'))
+  const wsk = generateSecretKey()
+  const wrap = finalizeEvent({ kind: 1059, created_at: now, tags: [['p', bridgePk]],
+    content: nip44.encrypt(JSON.stringify(seal), nip44.getConversationKey(wsk, bridgePk)) }, wsk)
+  return { wrap, senderPk: senderPk.toLowerCase() }
+}
+const admit = pk => grantSet.set(pk.toLowerCase(), { grantId: 'g-' + pk.slice(0, 8), grantor: 'test' })
+
+// --- config -----------------------------------------------------------------
+ok('relay_channels parsed', PUB.relayChannels.length === 1 && PUB.relayChannels[0] === CHAN)
+ok('resolveRelayDest accepts the allowlisted channel', resolveRelayDest(CHAN) === CHAN)
+ok('resolveRelayDest rejects an unlisted channel', resolveRelayDest(OTHER) === null)
+ok('resolveRelayDest rejects empty', resolveRelayDest('') === null)
+
+// --- happy path: granted sender, allowlisted channel ------------------------
+{
+  const sk = generateSecretKey(); const { wrap, senderPk } = wrapFor(sk)
+  admit(senderPk)
+  handleRelayIngress(wrap); await tick()
+  const d = delta()
+  ok('granted+allowlisted → posts kind:9 to the destination', !!relayPost(d) && relayPost(d).dest === CHAN)
+  ok('granted+allowlisted → seals an ack back', !!ack(d))
+  ok('the carried wrap is now deduped (relaySeen)', relaySeen.has(wrap.id))
+  // dedup-before-decrypt: replaying the SAME wrap does nothing
+  handleRelayIngress(wrap); await tick()
+  ok('replaying the same wrap carries nothing new (§6 dedup)', delta().length === 0)
+}
+
+// --- route() dispatches the branch ------------------------------------------
+{
+  const sk = generateSecretKey(); const { wrap, senderPk } = wrapFor(sk, { body: 'via route' })
+  admit(senderPk)
+  route(wrap); await tick()
+  ok('route() dispatches a waggle-addressed wrap into the relay lane', !!relayPost(delta()))
+}
+
+// --- gate: ungranted signer is ACKED ok:false, never posted -----------------
+{
+  const sk = generateSecretKey(); const { wrap } = wrapFor(sk) // NOT admitted
+  handleRelayIngress(wrap); await tick()
+  const d = delta()
+  ok('ungranted signer → NO channel post', !relayPost(d))
+  ok('ungranted signer → still ACKED (refusal is not silent, §5)', !!ack(d))
+}
+
+// --- gate: unlisted destination is ACKED ok:false, never posted -------------
+{
+  const sk = generateSecretKey(); const { wrap, senderPk } = wrapFor(sk, { channel: OTHER })
+  admit(senderPk)
+  handleRelayIngress(wrap); await tick()
+  const d = delta()
+  ok('unlisted destination → NO channel post', !relayPost(d))
+  ok('unlisted destination → ACKED ok:false', !!ack(d))
+}
+
+// --- empty body is rejected (post-auth, acked) ------------------------------
+{
+  const sk = generateSecretKey(); const { wrap, senderPk } = wrapFor(sk, { body: '' })
+  admit(senderPk)
+  handleRelayIngress(wrap); await tick()
+  const d = delta()
+  ok('empty body → NO post, but ACKED', !relayPost(d) && !!ack(d))
+}
+
+// --- authorship: rumor claiming a DIFFERENT author than the seal is dropped --
+{
+  const sk = generateSecretKey(); const other = getPublicKey(generateSecretKey())
+  const { wrap } = wrapFor(sk, { rumorPubkey: other }) // seal signed by sk, rumor claims `other`
+  admit(getPublicKey(sk)) // admitted — proving the drop is on the BIND, not the gate
+  const before = relayDropCounts.mismatch
+  handleRelayIngress(wrap); await tick()
+  const d = delta()
+  ok('rumor.pubkey ≠ seal.pubkey → dropped, NO post, NO ack (pre-auth)', !relayPost(d) && !ack(d))
+  ok('  and the mismatch counter incremented', relayDropCounts.mismatch === before + 1)
+}
+
+// --- authorship: a tampered seal signature is dropped pre-auth --------------
+{
+  const sk = generateSecretKey(); const { wrap } = wrapFor(sk, { breakSig: true })
+  admit(getPublicKey(sk))
+  const before = relayDropCounts.verify
+  handleRelayIngress(wrap); await tick()
+  ok('bad seal signature → verify drop, NO post/ack', !relayPost(delta()) && relayDropCounts.verify === before + 1)
+}
+
+// --- decrypt failure on garbage ciphertext is dropped pre-auth --------------
+{
+  const wsk = generateSecretKey()
+  const junk = finalizeEvent({ kind: 1059, created_at: Math.floor(Date.now() / 1000),
+    tags: [['p', bridgePk]], content: 'not-nip44-ciphertext' }, wsk)
+  const before = relayDropCounts.decrypt
+  handleRelayIngress(junk); await tick()
+  ok('undecryptable wrap → decrypt drop, NO post/ack', !relayPost(delta()) && relayDropCounts.decrypt === before + 1)
+}
+
+// --- routing discriminator: a well-formed DM to waggle with NO relay tag -----
+{
+  const sk = generateSecretKey(); const { wrap, senderPk } = wrapFor(sk, { tags: [] }) // kind:14, no relay tag
+  admit(senderPk)
+  const beforeNR = relayDropCounts.notRelay; const beforeTotal = relayDropTotalPreAuth()
+  handleRelayIngress(wrap); await tick()
+  const d = delta()
+  ok('kind:14 without a relay tag → left silent (real DM), NO post, NO ack', !relayPost(d) && !ack(d))
+  ok('  notRelay counter bumped', relayDropCounts.notRelay === beforeNR + 1)
+  ok('  but notRelay is EXCLUDED from the pre-auth flood total', relayDropTotalPreAuth() === beforeTotal)
+}
+
+// --- §7 hard wrap-size cap drops pre-auth -----------------------------------
+{
+  const saved = PUB.relayMaxWrapBytes; PUB.relayMaxWrapBytes = 200 // any real wrap exceeds this
+  const sk = generateSecretKey(); const { wrap, senderPk } = wrapFor(sk)
+  admit(senderPk)
+  const before = relayDropCounts.size
+  handleRelayIngress(wrap); await tick()
+  ok('oversize wrap → size drop before decrypt, NO post', !relayPost(delta()) && relayDropCounts.size === before + 1)
+  PUB.relayMaxWrapBytes = saved
+}
+
+// --- §7 decrypt budget: exhaustion drops pre-auth and does NOT dedup --------
+{
+  const saved = PUB.relayDecryptBudget; PUB.relayDecryptBudget = 0 // every attempt is over budget
+  const sk = generateSecretKey(); const { wrap, senderPk } = wrapFor(sk)
+  admit(senderPk)
+  const before = relayDropCounts.budget
+  handleRelayIngress(wrap); await tick()
+  ok('over decrypt budget → budget drop, NO post', !relayPost(delta()) && relayDropCounts.budget === before + 1)
+  ok('  a budget drop does NOT mark the wrap seen (may retry)', !relaySeen.has(wrap.id))
+  PUB.relayDecryptBudget = saved
+  // and now, budget restored, the same wrap goes through
+  handleRelayIngress(wrap); await tick()
+  ok('  once budget is restored, the same wrap posts', !!relayPost(delta()))
+}
+
+// --- MUST-FIX 2: the per-sender rate cap keys on seal.pubkey and bites -------
+{
+  const sk = generateSecretKey(); const senderPk = getPublicKey(sk).toLowerCase()
+  admit(senderPk)
+  let posts = 0, rejects = 0
+  // replier_per_min = 5; the 6th distinct wrap from the SAME authenticated sender must be rejected,
+  // even though each wrap's outer (ephemeral) key differs — proving the cap keys on seal.pubkey.
+  for (let i = 0; i < 6; i++) {
+    const { wrap } = wrapFor(sk, { body: `msg ${i}` })
+    handleRelayIngress(wrap); await tick()
+    const d = delta()
+    if (relayPost(d)) posts++
+    else if (ack(d)) rejects++
+  }
+  ok('same-sender cap bites at replier_per_min (5 post, 6th rejected)', posts === 5 && rejects === 1)
+}
+
+console.log(fails ? `\n${fails} FAIL` : '\nall passed')
+process.exit(fails ? 1 : 0)


### PR DESCRIPTION
Implements the relay lane from **DESIGN_RELAY_INGRESS** (#123, issue #122) — the ingress half of the sev-1. An admitted external agent seals a `kind:14` request (`relay` tag = destination channel) to waggle's **own** key; waggle opens its own mail, proves the sender off the **signed seal**, checks the same `grantSet` the public lane does, renders with the existing `renderReleased`, posts `kind:9` as the roster member it already is, journals it, and **seals an ack back** — the sender is not a member and cannot cold-read-back (§5), so a drop and a silence must not look the same.

Dennis's review (`CLEARED`) is folded into the build, not left in the doc:

- **MUST-FIX 1** — the line-8 header no longer states the absolute "NEVER unwraps". It never unwraps mail *carried for others*; it *does* open wraps addressed to its own key. A stale absolute invariant at the top of the file is a warning that never fires.
- **MUST-FIX 2** — the per-sender rate cap keys on the **authenticated `seal.pubkey`**, never `ev.pubkey` (the ephemeral wrap key, fresh per wrap → a no-op). It is therefore post-decrypt, and it bites (test: 6th wrap from one sender is rejected).
- **§3** — no new `da-cap`. The lane conveys no power beyond the public lane **except destination selection**, which `relay_channels` (default-empty) gates. Same `grantSet`, same A6 caps, same `maxContentBytes`.
- **§7** — a hard wrap-size cap and a **global decrypt budget** bound the DoS surface *before* the expensive decrypt; the pre-decrypt drop counter is exposed (`relayDropCounts` / `relayDropTotalPreAuth`) for the #116 alarm to watch — loud, not a dead counter. Dedup is replay-only (§6), not DoS, and does not pretend to share the load.
- **Routing discriminator** — `kind:14` + a well-formed `relay` tag is this lane; its absence is a real DM to waggle, left silent (not acked, not a flood signal).

### Sequencing / dependencies
- The §7 drop-counter **→ #116-alarm wire** lands once **#121** is in `main` (that seam does not exist here yet). The counter and accessor exist now so the alarm can subscribe without a second edit to this path.
- **#117** (sender-side ack-timeout) is a **hard dependency**, not optional: a pre-decrypt drop (decrypt-fail or budget-exhaustion) is unackable by construction, so §5+§7 require the sender to time out and retry.

### Scoping notes
- The `relay` tag carries the destination **channel UUID** (the `relay_channels` allowlist resolves names→UUIDs at boot). A name in the tag fails closed with an `ok:false` ack; tag-side name resolution is a follow-up.
- A channel waggle has not joined fails as a distinct `RELAY[buzz] ERR` (not marked seen → retries), so it can never masquerade as a §7 drop — Dennis's boot-roster concern, addressed by distinct failure surfacing.

### Tests
`tests/relay_ingress.mjs` — 26 assertions: happy path, dedup-before-decrypt, ungranted/unlisted/empty rejects (acked), author-mismatch + tampered-sig + garbage-ciphertext (pre-auth drops, counted, no ack), size cap, decrypt budget (drops + does-not-dedup + recovers), `route()` dispatch, and the MUST-FIX 2 same-sender cap. **Full suite green — 12 suites.**

The doc edits Dennis asked for (§3 destination-selection + audit-trail caveats, §7 mitigation-mapping, #117 as hard dependency) go into #123 so the design of record matches the code.

Drafted with assistance from [Claude Code](https://claude.com/claude-code)

---

**Reviewer note (per Dennis's tree review).** Enabling `relay_channels` turns waggle's BRIDGE key into an active *inbound* unwrapping inbox for the first time. A `kind:14` wrap to it with **no `relay` tag** is silently consumed and marked seen (`notRelay`) **by design** — not a swallowed DM. This is safe because BRIDGE_PK is explicitly filtered out of `TARGETS` and the author/grantor lists (`bridge.mjs:208,238`), so the relay lane is the *only* consumer of inbound-to-bridge wraps; no existing flow is disturbed.
