### PR TITLE
fix(relay-lane): claim the wrap at dispatch, or every send posts N times

### DIFF
--- a/src/bridge.mjs
+++ b/src/bridge.mjs
@@ -343,6 +343,15 @@ function markRelaySeen(id) {
   relaySeen.add(id)
   try { appendFileSync(RELAYSEEN_PATH, id + '\n') } catch (e) { err(`relay-lane dedup: append failed for ${id}: ${e.message}`) }
 }
+// Claim/rollback split, mirroring the return lane's addRlSeen/dropRlSeen (#121 finding #2).
+// The entry check `relaySeen.has(ev.id)` and the durable `markRelaySeen` sit on opposite sides of
+// an ASYNC buzz send. Without an in-memory claim taken synchronously at dispatch, every copy of
+// the same wrap arriving before the first send returns passes the check and posts again — and that
+// is not a rare race but the NORMAL case: a sender publishes to N relays and the bridge subscribes
+// to all of them. Observed on the lane's first live use: one wrap, two identical channel posts
+// 423ms apart. Claim on dispatch, persist on success, roll back on failure so it still retries.
+function addRelaySeen(id) { relaySeen.add(id) }
+function dropRelaySeen(id) { relaySeen.delete(id) }
 
 // A7 posted-map: append-only JSONL, same lifecycle as seen-ids. One {id, author, buzz,
 // dest, ts} record per reposted public note, plus {id, deleted:true} once withdrawn — the
@@ -1160,7 +1169,7 @@ async function postRelay(ev, sender, dest, wantCh, body) {
   execFile('buzz', ['messages', 'send', '--channel', dest, '--content', content], (e, so, se) => {
     // A channel waggle is not a member of fails HERE with a distinct RELAY[buzz] ERR — it can never
     // masquerade as a §7 drop, and it is NOT marked seen, so it retries rather than dropping.
-    if (e) { err(`RELAY[buzz] ERR -> ${dest}: ${se || e.message} — NOT marked seen, will retry`); return }
+    if (e) { dropRelaySeen(ev.id); err(`RELAY[buzz] ERR -> ${dest}: ${se || e.message} — claim rolled back, will retry`); return }
     // commit-AFTER-send (#114 finding-3): mark the wrap carried only once the kind:9 posted, so a
     // transient failure retries. Residual: a crash after this post but before the mark re-posts on
     // restart — kind:9 has no idempotency key, so the dup-on-crash residual stands (§6).
@@ -1208,6 +1217,7 @@ function handleRelayIngress(ev) {
   if (!bytes) return relayReject(sender, ev.id, 'empty body', wantCh)
   if (bytes > PUB.maxContentBytes) return relayReject(sender, ev.id, `over ${PUB.maxContentBytes}B cap`, wantCh)
   if (!relayRateOk(sender, dest, nowMs)) return relayReject(sender, ev.id, 'rate cap', wantCh)
+  addRelaySeen(ev.id)   // claim BEFORE the async send: a copy from another relay must not post again
   postRelay(ev, sender, dest, wantCh, body)
 }
 
@@ -1574,7 +1584,7 @@ function connectPublic(url) {
 // Exported so a harness can drive the REAL routing functions (not a copy) with synthetic
 // events in dryrun, without opening any relay socket. Set WB_NO_BOOT=1 to import without
 // booting the live subscriber. No effect on normal `node src/bridge.mjs` runs.
-export { returnLaneSend, publishWrapToRelays, scanReturnLane, pollScanChannels, scanChannel, scanSince, bumpScanCursor, loadScanCursors, agentAuthoredBy, rlSeen, rlKey, loadRlSeen, markRlSeen, addRlSeen, dropRlSeen, route, routePublic, routeDelete, processGrantEvent, grantSet, forwardPublic, clampCreated, rateOk, bumpPubWatermark, loadPubWatermark, markSeen, seen, PUB, postedMap, recordPosted, parseBuzzEventId, resolveChannels, handleRelayIngress, relaySeen, markRelaySeen, loadRelaySeen, relayRateOk, resolveRelayDest, relayDropTotalPreAuth, relayDropCounts }
+export { returnLaneSend, publishWrapToRelays, scanReturnLane, pollScanChannels, scanChannel, scanSince, bumpScanCursor, loadScanCursors, agentAuthoredBy, rlSeen, rlKey, loadRlSeen, markRlSeen, addRlSeen, dropRlSeen, route, routePublic, routeDelete, processGrantEvent, grantSet, forwardPublic, clampCreated, rateOk, bumpPubWatermark, loadPubWatermark, markSeen, seen, PUB, postedMap, recordPosted, parseBuzzEventId, resolveChannels, handleRelayIngress, relaySeen, markRelaySeen, addRelaySeen, dropRelaySeen, loadRelaySeen, relayRateOk, resolveRelayDest, relayDropTotalPreAuth, relayDropCounts }
 
 // --- boot -------------------------------------------------------------------
 if (!process.env.WB_NO_BOOT) {

--- a/tests/relay_ingress.mjs
+++ b/tests/relay_ingress.mjs
@@ -49,7 +49,7 @@ process.env.WB_STUB_SEND = '1'
 process.env.WB_NO_BOOT = '1'
 
 const bridge = await import('../src/bridge.mjs')
-const { handleRelayIngress, route, grantSet, relaySeen, relayDropCounts, relayDropTotalPreAuth, resolveRelayDest, PUB } = bridge
+const { handleRelayIngress, route, grantSet, relaySeen, addRelaySeen, dropRelaySeen, relayDropCounts, relayDropTotalPreAuth, resolveRelayDest, PUB } = bridge
 
 let fails = 0
 const ok = (n, c) => { console.log(`${c ? 'ok  ' : 'FAIL'} — ${n}`); if (!c) fails++ }
@@ -97,6 +97,25 @@ ok('resolveRelayDest rejects empty', resolveRelayDest('') === null)
   // dedup-before-decrypt: replaying the SAME wrap does nothing
   handleRelayIngress(wrap); await tick()
   ok('replaying the same wrap carries nothing new (§6 dedup)', delta().length === 0)
+}
+
+// --- the claim/rollback primitive that makes concurrent delivery safe ----------------------
+// HONEST SCOPE: this suite CANNOT reproduce the concurrency itself. Under WB_STUB_SEND the stub
+// branch marks synchronously — there is no async window — while the bug lives in the execFile
+// callback. A "two relays deliver at once" test written here passes with OR without the fix, so
+// it would be a check that has only ever passed. What IS testable is the primitive: a claim taken
+// at dispatch suppresses a re-entry, and a rollback restores retryability. The concurrency proof
+// is the live run (one wrap must produce exactly one channel post), not this file.
+{
+  const sk = generateSecretKey(); const { wrap, senderPk } = wrapFor(sk, { body: 'claim/rollback' })
+  admit(senderPk); delta()
+  addRelaySeen(wrap.id)
+  handleRelayIngress(wrap); await tick()
+  ok('a claimed wrap is not carried again', delta().filter(e => e.kind === 9 && e.lane === 'relay').length === 0)
+  dropRelaySeen(wrap.id)
+  ok('rollback clears the claim, so a failed send can retry', !relaySeen.has(wrap.id))
+  handleRelayIngress(wrap); await tick()
+  ok('after rollback the same wrap carries exactly once', delta().filter(e => e.kind === 9 && e.lane === 'relay').length === 1)
 }
 
 // --- route() dispatches the branch ------------------------------------------


### PR DESCRIPTION
**Found by the first live use of the relay lane**, not by the suite: one sealed request produced two identical channel posts 423ms apart from a single wrap.

`relaySeen.has(ev.id)` (entry) and `markRelaySeen` (durable) sit on opposite sides of an **async** buzz send. A sender publishes one wrap to N relays; the bridge subscribes to all of them; N copies arrive before the first send returns and each passes the check. **Not a rare race — the normal case on every send.**

Mirrors the return lane's existing answer (#121 finding #2): `addRelaySeen` claims in-memory synchronously at dispatch, `markRelaySeen` persists on success, `dropRelaySeen` rolls back on failure so a failed send still retries.

## On the test, honestly

The suite **cannot reproduce this**. Under `WB_STUB_SEND` the stub branch marks synchronously — no async window — while the bug lives in the `execFile` callback. I wrote the obvious "three relays deliver at once" test first; it **passed against the broken code**. That is a check that has only ever passed, so I discarded it rather than ship it green.

What is tested is the primitive: a claim suppresses re-entry, a rollback restores retryability, and the wrap then carries exactly once. **Negative control run:** breaking `addRelaySeen` fails the first assertion.

The concurrency proof is the live re-run — one wrap, one post — not this file. The suite's scope limit is written into the test as a comment so the next reader does not mistake it for coverage.

Twelve suites green.

Drafted with assistance from [Claude Code](https://claude.com/claude-code)