### PR TITLE
verify-config: surface relay_channels so a rebuild can't drop the relay lane silently (#104)

### DIFF
--- a/deploy/verify-config.sh
+++ b/deploy/verify-config.sh
@@ -94,6 +94,28 @@ if scan_channels or return_lane:
             print("           (%d author-binding(s) are live policy off-repo — a rebuild drops them and" % bound)
             print("            echo-skip falls back to the per-event registry; confirm each is deliberate)")
 
+# ── relay lane (admitted agents inject sealed kind:14 requests): relay_channels ──
+# Same failure class as watch_authors and scan_channels, and it has a valid empty state: the relay
+# lane is fully inert while relay_channels is empty (default-closed), so a box that does not run it
+# is correct with the key absent — which is why this cannot join the hard REQUIRED set above. But
+# config.example.json carries a PLACEHOLDER here (an angle-bracketed string, never a real channel).
+# A rebuild that fills in relays/inbox/watch_authors/approvers and leaves this untouched comes up
+# healthy and drops every relay-ingress request silently: an admitted agent's sealed post is acked
+# ok:false or never routed, with nothing at runtime to notice. So surface it — count when real,
+# and flag loudly when the only thing present is the example placeholder.
+relay_channels = live.get("relay_channels")
+if relay_channels:
+    real = [c for c in relay_channels if isinstance(c, str) and c and "<" not in c]
+    print()
+    print("relay lane (admitted agents inject sealed requests) — live policy the repo cannot hold:")
+    if real:
+        print("  ok       relay_channels %d allowlisted channel(s) — box-side policy a rebuild would drop" % len(real))
+    else:
+        print("  MISSING  relay_channels present but unfilled (example placeholder only) — the relay lane is INERT")
+        print("           (this is what a rebuild from config.example.json lands on; fill in the live")
+        print("            channel(s) or drop the key entirely, but do not ship the placeholder)")
+        fail = 1
+
 print()
 if fail:
     print("FAILED — the bridge will start and route less than you think.")


### PR DESCRIPTION
Continues #104 (live config drifts from the repo), same pattern as #115 which surfaced the return-lane keys.

## Why

`relay_channels` (the relay-ingress allowlist, #122/#124) is a live-only value in the `public` block — `config.json` is gitignored, so the repo has no record of it, exactly like `watch_authors` and `return_lane`. `verify-config.sh` did not check it: it was in neither the hard-`REQUIRED` set nor the "live policy the repo cannot hold" surfacing.

It is **default-closed** — the relay lane is fully inert while `relay_channels` is empty (`bridge.mjs`), so a box that does not run the lane is correct with the key absent. That is why it can't join the hard `REQUIRED` set. But `config.example.json` carries a **placeholder** here. A rebuild that fills in `relays`/`inbox`/`watch_authors`/`approvers` and leaves this untouched comes up healthy and drops every relay-ingress request silently — an admitted agent's sealed post is acked `ok:false` or never routed, with nothing at runtime to notice.

## What

Surface `relay_channels` in the "live policy the repo cannot hold" section:
- **real allowlist** → `ok`, count only (like `return_lane`)
- **present but placeholder-only** (angle-bracketed example value) → `MISSING` + **exit 2**; this is the exact state a rebuild-from-example lands on
- **absent or `[]`** → silent, no relay block — a box legitimately not running the lane

## Validation (states reproduced, not asserted)

| config | result |
|---|---|
| live read-lane config (`relay_channels: ["waggle-test"]`) | `ok  relay_channels 1 allowlisted channel(s)` — exit 0 |
| `config.example.json` (placeholder) | `MISSING relay_channels … INERT` — **exit 2** |
| `relay_channels` absent | no relay block — exit 0 |
| `relay_channels: []` | no relay block — exit 0 |

Full suite green (12/12).

Drafted with assistance from [Claude Code](https://claude.com/claude-code)