### PR TITLE
deploy: pull-based deploy runner so nobody holds standing write to prod (#129)

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -88,6 +88,62 @@ This is the automated form of the manual "sealed tree md5 vs the repo baseline" 
 *Pre-cutover box checks* — prefer this. The regression test `tests/deploy_verify.mjs`
 proves it reports drift on a deliberately stale tree.
 
+## Pull-based deploy runner (#129)
+
+`deploy.sh` is a **push** from the Mac, and a push needs a standing grant on the box that
+can restart the unit as `bridge` — which is also arbitrary execution as `bridge`, i.e. the
+ability to sign as waggle. The deploy path is the last place standing write to production
+hides. `deploy/deploy-runner.sh` inverts it: the **box pulls**. A timer runs the runner;
+it looks for a commit on `main` that CI has marked green, ships that commit into the lane
+tree, records the SHA, and runs `verify-deployed.sh` — refusing loudly on drift. There is
+no inbound credential to the box, so a GitHub compromise is not a production compromise.
+
+```
+sh deploy/deploy-runner.sh read      # /opt/waggle-read
+sh deploy/deploy-runner.sh sealed    # /opt/waggle-sealed
+```
+
+**Authorisation = merged + green.** Nothing here deploys a commit that is not both on
+`main` and passing CI for *that exact SHA* (GitHub check-runs, not the legacy status API).
+To require an explicit human blessing per release, point `WB_REF` at a signed tag instead
+of `origin/main` — a one-line swap, no rebuild.
+
+**Gates the runner keeps** (all covered by `tests/deploy_runner.mjs`, negative controls
+included — a `pending` build waits, a `red` build is refused, an injected post-ship change
+alarms):
+
+- deploys only a CI-green commit; `pending` retries next tick, `failure` refuses and says so
+- never touches `config.json`, `.env` or `data/` — not in the ship list, and no `--delete`.
+  These hold the live-only values (`watch_authors`, `return_lane`, `scan_channels`,
+  `relay_channels` — see #104) a careless deploy would erase.
+- records the deployed SHA to `<tree>/DEPLOYED_SHA` so drift is checkable without a checkout
+- runs `verify-deployed.sh` after every deploy; a mismatch **alarms** (exit 1 / FAILED unit),
+  it never logs-and-passes
+
+### One-time bootstrap (the only privileged step)
+
+The runner removes *standing* write; installing it is a *bounded, one-time* privileged act.
+
+1. **Hub clone** the box pulls into (never a lane tree): `git clone <repo> /opt/waggle-hub`,
+   owned by the deploy identity. The runner only `fetch`es and `checkout --detach`s here.
+2. **Units:** `sudo cp deploy/deploy-runner@.{service,timer} /etc/systemd/system/` then
+   `sudo systemctl daemon-reload`.
+3. **read lane:** `sudo systemctl enable --now deploy-runner@read.timer`. It runs as
+   `bridge`, which already owns `/opt/waggle-read` and holds the scoped `sudo systemctl
+   restart waggle-read.service` grant (`deploy/sudoers-bridge`). No new authority.
+4. **sealed lane — get it off root in the same pass.** `/opt/waggle-sealed` is administered
+   as **root** today; do not deploy it as root. Create a scoped `deploy` user that owns the
+   sealed tree + hub and holds *only* `sudo systemctl restart waggle-sealed.service`, add the
+   drop-in from the unit header (`User=deploy`), then
+   `sudo systemctl enable --now deploy-runner@sealed.timer`. Now neither lane is deployed by
+   root, and no principal holds a general shell on production.
+5. Confirm: `systemctl list-timers 'deploy-runner@*'`.
+
+For a **private** repo, drop a read-only token in `/opt/waggle-hub/deploy-runner.env`
+(`GH_TOKEN=…`, `0600`, never committed) — a read cap, still no write authority on the box.
+
+Nothing arms until it passes a review and a green `verify-deployed.sh` against the box.
+
 ## ⚠ Root-SSH disable is lockout-sensitive
 
 Today the management key lands on root and the sealed unit is administered as root.

--- a/deploy/deploy-runner.sh
+++ b/deploy/deploy-runner.sh
@@ -1,0 +1,159 @@
+#!/bin/sh
+# deploy/deploy-runner.sh — pull-based deploy (issue #129).
+#
+# The inverse of deploy.sh. Instead of an operator PUSHING code to the box over ssh with a
+# standing sudo grant, the BOX PULLS: a timer runs this script, it looks for a commit on
+# main that CI has marked green, deploys that commit into the lane tree, records the SHA,
+# and runs verify-deployed.sh — refusing LOUDLY on drift. No inbound credential to the box,
+# so a GitHub compromise is not a production compromise.
+#
+#   sh deploy/deploy-runner.sh read     # public read lane -> /opt/waggle-read
+#   sh deploy/deploy-runner.sh sealed   # sealed lanes     -> /opt/waggle-sealed
+#
+# Authorisation model: "merged to main + CI green" IS the authorisation. Nothing here can
+# deploy a commit that is not both. To require an explicit human blessing per release,
+# point WB_REF at a signed tag ref instead of origin/main (see README) — one-line swap.
+#
+# Gates (each enforced below, none optional):
+#   - deploy ONLY a commit CI reports success for (green_state)
+#   - NEVER touch config.json, .env or data/ — they are not in the ship list, and rsync has
+#     no --delete. These hold the live-only values (watch_authors, return_lane, scan_channels,
+#     relay_channels — see #104) a careless deploy would erase.
+#   - record the deployed SHA on the box ($TREE/DEPLOYED_SHA) so drift is checkable
+#   - run verify-deployed.sh after every deploy; a mismatch ALARMS (exit 1), never logs-and-passes
+#
+# Exit: 0 = deployed, or nothing to do (already current / not yet green).
+#       1 = a deploy was attempted and post-deploy verification found DRIFT — needs eyes.
+#       2 = usage / environment error (bad lane, missing hub clone).
+#
+# Seams for the test + for the box (default to the real thing; overridable so the unit test
+# needs no network, no systemd, no npm registry):
+#   WB_HUB          hub git clone the box pulls into           (default /opt/waggle-hub)
+#   WB_REF          ref to track                                (default origin/$WB_BRANCH)
+#   WB_BRANCH       branch to fetch                             (default main)
+#   WB_SLUG         owner/repo for the CI query                 (default JAFairweather/waggle)
+#   WB_CI_STATE_CMD `sh -c "<cmd> <sha>"` -> success|failure|pending  (default: GitHub check-runs API)
+#   WB_NPM_CMD      dependency install run inside $TREE         (default: npm ci --omit=dev ...)
+#   WB_RESTART_CMD  `sh -c "<cmd> <unit>"` to restart the lane  (default: sudo systemctl restart)
+#   WB_NO_FETCH=1   skip `git fetch` (test drives the hub directly)
+#   DRY_RUN=1       resolve + gate, then report what WOULD ship; change nothing
+set -eu
+
+LANE="${1:-}"
+case "$LANE" in
+  read)   TREE=/opt/waggle-read;   UNIT=waggle-read.service ;;
+  sealed) TREE=/opt/waggle-sealed; UNIT=waggle-sealed.service ;;
+  *) echo "usage: sh deploy/deploy-runner.sh read|sealed"; exit 2 ;;
+esac
+# test override of the destination tree (guarded: a bare `&&` here would trip `set -e` when
+# WB_TREE is unset — which is every production run).
+if [ -n "${WB_TREE:-}" ]; then TREE="$WB_TREE"; fi
+
+HUB="${WB_HUB:-/opt/waggle-hub}"
+BRANCH="${WB_BRANCH:-main}"
+REF="${WB_REF:-origin/$BRANCH}"
+SLUG="${WB_SLUG:-JAFairweather/waggle}"
+NPM_CMD="${WB_NPM_CMD:-npm ci --omit=dev --no-audit --no-fund}"
+RESTART_CMD="${WB_RESTART_CMD:-sudo systemctl restart}"
+DRY_RUN="${DRY_RUN:-}"
+
+# Ship list — MUST mirror deploy.sh's rsync set and verify-deployed.sh's SHIP. config.json,
+# .env and data/ are absent by construction: not listed, and no --delete. That is the whole
+# no-clobber guarantee, stated in one place.
+SHIP='src tests tools package.json package-lock.json config.example.json'
+
+log() { echo "deploy-runner[$LANE] $*"; }
+alarm() { echo "deploy-runner[$LANE] ALARM: $*" >&2; }
+
+# Default CI-state resolver: GitHub Actions records results as CHECK-RUNS (not legacy commit
+# statuses), so ask the check-runs API for this exact sha and aggregate. Unauthenticated for a
+# public repo (a poll every few minutes is well under the 60/hr limit); a private repo needs a
+# READ-only token in GH_TOKEN — still no write credential on the box. Echoes one word:
+#   success  every check-run completed with conclusion=success (and there was at least one)
+#   failure  a check-run completed non-success  |  pending  none yet, or one still running
+#   error    the API could not be reached / parsed  (caller refuses to deploy on error)
+ci_state_github() {
+  _sha="$1"
+  _url="https://api.github.com/repos/$SLUG/commits/$_sha/check-runs"
+  # Build the optional auth header via positional params so the value ("Authorization: Bearer
+  # <tok>") survives as ONE argument — plain word-splitting would break it at its spaces. _sha
+  # is already saved above, so clobbering $@ here is safe.
+  if [ -n "${GH_TOKEN:-}" ]; then set -- -H "Authorization: Bearer $GH_TOKEN"; else set --; fi
+  _json=$(curl -fsSL -H 'Accept: application/vnd.github+json' "$@" "$_url" 2>/dev/null) \
+    || { echo error; return; }
+  printf '%s' "$_json" | node -e '
+    let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{
+      try{const r=(JSON.parse(s).check_runs)||[];
+        if(!r.length) return console.log("pending");
+        if(r.some(c=>c.status!=="completed")) return console.log("pending");
+        if(r.some(c=>c.conclusion!=="success")) return console.log("failure");
+        console.log("success");
+      }catch(_){console.log("error");}
+    });' 2>/dev/null || echo error
+}
+
+[ -d "$HUB/.git" ] || { echo "  ✗ hub clone not found at $HUB (WB_HUB) — bootstrap it first"; exit 2; }
+
+# --- resolve the candidate commit -------------------------------------------------------
+if [ -z "${WB_NO_FETCH:-}" ]; then
+  git -C "$HUB" fetch --quiet origin "$BRANCH" || { echo "  ✗ git fetch failed"; exit 2; }
+fi
+TARGET_SHA=$(git -C "$HUB" rev-parse "$REF" 2>/dev/null) \
+  || { echo "  ✗ cannot resolve ref $REF in $HUB"; exit 2; }
+SHORT=$(git -C "$HUB" rev-parse --short "$TARGET_SHA")
+DEPLOYED_SHA=$(cat "$TREE/DEPLOYED_SHA" 2>/dev/null || echo none)
+
+log "target $SHORT ($REF); deployed $DEPLOYED_SHA"
+
+if [ "$TARGET_SHA" = "$DEPLOYED_SHA" ]; then
+  log "already current — nothing to do"; exit 0
+fi
+
+# --- green gate: merged is not enough, CI must have passed for THIS sha ------------------
+if [ -n "${WB_CI_STATE_CMD:-}" ]; then
+  STATE=$(sh -c "$WB_CI_STATE_CMD \"$TARGET_SHA\"" 2>/dev/null || echo error)
+else
+  STATE=$(ci_state_github "$TARGET_SHA")
+fi
+case "$STATE" in
+  success) log "CI green for $SHORT" ;;
+  failure) alarm "CI is RED for $SHORT on $BRANCH — refusing to deploy a failing commit"; exit 0 ;;
+  pending) log "CI still running for $SHORT — will retry next tick"; exit 0 ;;
+  *)       alarm "could not determine CI state for $SHORT (got '$STATE') — refusing to deploy blind"; exit 0 ;;
+esac
+
+if [ -n "$DRY_RUN" ]; then
+  log "DRY_RUN — would deploy $SHORT into $TREE; ship list: $SHIP"
+  exit 0
+fi
+
+# --- deploy: check out the exact sha in the hub, ship code-only into the tree ------------
+git -C "$HUB" checkout --quiet --detach "$TARGET_SHA" \
+  || { alarm "could not check out $SHORT in hub"; exit 2; }
+
+log "shipping code into $TREE"
+# From the hub checked out at TARGET_SHA, ship exactly deploy.sh's set (no --delete, so
+# config.json/.env/data on the tree are untouched). Source has no trailing slash, so each
+# dir lands as $TREE/<name>, matching what verify-deployed.sh resolves.
+# shellcheck disable=SC2086  # SHIP is an intentional word list
+( cd "$HUB" && rsync -a $SHIP "$TREE/" ) || { alarm "rsync into $TREE failed — tree may be half-shipped"; exit 1; }
+
+log "installing deps in $TREE"
+( cd "$TREE" && sh -c "$NPM_CMD" ) || { alarm "dependency install failed in $TREE"; exit 1; }
+
+# record the SHA atomically BEFORE restart, so a crash mid-restart still leaves the tree's
+# provenance truthful for the next verify.
+printf '%s\n' "$TARGET_SHA" > "$TREE/DEPLOYED_SHA.tmp" && mv "$TREE/DEPLOYED_SHA.tmp" "$TREE/DEPLOYED_SHA"
+
+log "restarting $UNIT"
+sh -c "$RESTART_CMD \"$UNIT\"" || { alarm "restart of $UNIT failed"; exit 1; }
+
+# --- post-deploy: what is on disk MUST equal git at the sha we shipped -------------------
+log "verifying deployed tree against $SHORT"
+if sh "$HUB/deploy/verify-deployed.sh" "$LANE" "$TREE" "$TARGET_SHA"; then
+  log "deploy OK — $TREE now at $SHORT, verified"
+  exit 0
+else
+  alarm "post-deploy drift at $SHORT — deployed tree does NOT match git; investigate now"
+  exit 1
+fi

--- a/deploy/deploy-runner@.service
+++ b/deploy/deploy-runner@.service
@@ -1,0 +1,52 @@
+# waggle pull-based deploy runner (issue #129), templated per lane: %i = read | sealed.
+# Driven by deploy-runner@.timer. Oneshot: each tick fetches main into the hub clone, and
+# IF a new commit is CI-green, ships it into /opt/waggle-%i, records the SHA, and runs
+# verify-deployed.sh — alarming (FAILED unit) on drift. No inbound credential to the box.
+#
+#   sudo cp deploy/deploy-runner@.{service,timer} /etc/systemd/system/
+#   sudo systemctl daemon-reload
+#   sudo systemctl enable --now deploy-runner@read.timer
+#   # sealed lane: see the drop-in below FIRST, then enable deploy-runner@sealed.timer
+#
+# IDENTITY (the point of #129 — no standing write, scoped per tree):
+#   read   -> runs as 'bridge', which already holds scoped `sudo systemctl restart
+#             waggle-read.service` (deploy/sudoers-bridge) and owns /opt/waggle-read.
+#   sealed -> /opt/waggle-sealed runs as ROOT today; do NOT run its deploy as root. Create a
+#             scoped 'deploy' user that owns the sealed tree + hub and holds ONLY
+#             `sudo systemctl restart waggle-sealed.service`, then add an override so this
+#             instance runs as that user:
+#               /etc/systemd/system/deploy-runner@sealed.service.d/override.conf
+#                 [Service]
+#                 User=deploy
+#                 Group=deploy
+#             Getting sealed off a root deploy path is the same-pass hardening the issue asks
+#             for — landing it here means neither lane is deployed by root.
+#
+# Optional /opt/waggle-hub/deploy-runner.env (0600, NEVER committed) — only needed if the
+# repo is private (a READ-only token, still no write authority on the box):
+#   GH_TOKEN=<read-only PAT>
+[Unit]
+Description=waggle deploy runner (%i lane) — pull a CI-green main and verify
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+User=bridge
+Group=bridge
+WorkingDirectory=/opt/waggle-hub
+Environment=PATH=/usr/local/bin:/usr/bin:/bin
+Environment=WB_HUB=/opt/waggle-hub
+# The env file is optional; '-' means "do not fail if it is absent" (public repo needs none).
+EnvironmentFile=-/opt/waggle-hub/deploy-runner.env
+ExecStart=/bin/sh /opt/waggle-hub/deploy/deploy-runner.sh %i
+# The runner restarts the lane via the scoped `sudo systemctl restart waggle-%i.service`
+# grant, so privilege escalation must be allowed for that one exact command.
+NoNewPrivileges=no
+ProtectHome=yes
+PrivateTmp=yes
+# Writable: the hub clone it fetches/checks out, and the lane tree it ships into. Nothing
+# else — config.json/.env/data inside the tree are never in the ship list, so they are not
+# touched even though the tree is writable.
+ProtectSystem=strict
+ReadWritePaths=/opt/waggle-hub /opt/waggle-%i

--- a/deploy/deploy-runner@.timer
+++ b/deploy/deploy-runner@.timer
@@ -1,0 +1,23 @@
+# Drives deploy-runner@%i.service on a fixed cadence, so "deploy the latest green main" is a
+# property of the INSTALL, not of an operator running a push script. %i = read | sealed.
+#
+#   sudo systemctl enable --now deploy-runner@read.timer
+#   sudo systemctl enable --now deploy-runner@sealed.timer     # after the sealed drop-in
+#   systemctl list-timers 'deploy-runner@*'                    # confirm scheduled
+#
+# Cadence: 3 min. A tick with no new green commit is cheap — one API read and a git fetch,
+# then exit 0 "already current". The window between a merge going green and the box picking
+# it up is at most one cadence plus the jitter.
+[Unit]
+Description=waggle deploy runner (%i lane) — poll for a CI-green main every 3 min
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=3min
+# Jitter so read and sealed (and many installs) do not all hit the GitHub API on the same tick.
+RandomizedDelaySec=45s
+# Catch up one run if the host was down at the scheduled time.
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "start": "node src/bridge.mjs",
     "dryrun": "FORWARD_MODE=dryrun node src/bridge.mjs",
-    "test": "node tests/a1_quarantine.mjs && node tests/a7_deletion.mjs && node tests/lane2_caps.mjs && node tests/nipda_admission.mjs && node tests/render_states.mjs && node tests/deploy_verify.mjs && node tests/return_lane.mjs && node tests/return_lane_scan.mjs && node tests/return_lane_nomiss.mjs && node tests/relay_ingress.mjs && node tests/tripwire_union.mjs && node tests/tripwire_detection.mjs",
+    "test": "node tests/a1_quarantine.mjs && node tests/a7_deletion.mjs && node tests/lane2_caps.mjs && node tests/nipda_admission.mjs && node tests/render_states.mjs && node tests/deploy_verify.mjs && node tests/return_lane.mjs && node tests/return_lane_scan.mjs && node tests/return_lane_nomiss.mjs && node tests/relay_ingress.mjs && node tests/tripwire_union.mjs && node tests/tripwire_detection.mjs && node tests/deploy_runner.mjs",
     "console": "node tools/serve-console.mjs"
   },
   "dependencies": {

--- a/tests/deploy_runner.mjs
+++ b/tests/deploy_runner.mjs
@@ -31,7 +31,10 @@ const work = mkdtempSync(join(tmpdir(), 'wb-runner-'))
 // One hub clone shared across cases (the runner only reads + detaches within it).
 const hub = join(work, 'hub')
 execSync(`git clone --quiet --no-hardlinks "${REPO}" "${hub}"`, { stdio: 'ignore' })
-const TARGET = execSync(`git -C "${hub}" rev-parse origin/main`, { encoding: 'utf8' }).trim()
+// Resolve the target from the clone's HEAD, not origin/main: CI checks the repo out in
+// DETACHED HEAD (no local main branch), so the clone has no origin/main to rev-parse. HEAD
+// is the checked-out commit either way. Pass it explicitly as WB_REF on every run below.
+const TARGET = execSync(`git -C "${hub}" rev-parse HEAD`, { encoding: 'utf8' }).trim()
 
 // Run the runner against a fresh tree. state = CI stub (success|failure|pending); extraEnv
 // lets a case override npm/restart. Returns { code, out, tree, restartMarker }.
@@ -44,6 +47,7 @@ function runCase(state, extraEnv = {}) {
     ...process.env,
     WB_HUB: hub,
     WB_TREE: tree,
+    WB_REF: TARGET,                                    // explicit sha (no origin/main in a CI clone)
     WB_NO_FETCH: '1',                                  // offline: drive the hub as-is
     STUB_CI_STATE: state,
     WB_CI_STATE_CMD: 'echo "$STUB_CI_STATE" #',        // ignore the sha arg (commented out)
@@ -80,7 +84,7 @@ try {
   // deploy on top of the seeded tree
   const keep2 = (() => {
     const restartMarker = join(keep.tree, '.restarted2')
-    const e = { ...process.env, WB_HUB: hub, WB_TREE: keep.tree, WB_NO_FETCH: '1',
+    const e = { ...process.env, WB_HUB: hub, WB_TREE: keep.tree, WB_REF: TARGET, WB_NO_FETCH: '1',
       STUB_CI_STATE: 'success', WB_CI_STATE_CMD: 'echo "$STUB_CI_STATE" #', WB_NPM_CMD: ':',
       WB_RESTART_CMD: `touch "${restartMarker}" #` }
     // force a re-deploy by clearing the recorded sha
@@ -117,7 +121,7 @@ try {
   try {
     out2 = execFileSync('sh', ['-c', `sh "${SCRIPT}" read 2>&1`], {
       cwd: REPO, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'],
-      env: { ...process.env, WB_HUB: hub, WB_TREE: first.tree, WB_NO_FETCH: '1',
+      env: { ...process.env, WB_HUB: hub, WB_TREE: first.tree, WB_REF: TARGET, WB_NO_FETCH: '1',
              STUB_CI_STATE: 'success', WB_CI_STATE_CMD: 'echo "$STUB_CI_STATE" #',
              WB_NPM_CMD: ':', WB_RESTART_CMD: `touch "${first.restartMarker}" #` },
     })
@@ -138,7 +142,7 @@ try {
   try {
     dOut = execFileSync('sh', ['-c', `sh "${SCRIPT}" read 2>&1`], {
       cwd: REPO, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'],
-      env: { ...process.env, WB_HUB: hub, WB_NO_FETCH: '1', DRY_RUN: '1',
+      env: { ...process.env, WB_HUB: hub, WB_REF: TARGET, WB_NO_FETCH: '1', DRY_RUN: '1',
              STUB_CI_STATE: 'success', WB_CI_STATE_CMD: 'echo "$STUB_CI_STATE" #' },
     })
   } catch (e) { dc = e.status ?? 1; dOut = (e.stdout || '') + (e.stderr || '') }

--- a/tests/deploy_runner.mjs
+++ b/tests/deploy_runner.mjs
@@ -1,0 +1,152 @@
+// #129 pull-based deploy runner — regression test for deploy/deploy-runner.sh.
+//
+// Proves the gates the issue names, with NO box: the runner's box-facing actions are seams
+// (CI-state query, npm, systemctl) so the test drives them locally. A real git clone stands
+// in for the on-box hub, and verify-deployed.sh runs for real in local-tree mode — the same
+// check the runner will run on the droplet, only the transport differs.
+//
+// Asserts:
+//   1. green commit  -> deploys: tree gets the code, DEPLOYED_SHA recorded, restart invoked,
+//                       post-deploy verify passes, exit 0
+//   2. config.json / .env / data/ pre-existing on the tree are NEVER touched by a deploy
+//   3. pending CI    -> skips (exit 0, nothing shipped)
+//   4. red CI        -> refuses (exit 0, nothing shipped) — merged is not enough
+//   5. already current -> nothing to do on the second tick (no re-ship, no restart)
+//   6. drift between ship and verify -> ALARM, exit 1 (never logs-and-passes)
+//
+// Run: node tests/deploy_runner.mjs   (exit 0 = pass, 1 = fail)
+
+import { execFileSync, execSync } from 'node:child_process'
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync, existsSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const REPO = join(dirname(fileURLToPath(import.meta.url)), '..')
+const SCRIPT = 'deploy/deploy-runner.sh'
+let failed = 0
+const check = (cond, msg) => { if (!cond) { console.error('  ✗', msg); failed++ } else { console.log('  ✓', msg) } }
+
+const work = mkdtempSync(join(tmpdir(), 'wb-runner-'))
+// One hub clone shared across cases (the runner only reads + detaches within it).
+const hub = join(work, 'hub')
+execSync(`git clone --quiet --no-hardlinks "${REPO}" "${hub}"`, { stdio: 'ignore' })
+const TARGET = execSync(`git -C "${hub}" rev-parse origin/main`, { encoding: 'utf8' }).trim()
+
+// Run the runner against a fresh tree. state = CI stub (success|failure|pending); extraEnv
+// lets a case override npm/restart. Returns { code, out, tree, restartMarker }.
+let caseN = 0
+function runCase(state, extraEnv = {}) {
+  const tree = join(work, `tree-${caseN++}`)
+  mkdirSync(tree, { recursive: true })
+  const restartMarker = join(tree, '.restarted')
+  const env = {
+    ...process.env,
+    WB_HUB: hub,
+    WB_TREE: tree,
+    WB_NO_FETCH: '1',                                  // offline: drive the hub as-is
+    STUB_CI_STATE: state,
+    WB_CI_STATE_CMD: 'echo "$STUB_CI_STATE" #',        // ignore the sha arg (commented out)
+    WB_NPM_CMD: ':',                                   // no registry in the test
+    WB_RESTART_CMD: `touch "${restartMarker}" #`,      // record the restart, ignore unit arg
+    ...extraEnv,
+  }
+  let code = 0, out = ''
+  try {
+    // merge stderr (where alarms go) into the captured output, on success AND failure
+    out = execFileSync('sh', ['-c', `sh "${SCRIPT}" read 2>&1`], { cwd: REPO, env, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] })
+  } catch (e) { code = e.status ?? 1; out = (e.stdout || '') + (e.stderr || '') }
+  return { code, out, tree, restartMarker }
+}
+
+try {
+  // (1) green -> full deploy
+  const g = runCase('success')
+  check(g.code === 0, 'green commit -> exit 0')
+  check(existsSync(join(g.tree, 'src', 'bridge.mjs')), 'green -> code shipped into tree (src/bridge.mjs)')
+  check(existsSync(g.restartMarker), 'green -> unit restart invoked')
+  check(existsSync(join(g.tree, 'DEPLOYED_SHA')), 'green -> DEPLOYED_SHA recorded')
+  check(existsSync(join(g.tree, 'DEPLOYED_SHA')) &&
+        readFileSync(join(g.tree, 'DEPLOYED_SHA'), 'utf8').trim() === TARGET, 'green -> recorded SHA == target')
+  check(/deploy OK/.test(g.out) && /verified/.test(g.out), 'green -> post-deploy verify passed')
+  // config.json / .env / data/ must never appear from a deploy (they are not in the ship list)
+  check(!existsSync(join(g.tree, 'config.json')), 'deploy never creates config.json')
+
+  // (2) live-only files pre-existing on the tree survive a deploy untouched
+  const keep = runCase('success', {})
+  const cfg = join(keep.tree, 'config.json'), env = join(keep.tree, '.env'), data = join(keep.tree, 'data')
+  mkdirSync(data, { recursive: true })
+  writeFileSync(cfg, '{"live":"policy"}'); writeFileSync(env, 'SECRET=1'); writeFileSync(join(data, 'seen.log'), 'a\nb\n')
+  // deploy on top of the seeded tree
+  const keep2 = (() => {
+    const restartMarker = join(keep.tree, '.restarted2')
+    const e = { ...process.env, WB_HUB: hub, WB_TREE: keep.tree, WB_NO_FETCH: '1',
+      STUB_CI_STATE: 'success', WB_CI_STATE_CMD: 'echo "$STUB_CI_STATE" #', WB_NPM_CMD: ':',
+      WB_RESTART_CMD: `touch "${restartMarker}" #` }
+    // force a re-deploy by clearing the recorded sha
+    rmSync(join(keep.tree, 'DEPLOYED_SHA'), { force: true })
+    let code = 0, out = ''
+    try { out = execFileSync('sh', ['-c', `sh "${SCRIPT}" read 2>&1`], { cwd: REPO, env: e, encoding: 'utf8', stdio: ['ignore','pipe','pipe'] }) }
+    catch (x) { code = x.status ?? 1; out = (x.stdout||'')+(x.stderr||'') }
+    return { code, out }
+  })()
+  check(keep2.code === 0, 'deploy over a live tree -> exit 0')
+  check(readFileSync(cfg, 'utf8') === '{"live":"policy"}', 'config.json content untouched by deploy')
+  check(readFileSync(env, 'utf8') === 'SECRET=1', '.env content untouched by deploy')
+  check(readFileSync(join(data, 'seen.log'), 'utf8') === 'a\nb\n', 'data/ content untouched by deploy')
+
+  // (3) pending CI -> skip, ship nothing
+  const p = runCase('pending')
+  check(p.code === 0, 'pending CI -> exit 0 (retry next tick)')
+  check(!existsSync(join(p.tree, 'src')), 'pending -> nothing shipped')
+  check(!existsSync(p.restartMarker), 'pending -> no restart')
+  check(/still running/.test(p.out), 'pending -> reports waiting, not failure')
+
+  // (4) red CI -> refuse, ship nothing
+  const r = runCase('failure')
+  check(r.code === 0, 'red CI -> exit 0 (refuse, do not fail the timer)')
+  check(!existsSync(join(r.tree, 'src')), 'red -> nothing shipped')
+  check(!existsSync(r.restartMarker), 'red -> no restart')
+  check(/RED/.test(r.out), 'red -> alarms that main is red')
+
+  // (5) already current -> no work on the second tick
+  const first = runCase('success')
+  check(first.code === 0 && existsSync(first.restartMarker), 'first deploy succeeded')
+  rmSync(first.restartMarker, { force: true })
+  let out2 = '', code2 = 0
+  try {
+    out2 = execFileSync('sh', ['-c', `sh "${SCRIPT}" read 2>&1`], {
+      cwd: REPO, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'],
+      env: { ...process.env, WB_HUB: hub, WB_TREE: first.tree, WB_NO_FETCH: '1',
+             STUB_CI_STATE: 'success', WB_CI_STATE_CMD: 'echo "$STUB_CI_STATE" #',
+             WB_NPM_CMD: ':', WB_RESTART_CMD: `touch "${first.restartMarker}" #` },
+    })
+  } catch (e) { code2 = e.status ?? 1; out2 = (e.stdout || '') + (e.stderr || '') }
+  check(code2 === 0, 'second tick on same SHA -> exit 0')
+  check(/already current/.test(out2), 'second tick -> "already current"')
+  check(!existsSync(first.restartMarker), 'second tick -> no re-restart')
+
+  // (6) drift between ship and verify -> ALARM, exit 1. Model it by mutating a shipped file
+  // in the NPM step (which runs after rsync, before verify), so the tree no longer matches git.
+  const d = runCase('success', { WB_NPM_CMD: 'printf "\\n// injected drift\\n" >> src/bridge.mjs' })
+  check(d.code === 1, 'post-deploy drift -> exit 1')
+  check(/ALARM/.test(d.out) && /drift/i.test(d.out), 'drift -> ALARM emitted, not a silent pass')
+
+  // (7) WB_TREE unset (every production run) must not trip `set -e` on the override guard.
+  // DRY_RUN so it resolves + gates green, then reports, without writing to the real /opt tree.
+  let dc = 0, dOut = ''
+  try {
+    dOut = execFileSync('sh', ['-c', `sh "${SCRIPT}" read 2>&1`], {
+      cwd: REPO, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'],
+      env: { ...process.env, WB_HUB: hub, WB_NO_FETCH: '1', DRY_RUN: '1',
+             STUB_CI_STATE: 'success', WB_CI_STATE_CMD: 'echo "$STUB_CI_STATE" #' },
+    })
+  } catch (e) { dc = e.status ?? 1; dOut = (e.stdout || '') + (e.stderr || '') }
+  check(dc === 0, 'WB_TREE unset + DRY_RUN -> exit 0 (no set -e trip on the override guard)')
+  check(/DRY_RUN/.test(dOut) && /waggle-read/.test(dOut), 'unset WB_TREE -> tree defaults to /opt/waggle-read')
+} finally {
+  rmSync(work, { recursive: true, force: true })
+}
+
+if (failed) { console.error(`deploy_runner: ${failed} check(s) failed`); process.exit(1) }
+console.log('deploy_runner: all checks passed')


### PR DESCRIPTION
Closes #129.

## Why
`deploy.sh` is a **push** from the Mac, and a push needs a standing grant on the box that can restart the unit as `bridge` — which is arbitrary execution as `bridge`, i.e. the ability to sign as waggle. The deploy path is the last place standing write to production hides. This inverts it the same way §4 dissolved SSH-for-approvals: the **box pulls**.

## What
`deploy/deploy-runner.sh` — a timer runs it; it deploys a commit on `main` **only if CI marked that exact SHA green** (GitHub check-runs, not the legacy status API), records the SHA to `<tree>/DEPLOYED_SHA`, and runs `verify-deployed.sh` — **alarming (exit 1 / FAILED unit) on drift**, never logging-and-passing. No inbound credential to the box, so a GitHub compromise is not a production compromise.

**Authorisation = merged + green.** To require an explicit human blessing per release, point `WB_REF` at a signed tag instead of `origin/main` — a one-line swap, the lever left in your hand.

## Gates (each with a negative control in `tests/deploy_runner.mjs`)
- green deploys · **pending waits** · **red refuses** (merged is not enough)
- `config.json` / `.env` / `data/` are never in the ship list and rsync has no `--delete`, so the live-only values (`watch_authors`, `return_lane`, `scan_channels`, `relay_channels` — #104) a careless deploy would erase are untouched
- records the deployed SHA so drift is checkable without a checkout
- an injected post-ship change **alarms**, exit 1
- a regression guard that `WB_TREE` unset (every prod run) does not trip `set -e`

## Identity — the point of #129
- **read** runs as the existing scoped `bridge` (already owns `/opt/waggle-read` + holds scoped `sudo systemctl restart waggle-read.service`). No new authority.
- **sealed** is administered as **root** today — this gets it off root in the same pass via a drop-in to a scoped `deploy` user (`deploy/README.md` → *One-time bootstrap*). After install, no principal holds a general shell on production.

## Testing
Box-facing actions (CI query, npm, systemctl) are seams, so the suite runs with **no box, no network, no registry**: a real git clone stands in for the hub and `verify-deployed.sh` runs for real in local-tree mode. `npm test` full suite green locally.

**Not for auto-merge** — this is production deploy machinery touching the sealed/root path. It ships through review + my steward sign-off, and nothing arms until a green `verify-deployed.sh` against the box. The one-time unit install is a bounded privileged step (root, one time); the runner is exactly what removes standing write thereafter.

Originating discussion: waggle-test channel (roll-call thread).

Drafted with assistance from [Claude Code](https://claude.com/claude-code)