### PR TITLE
docs: make CLAUDE.md the portable orientation anchor; fix stale runbook pointer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,8 +3,19 @@
 Auto-loaded by Claude Code sessions in this repo. Read it before touching anything.
 
 Host-specific operations — deployment paths, channel ids, how to reach the boxes, how to message
-the crew — are **not** here, because this repo is public. They live in the operator's local
-runbook (`~/.buzz/GUIDES/CLAUDE_OPERATING_RUNBOOK.md` on the maintainer's machine).
+the crew — are **not** here, because this repo is public. They live in the operator's private
+brief, **`~/.buzz/GUIDES/WAGGLE_BRIEF.md`** on the maintainer's machine (which supersedes the older
+`CLAUDE_OPERATING_RUNBOOK.md`).
+
+**If you cannot reach that brief, you are in a limited environment** — e.g. a cloud container with
+only this repo cloned, no `~/.buzz`, no `~/Projects`, no `buzz`/`gh` CLI. That is expected, not
+broken. When it happens:
+- Work the **repo surface** — code, tests, design, and spec/research issues — and land every change
+  as a **PR for the maintainer to merge**. Never push to a live host or restore host privilege.
+- **Do not guess operational procedures** (relay-lane sends, crew contact, deploy). Being unable to
+  check is not permission (`docs/AGENT_BRIEF.md`). Ask the maintainer to paste the brief section you
+  need, or scope your work to what the repo alone supports.
+- `gh` → the GitHub MCP (`list_pull_requests` / `list_issues`) is a fine substitute; say you did it.
 
 ---
 


### PR DESCRIPTION
A fresh session launched in a **cloud container** (only this repo cloned — no `~/.buzz`, no `~/Projects`, no `buzz`/`gh` CLI) found two real gaps:

1. **`CLAUDE.md:7` stale pointer** — still directed operators at `CLAUDE_OPERATING_RUNBOOK.md`, which `WAGGLE_BRIEF.md` superseded on 07-31.
2. **The operational brief is unreachable from a repo-only environment** — it lives in `~/.buzz` and *can't* be committed (host + key material, public repo). So a remote session had no verified crew-contact or deploy procedure, and nothing telling it that's **expected, not broken**.

`CLAUDE.md` is the one doc reachable from every environment, so it becomes the anchor: names `WAGGLE_BRIEF.md` as the private brief, and gives a limited-environment session explicit rules — repo-surface work, PRs only, never guess an operational procedure, never touch a live host, GitHub MCP substitutes for `gh`. The session that surfaced this did all of it correctly by instinct; this writes it down so the next one doesn't have to.

Doc-only. Drafted with assistance from [Claude Code](https://claude.com/claude-code)