### PR TITLE
docs: sync the test-suite count to package.json (13), the count of record

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,13 @@
 name: CI
 
-# Run the test suite on every PR and on pushes to main (issue #38). The four
-# suites — quarantine gating, deletion propagation, lane-2 rate caps, grant
-# admission — plus render/deploy-verify/return-lane are side-effect-free (temp
-# dirs, stubbed sends), so they are safe to run unattended. A visible green
-# check replaces "whoever remembered to run it locally", and is part of the
-# credibility story for a public repo.
+# Run the test suite on every PR and on pushes to main (issue #38). Every suite in
+# the `test` script is side-effect-free (temp dirs, stubbed sends), so they are safe
+# to run unattended. A visible green check replaces "whoever remembered to run it
+# locally", and is part of the credibility story for a public repo.
+#
+# Deliberately no suite count or roster here: package.json's `test` script is the only
+# place that knows it, and a restated count goes stale silently — this one drifted to
+# three different numbers in a day.
 
 on:
   push:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,14 +112,16 @@ that merely ran.** The suite was green through all of them.
 
 ## Tests
 
-`npm test` — ten suites, against the real exported functions with synthetic events. No sockets,
+`npm test` — 13 suites, against the real exported functions with synthetic events. No sockets,
 no production state, no writes outside a temp dir.
 
 quarantine gating · deletion propagation · sealed-lane rate caps · grant admission · message
-rendering · deployed-build verification · return lane · return-lane scan · tripwire union ·
-tripwire detection drill
+rendering · deployed-build verification · return lane · return-lane scan · return-lane no-miss ·
+relay ingress · tripwire union · tripwire detection drill · deploy runner
 
-CI runs them on push and PR. **If a run reports fewer than ten, the branch is on a stale base.**
+CI runs them on push and PR. **If a run reports fewer than 13, the branch is on a stale base.**
+The count of record is the `test` script in `package.json`; a prose count that disagrees with it
+is the prose being wrong.
 
 The rendering suite is the one to read when reviewing: it tests what the bridge **refuses**. A
 hostile note tries to ping the approver, mint an `APPROVED BY` heading, break out of its quote and

--- a/README.md
+++ b/README.md
@@ -101,11 +101,12 @@ against what git says, because a stale build is invisible while every status sur
 
 ## Tests
 
-`npm test` runs seven suites against the **real** exported functions with synthetic events — no
+`npm test` runs 13 suites against the **real** exported functions with synthetic events — no
 sockets, no production state:
 
 quarantine gating · deletion propagation · sealed-lane rate caps · grant admission · message
-rendering · deployed-build verification · the return lane
+rendering · deployed-build verification · return lane · return-lane scan · return-lane no-miss ·
+relay ingress · tripwire union · tripwire detection drill · deploy runner
 
 The rendering suite is the one to read if you are reviewing. It tests what the bridge **refuses**,
 not only what it does: a hostile note tries to ping the approver, mint an `APPROVED BY` heading,

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -120,7 +120,7 @@ in [deploy/README.md](../deploy/README.md).
 - **Publish the agent relay list:** `node tools/publish_relay_list.mjs` (so the identity
   is discoverable).
 - **Admit a participant**, if you want one: `sh tools/grant-setup.sh`.
-- **Run the safety gates before you ship:** `npm test` — six suites driving the real
+- **Run the safety gates before you ship:** `npm test` — 13 suites driving the real
   routing functions with synthetic events (no sockets, no production state), all green.
 
 `waggle-init.mjs --check` rolls the config half of this into one readiness verdict; the


### PR DESCRIPTION
## What

`npm test` runs **13** suites. Nothing else in the repo agreed — and the disagreements pointed in three different directions.

| Site | Said | Now |
|---|---|---|
| `package.json` | **13** — ground truth | unchanged |
| `CLAUDE.md` | ten | 13 |
| `README.md` | seven | 13 |
| `docs/GETTING_STARTED.md` | six | 13 |
| `.github/workflows/ci.yml` | "The four suites … plus render/deploy-verify/return-lane" | count removed |

Ground truth is firm in both directions: **13 files in `tests/`, 13 invoked by the `test` script, and they are the same set** — no orphan file, no phantom invocation.

## Why this isn't pedantry

`CLAUDE.md` makes the count load-bearing:

> **If a run reports fewer than ten, the branch is on a stale base.**

That is a stale-base detector calibrated to the wrong number. It would have sat quiet through a branch missing three suites — exactly the failure mode this repo already names: *an alarm that always fires and one that never fires fail identically.* Syncing the number is the point; the roster is the follow-on.

The prose rosters had also never picked up three suites, so they've been added: **return-lane no-miss · relay ingress · deploy runner.**

`ci.yml`'s comment drops its count and roster entirely rather than restating them — nothing in that file needs to know the number, and a comment that repeats it is one more thing to go stale.

## The real fix — your call, not mine

Syncing five sites by hand is a fix with a shelf life. **This drifted to five different values in a day**, which is what a restated constant does. Two candidate fixes, and I'd rather you pick than have me pick for you:

**A. Docs stop stating the number.** Every prose site says "the suites in `package.json`'s `test` script" and links there. One source, structurally impossible to drift.
*Cost:* a reader can't see the count without opening `package.json`, and the stale-base heuristic loses its concrete number — it becomes "compare against the script" rather than "fewer than 13 is wrong."

**B. CI asserts the count.** A step that counts `tests/*.mjs`, counts the invocations in the `test` script, and counts what the docs claim — failing if any disagree. Drift becomes a red check rather than a thing someone notices months later.
*Cost:* a little more CI surface, and it needs a negative-control run to be worth anything — per this repo's own rule, an assertion that has only ever passed proves nothing.

**My recommendation: B, with A for the two narrative sites.** B is the one that actually holds, because it fails loudly instead of relying on the next person to look; the stale-base line in `CLAUDE.md` genuinely wants a concrete number, and B is what keeps that number honest. A alone would quietly delete the detector rather than fix it. Happy to build either — say the word and I'll open it as its own issue and PR.

I've deliberately not implemented either here. This PR is the sync only, so it stays reviewable at a glance.

## Verification

- `npm test` → **exit 0, 13/13 suites green, 171 checks** on this branch.
- Multiline sweep for restated counts across the repo → only the three intended sites remain, all reading 13. (My first sweep was line-based and **missed** the `ci.yml` comment, because "The four / suites" was split across lines; I found that one by reading, then re-swept multiline. Flagging it because a search that already failed once shouldn't be quoted as clean evidence without saying so.)
- `docs/SPEC_EXTERNAL.md` is generated and states no suite count — deliberately untouched.

### One thing worth knowing, not a repo bug

On a bare container, `npm test` initially failed 11 checks in `deploy_runner` — every failing check was a "proceed and deploy" path, every refusal path passed. Cause: **`rsync` is not installed**, and the runner correctly alarmed (`ALARM: rsync into … failed — tree may be half-shipped`, exit 1) rather than passing silently. With `rsync` installed, 13/13 green.

Worth noting because a deploy runner that refuses everything scores 16/27 and *looks* mostly fine. CI's `ubuntu-latest` has `rsync`, so this never shows there — but it's an undeclared host dependency for anyone running the suite locally. Say the word and I'll file it; I haven't, to keep this PR to one thing.

## Notes

- Docs-only plus one CI comment. No source, no behaviour, no host touched.
- No preceding issue, against the issues-first rule in `CLAUDE.md` — this was assigned directly in-session. Happy to file one retroactively if you want the trail intact.

---

Drafted with assistance from [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pj7AyMK4XPsib7tdR8P8JB)_