### PR TITLE
security: verify what the lane trusts, and stop serving the key over HTTP

### DIFF
--- a/console/index.html
+++ b/console/index.html
@@ -247,6 +247,14 @@ const toHex = (v) => {
   throw new Error(`That does not look like a key. Paste an npub (starts with npub1…), or a 64-character hex key. Got: ${s || '(nothing)'}`)
 }
 const short = (h) => h ? `${h.slice(0, 8)}…${h.slice(-4)}` : '?'
+// Everything a grant carries is chosen by whoever SIGNED it, and the grantor key is typed into
+// this page by the operator — inspecting a stranger's key is a supported thing to do here ("who
+// has access by this key"), so "signed" is not "trusted". A `p` or `da-cap` tag holding markup
+// would otherwise be written straight into the table by innerHTML, on the one page that holds a
+// live signing session. Verifying a signature proves who wrote a value, never that it is safe to
+// render.
+const esc = (s) => String(s ?? '').replace(/[&<>"']/g, c =>
+  ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]))
 
 // One relay. Reports whether it actually answered — a refusal is not an absence, and a count
 // built on silent failures would misreport "nobody is admitted".
@@ -290,16 +298,16 @@ function renderRows() {
   }
   rows.innerHTML = lastGrants.map(g => `
       <tr>
-        <td class="who">${short(g.grantee)}</td>
+        <td class="who">${esc(short(g.grantee))}</td>
         <td><span class="pill ${g.live ? 'live' : 'revoked'}">${g.live ? 'Active' : 'Removed'}</span></td>
-        <td>${capLabel(g.cap)}</td>
+        <td>${esc(capLabel(g.cap))}</td>
         <td>${g.scopeLabel === 'opaque'
               ? `<span title="This approval names its channel as a salted hash, so a passer-by cannot tell which one it is. Enter the channel above and it will resolve.">Hidden</span>`
               : g.scopeLabel}</td>
         <td>${new Date(g.at * 1000).toISOString().slice(0, 16).replace('T', ' ')}</td>
         <td class="who">${short(g.id)}</td>
         <td>${g.live && signer && signerPk === lastGrantor
-            ? `<button class="btn ghost" style="margin:0;padding:5px 12px;font-size:12.5px" onclick="__revoke('${g.id}','${short(g.grantee)}')">Revoke</button>`
+            ? `<button class="btn ghost" style="margin:0;padding:5px 12px;font-size:12.5px" onclick="__revoke('${esc(g.id)}','${esc(short(g.grantee))}')">Revoke</button>`
             : ''}</td>
       </tr>`).join('')
 }

--- a/deploy/verify-deployed.sh
+++ b/deploy/verify-deployed.sh
@@ -76,8 +76,14 @@ case "$DEST_KIND" in
   remote)
     # stderr is NOT swallowed: it carries the ssh failure, the host-key prompt, and the remote
     # shell's own complaint. Hiding it is how "cannot reach the box" becomes "exited 3".
-    if ! ssh "$DEST" "$REMOTE_SCAN" > "$ACT"; then
-      RC=$?
+    # `RC=$?` inside `if ! ssh …; then` reads the status of the NEGATION, which is 0 whenever the
+    # branch is taken — so every failure reported "exit 0" and the two diagnoses below (tree
+    # missing, host unreachable) could never fire. Capture the real status with `|| RC=$?`, which
+    # also keeps `set -e` from killing the script before we can explain what went wrong. Same
+    # family as the pipeline `$?` trap in CLAUDE.md's verification discipline.
+    RC=0
+    ssh "$DEST" "$REMOTE_SCAN" > "$ACT" || RC=$?
+    if [ "$RC" -ne 0 ]; then
       case "$RC" in
         3) echo "  ✗ deployed tree $TREE does not exist on $DEST" ;;
         255) echo "  ✗ could not reach $DEST over ssh — check the host, the alias, or your key" ;;

--- a/src/bridge.mjs
+++ b/src/bridge.mjs
@@ -443,7 +443,11 @@ function l2Drop(reason, plane, ev) {
 }
 // Plane + global gate. Returns false (and logs) when the event must not fan out at all.
 function l2PlaneOk(plane, ev, nowMs) {
-  if (JSON.stringify(ev).length > L2.perPlane.maxEventBytes) { l2Drop('size', plane, ev); return false }
+  // byteLength, not .length: the cap is named maxEventBytes and every other size gate here
+  // (public content, relay wrap, relay body) measures bytes. String .length counts UTF-16 code
+  // units, so non-ASCII content sails past a cap it should have hit — the one lane where the
+  // measure disagreed with the name.
+  if (Buffer.byteLength(JSON.stringify(ev)) > L2.perPlane.maxEventBytes) { l2Drop('size', plane, ev); return false }
   const boot = l2BootRemaining > 0
   const mins = slide(l2PlaneMin.get(plane) || [], nowMs, 60_000)
   if (!boot && mins.length >= L2.perPlane.postsPerMinute) { l2Drop('plane-per-min', plane, ev); return false }
@@ -650,17 +654,37 @@ function relayDropTotalPreAuth() {
 // markdown/mention/link characters are stripped and the length capped before use.
 const nameCache = new Map() // pubkey -> { name: string|null, ts }
 const NAME_TTL_MS = 3600_000
+// Bounded like every other in-memory store here (rlDropLogged, seen, relaySeen). The TTL only
+// decides when an entry is re-fetched, never when it leaves — so without a cap the map grows one
+// entry per distinct author ever reposted, on a process meant to run for months. Insertion-ordered
+// eviction, same shape as rlDropOnce.
+const NAME_CACHE_CAP = Number(process.env.NAME_CACHE_CAP || 5000)
+function cacheName(pubkey, name) {
+  nameCache.set(pubkey, { name, ts: Date.now() })
+  if (nameCache.size > NAME_CACHE_CAP) nameCache.delete(nameCache.keys().next().value)
+}
 function fetchProfileName(pubkey) {
   const hit = nameCache.get(pubkey)
   if (hit && Date.now() - hit.ts < NAME_TTL_MS) return Promise.resolve(hit.name)
   return new Promise(res => {
     let best = null, open = PUB.relays.length, done = false
-    const finish = () => { if (done) return; done = true; nameCache.set(pubkey, { name: best, ts: Date.now() }); res(best) }
+    // Sockets are tracked and closed by finish() — matching fetchEventById. Closing only in bye()
+    // left every socket of a relay that never answers open FOREVER when the 2s timeout won the
+    // race, which is exactly the case the timeout exists for.
+    const socks = []
+    const finish = () => {
+      if (done) return
+      done = true
+      for (const w of socks) { try { w.close() } catch { /* already closed */ } }
+      cacheName(pubkey, best)
+      res(best)
+    }
     if (!open) return finish()
     const t = setTimeout(finish, 2000)
     for (const url of PUB.relays) {
       let ws
       try { ws = new WebSocket(url) } catch { if (--open === 0) { clearTimeout(t); finish() } continue }
+      socks.push(ws)
       const bye = () => { try { ws.close() } catch { /* closed */ } if (--open === 0) { clearTimeout(t); finish() } }
       ws.on('open', () => ws.send(JSON.stringify(['REQ', 'nm', { kinds: [0], authors: [pubkey], limit: 1 }])))
       ws.on('message', d => {
@@ -796,6 +820,24 @@ async function forwardPublic(ev, why, dest, quarantine) {
 
 function routePublic(ev) {
   if (!ev || !ev.id || ev.kind !== 1 || seen.has(ev.id)) return
+  // Signature verification is MANDATORY, and it comes BEFORE the trust classification below —
+  // because that classification reads `ev.pubkey`, which is just a claim until the signature
+  // proves it. A relay is not a trusted party: the lane holds open REQs to several public ones,
+  // and ONE hostile or compromised relay is enough to serve a note that says whatever it likes
+  // under a watched author's key. Unverified, the highest-trust paths were the unguarded ones —
+  // 'mirrored feed' and 'granted participant' route STRAIGHT to the community channel, skipping
+  // the quarantine a stranger gets, and a granted author additionally earns live @mentions
+  // (liveRefs below), so a forgery could summon the room. The release path already verified
+  // (handleCommand), and so did routeDelete and processGrantEvent; this path did not, which
+  // inverted the gradient — the more we trusted an identity, the less we checked it.
+  // markSeen so the same forgery re-served by another relay is dropped cheaply.
+  let okSig = false
+  try { okSig = verifyEvent(ev) } catch { okSig = false }
+  if (!okSig) {
+    err(`PUBLIC drop[bad-signature]: kind1 ${ev.id.slice(0, 12)}… claims ${String(ev.pubkey || '?').slice(0, 12)}…`)
+    if (FORWARD_MODE === 'buzz') markSeen(ev.id)
+    return
+  }
   // A1: classify by TRUST, not just by match. An allowlisted watched author is trusted; a
   // reply from anyone else is an untrusted stranger and is quarantined.
   const trusted = PUB.authors.includes(ev.pubkey)

--- a/tests/a1_quarantine.mjs
+++ b/tests/a1_quarantine.mjs
@@ -5,6 +5,12 @@
 // community channel, while an allowlisted watched author is trusted straight to the inbox,
 // and an unrelated stranger note is dropped entirely.
 //
+// Also proves the gate that guards all three: a note whose SIGNATURE does not hold is dropped
+// before any of that classification runs. `ev.pubkey` is only a claim until the signature backs
+// it, and the trust tiers are keyed on exactly that field — so an unverified note wearing a
+// watched author's key would take the MOST trusted path in the file. The relays are not trusted
+// parties; one hostile relay is enough to serve such a note.
+//
 // Side-effect-free: FORWARD_MODE=dryrun (no network send, no markSeen, no watermark bump)
 // and SEEN_PATH / PUB_WATERMARK_PATH redirected to a throwaway temp dir, so it touches no
 // production dedup state. Drives the REAL exported routePublic — not a copy.
@@ -14,6 +20,7 @@
 import { mkdtempSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { finalizeEvent, generateSecretKey, getPublicKey } from 'nostr-tools/pure'
 
 const tmp = mkdtempSync(join(tmpdir(), 'wb-a1-'))
 process.env.WB_NO_BOOT = '1'            // import without opening any relay socket
@@ -26,12 +33,20 @@ const { routePublic, PUB } = await import('../src/bridge.mjs')
 // Ground the test in the live config so a config drift (e.g. staging removed) fails it.
 const COMMUNITY = PUB.inbox                 // real community channel
 const STAGING = PUB.staging                 // real quarantine channel
-const WATCHED_AUTHOR = PUB.authors[0]       // allowlisted (trusted)
 const WATCHED_NOTE = PUB.events[0]          // one of our own published notes
-const STRANGER = 'f'.repeat(64)             // a key on nobody's allowlist
 
 if (!STAGING) { console.error('FAIL: no staging channel configured — A1 default-closes to HOLD, cannot demo quarantine'); process.exit(1) }
-if (!WATCHED_AUTHOR || !WATCHED_NOTE) { console.error('FAIL: config missing watch_authors/watch_events'); process.exit(1) }
+if (!PUB.authors.length || !WATCHED_NOTE) { console.error('FAIL: config missing watch_authors/watch_events'); process.exit(1) }
+
+// The AUTHORS, unlike the channels, are generated rather than read from config: routePublic now
+// demands a valid signature, and only a key we hold can produce one. So the test mints its own
+// watched author and admits it to the mirrored-feed tier for the duration of the run. The config
+// grounding above still fails on drift; what moves here is only who signs.
+const watchedSk = generateSecretKey()
+const WATCHED_AUTHOR = getPublicKey(watchedSk)
+const strangerSk = generateSecretKey()
+const STRANGER = getPublicKey(strangerSk)
+PUB.authors.push(WATCHED_AUTHOR)
 
 // Capture everything the module logs while routing.
 let buf = ''
@@ -39,41 +54,50 @@ const cap = (c => (...a) => { buf += a.join(' ') + '\n' })()
 console.log = cap
 console.error = cap
 
-// Pad on the RIGHT: the bridge logs a note's id truncated to its first 12 chars, so the
-// distinguishing digit must live at the FRONT or every synthetic id collapses to one string.
-const hexId = n => String(n).padEnd(64, '0')
-const note = (over) => ({ id: hexId(over.n), kind: 1, pubkey: STRANGER, tags: [], content: 'hi', created_at: Math.floor(Date.now() / 1000), ...over })
+const note = (sk, over) => finalizeEvent({
+  kind: 1, tags: [], content: 'hi', created_at: Math.floor(Date.now() / 1000), ...over,
+}, sk)
 
 // Case A — allowlisted watched author posts. Trusted → community inbox, NOT quarantined.
-routePublic(note({ n: 1, pubkey: WATCHED_AUTHOR, content: 'watched-author note' }))
+const a = note(watchedSk, { content: 'watched-author note' })
+routePublic(a)
 // Case B — UNKNOWN key replies (#e) to one of our notes. Untrusted → STAGING.
-routePublic(note({ n: 2, pubkey: STRANGER, tags: [['e', WATCHED_NOTE]], content: 'stranger reply' }))
+const b = note(strangerSk, { tags: [['e', WATCHED_NOTE]], content: 'stranger reply' })
+routePublic(b)
 // Case C — unknown key, no #e to a watched note, not a watched author. Dropped (no route).
-routePublic(note({ n: 3, pubkey: STRANGER, tags: [['e', hexId(999)]], content: 'unrelated stranger' }))
+const c = note(strangerSk, { tags: [['e', 'd'.repeat(64)]], content: 'unrelated stranger' })
+routePublic(c)
+// Case D — FORGERY. A note genuinely signed by the stranger, then re-labelled with the watched
+// author's key. JSON round-trip because that is how a relay delivers it — and because nostr-tools
+// memoises a verification result on the object itself, so a spread copy would carry the original's
+// verdict and the forgery would appear to verify. On the wire there is no such shortcut.
+const d = JSON.parse(JSON.stringify({ ...note(strangerSk, { content: 'forged: I never wrote this' }), pubkey: WATCHED_AUTHOR }))
+routePublic(d)
 
 const out = buf
-const restore = () => { /* process exits right after; no need to restore */ }
-restore()
-
 const line = (sub) => out.split('\n').filter(l => l.includes(sub))
-const has = (sub) => out.includes(sub)
-const idlog = (n) => hexId(n).slice(0, 12) // how the bridge prints a note's id (truncated)
+const idlog = (ev) => ev.id.slice(0, 12) // how the bridge prints a note's id (truncated)
 
 let pass = true
 const check = (cond, label) => { console.info(`${cond ? 'ok  ' : 'FAIL'} — ${label}`); if (!cond) pass = false }
 
 // Case A: routed to the community inbox, labelled inbox (not STAGING).
-check(line(idlog(1)).some(l => l.includes(`-> inbox ${COMMUNITY}`)),
+check(line(idlog(a)).some(l => l.includes(`-> inbox ${COMMUNITY}`)),
   `allowlisted watched author -> community inbox (${COMMUNITY.slice(0, 8)})`)
 // Case B: routed to STAGING, and specifically the id-2 event went there.
-check(line(idlog(2)).some(l => l.includes(`-> STAGING ${STAGING}`)),
+check(line(idlog(b)).some(l => l.includes(`-> STAGING ${STAGING}`)),
   `unknown-key reply -> STAGING (${STAGING.slice(0, 8)})`)
 // Case B, the load-bearing negative: the stranger reply NEVER hit the community inbox.
-check(!line(idlog(2)).some(l => l.includes(`-> inbox ${COMMUNITY}`)),
+check(!line(idlog(b)).some(l => l.includes(`-> inbox ${COMMUNITY}`)),
   `unknown-key reply NEVER reaches community inbox`)
 // Case C: unrelated stranger note produced no PUBLIC routing line at all.
-check(!line(idlog(3)).some(l => l.includes('PUBLIC')),
+check(!line(idlog(c)).some(l => l.includes('PUBLIC')),
   `unrelated stranger note -> dropped (no route)`)
+// Case D: the forgery is refused, by name, and lands NOWHERE.
+check(line(idlog(d)).some(l => l.includes('drop[bad-signature]')),
+  `forged note wearing a watched author's key -> dropped, and said so`)
+check(!line(idlog(d)).some(l => l.includes(`-> inbox ${COMMUNITY}`) || l.includes(`-> STAGING ${STAGING}`)),
+  `forged note reaches NEITHER the community inbox NOR staging`)
 
 console.info(pass ? '\nA1 PASS — quarantine gate holds' : '\nA1 FAIL')
 process.exit(pass ? 0 : 1)

--- a/tests/deploy_runner.mjs
+++ b/tests/deploy_runner.mjs
@@ -27,6 +27,17 @@ const SCRIPT = 'deploy/deploy-runner.sh'
 let failed = 0
 const check = (cond, msg) => { if (!cond) { console.error('  ✗', msg); failed++ } else { console.log('  ✓', msg) } }
 
+// The runner ships with rsync, so without it every deploy-path case fails — eleven red checks
+// that read as eleven regressions and are really one missing binary. Say which it is: exit 3 =
+// INCONCLUSIVE, the same signal tripwire.mjs and verify-firewall.sh use. NOT an all-clear, and
+// not a pass — a suite that cannot run must never look like a suite that ran.
+try { execFileSync('sh', ['-c', 'command -v rsync'], { stdio: 'ignore' }) }
+catch {
+  console.error('deploy_runner: INCONCLUSIVE — rsync is not installed, so the deploy path cannot be')
+  console.error('  exercised at all. This is NOT an all-clear. Install rsync and re-run.')
+  process.exit(3)
+}
+
 const work = mkdtempSync(join(tmpdir(), 'wb-runner-'))
 // One hub clone shared across cases (the runner only reads + detaches within it).
 const hub = join(work, 'hub')

--- a/tools/serve-console.mjs
+++ b/tools/serve-console.mjs
@@ -10,21 +10,37 @@
 // your own machine, nobody else gets a vote.
 import { createServer } from 'node:http'
 import { readFile } from 'node:fs/promises'
-import { extname, join, normalize, dirname, resolve } from 'node:path'
+import { extname, join, normalize, dirname, resolve, sep } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+// The document root is console/, NOT the repo. Serving the repo put `.env` — the file holding the
+// one private key waggle owns — and `config.json` on a listening socket, at 200, in full. Loopback
+// bound it to this machine, which is not the same as bounding it to this PERSON: any local process
+// could read it, and a browser pointed at a hostile page can be walked onto 127.0.0.1 by DNS
+// rebinding. That silently undid the `0600` the README leans on. console/ is the only thing this
+// server exists to hand out; everything else was reach it never needed.
+const DOCROOT = resolve(ROOT, 'console')
 const PORT = Number(process.env.PORT || 8080)
 const TYPES = { '.html': 'text/html; charset=utf-8', '.mjs': 'text/javascript; charset=utf-8',
   '.js': 'text/javascript; charset=utf-8', '.css': 'text/css', '.json': 'application/json', '.svg': 'image/svg+xml' }
 
 createServer(async (req, res) => {
-  let url = (req.url || '/').split('?')[0]
-  if (url === '/' || url === '/console' || url === '/console/') url = '/console/index.html'
-  // Refuse to climb out of the repo, however the path is spelled.
-  const rel = normalize(decodeURIComponent(url)).replace(/^(\.\.[/\\])+/, '')
-  const file = join(ROOT, rel)
-  if (!file.startsWith(ROOT)) { res.writeHead(403); return res.end('forbidden') }
+  const url = (req.url || '/').split('?')[0]
+  // Decode first, so a percent-encoded separator cannot hide from the normalisation below. A
+  // malformed escape throws here rather than rejecting inside the handler and hanging the request.
+  let decoded
+  try { decoded = decodeURIComponent(url) } catch { res.writeHead(400); return res.end('bad request') }
+  // Refuse to climb out, however the path is spelled — normalise, then drop any leading `../`.
+  let rel = normalize(decoded).replace(/^(\.\.[/\\])+/, '')
+  // The console is published at /console/ but its files ARE the document root, so the prefix is
+  // stripped after normalisation (never before — `/console/../..` must collapse first).
+  if (rel === '/' || rel === '/console' || rel === '/console/') rel = '/index.html'
+  else if (rel.startsWith('/console/')) rel = rel.slice('/console'.length)
+  const file = join(DOCROOT, rel)
+  // The trailing separator matters: a bare prefix test also accepts a SIBLING whose name merely
+  // starts with the same characters (console-backup/), which is not the directory we vouched for.
+  if (file !== DOCROOT && !file.startsWith(DOCROOT + sep)) { res.writeHead(403); return res.end('forbidden') }
   try {
     const body = await readFile(file)
     res.writeHead(200, { 'Content-Type': TYPES[extname(file)] || 'application/octet-stream', 'Cache-Control': 'no-store' })


### PR DESCRIPTION
A review pass over the repo. Three are security defects where a stated guarantee was not the one actually in force; the rest are correctness. Every claim below was reproduced before it was fixed, and both new gates were watched failing on purpose.

**Rebased on `73b57d5` and one section dropped — worth reading first.** My initial push carried a doc fix syncing the test-suite count. That work was already merged as **#138**, which caught two files I had missed (`GETTING_STARTED.md`, `ci.yml`). I could not see it: the clone this session was given was stale at `2131e52` while `main` was three commits ahead, and `list_pull_requests --state open` correctly returned nothing because the work was *merged*, not open. Checking open PRs is not sufficient when the base itself is stale — the branch has been rebased and my redundant doc edits dropped, with `git diff origin/main -- CLAUDE.md README.md docs/ .github/` confirmed empty so nothing of #138's is reverted.

**Deviation from issues-first, stated up front:** these findings had no issues, because the review produced them. Each section is written to lift into one.

## Security

### 1. The public lane never verified a signature (`routePublic`)

Every trust decision on the public read lane keys on `ev.pubkey` — and that field is only a *claim* until a signature backs it. `routePublic` classified and reposted without ever calling `verifyEvent`.

The lane holds open REQs to five public relays. **One** hostile or compromised relay is enough to serve a note under a watched author's key. That note took the `mirrored feed` path: straight to the community channel, skipping the quarantine an actual stranger gets. Under a *granted* participant's key it also earned `liveRefs: true`, so the forgery could summon the room with live `@mentions`.

What makes this a gradient inversion rather than a simple omission: `routeDelete` verifies (mandatory), `processGrantEvent` verifies, and the quarantine-*release* path in `handleCommand` verifies. Only the two highest-trust entry paths did not. The more an identity was trusted, the less it was checked.

Reproduced before fixing — a note genuinely signed by an unrelated key, relabelled with a watched author's pubkey and JSON round-tripped the way a relay delivers it:

```
verifyEvent(forged) = false   <-- as the wire delivers it
PUBLIC[dryrun] -> inbox <community>: kind1 cb5acbc92d69… (mirrored feed) :: "FORGED: I never wrote this"
```

Fixed by verifying before classification, with the drop logged by reason per the A6 no-silent-drop rule, and `markSeen` so the same forgery re-served by another relay is cheap.

*For whoever reviews the test:* nostr-tools memoises a verification verdict on the event object, so an object-spread copy inherits the original's "verified" answer and a forgery appears to pass. My first proof-of-concept was wrong for exactly that reason. The wire has no such shortcut, so both the PoC and the new test case round-trip through JSON. Worth knowing before writing any other signature test here.

### 2. `npm run console` served the bridge's own key over HTTP

`serve-console.mjs` used the repo as its document root, so the tool whose entire promise is *"here is exactly what you are about to sign"* also answered `GET /.env` with `BUZZ_PRIVATE_KEY`, at 200, in full — plus `config.json`. Confirmed by cold read-back against a canary `.env`, not inferred.

**This was never a git problem.** `.env` is gitignored and has never existed in any commit on any branch — verified across all 82 commits and 202 blobs. The exposure was a running process on the box handing out a file that is correctly kept out of the repo. Loopback binding bounds it to the *machine*, not to the *person*: any local process can read it, which silently undoes the `0600` the README leans on, and DNS rebinding reaches a loopback server with no Host check from a browser.

Document root is now `console/`. Verified after the change:

| path | before | after |
|---|---|---|
| `/.env`, `/config.json`, `/package.json`, `/src/bridge.mjs` | 200 | 404 |
| `/../.env`, `/%2e%2e/.env`, `/console/../.env` | 404 | 404 |
| `/`, `/console/`, `/console/index.html`, `/console/vendor/*.mjs` | 200 | 200 |

**Residual, not fixed here:** no `Host` header check, so DNS rebinding can still reach the console page. That is now a page with no secrets on it, which is why I stopped at the doc root rather than widening the change.

### 3. Console rendered grant tag values into `innerHTML` unescaped

`da-cap` and the `p` (grantee) tag were interpolated raw, including inside a single-quoted `onclick`. The console verifies signatures before rendering — but verifying a signature proves *who wrote* a value, never that it is *safe to render*. And "who has access by this key" invites the operator to paste in a **stranger's** grantor key, so signed ≠ trusted here. The payload would land on the one page holding a live signing session.

Escaped at the interpolation points. Low severity — it needs a grant signed by a key you chose to inspect — but the fix is six lines on the highest-consequence page in the repo.

## Correctness

- **`verify-deployed.sh` — both remote diagnoses were dead code.** `RC=$?` inside `if ! ssh …; then` reads the status of the *negation*, which is `0` whenever the branch is taken. So the exit-3 (tree missing) and exit-255 (unreachable) messages could never fire, and every real failure printed `remote scan failed (exit 0)`. Same family as the pipeline-`$?` trap in `CLAUDE.md`. Confirmed both ways in a scratch script.
- **Lane-2 size gate measured the wrong unit.** `JSON.stringify(ev).length` counts UTF-16 code units against a cap named `maxEventBytes`; the other three size gates use `Buffer.byteLength`. Non-ASCII content sailed past a cap it should have hit.
- **`nameCache` was unbounded.** The TTL decides when an entry is *re-fetched*, never when it *leaves* — one entry per distinct author ever reposted, on a process meant to run for months. Capped with insertion-ordered eviction, the same shape as `rlDropOnce`.
- **`fetchProfileName` leaked sockets.** Closed only in `bye()`, so a relay that never answers left its socket open forever precisely when the 2s timeout won the race — the case the timeout exists for. Now closed in `finish()`, matching `fetchEventById`.

## Tests

- **`a1_quarantine` now signs its fixtures.** It previously routed unsigned synthetic notes, which is what let the missing verification stay invisible. It mints its own keypairs (only a key we hold can sign) while keeping the channel grounding that catches config drift, and adds the forgery as a negative control.
- **`deploy_runner` reports INCONCLUSIVE (exit 3) when `rsync` is absent.** It previously produced eleven red checks that read as eleven regressions and were really one missing binary — I lost a cycle to exactly that. Matches the `tripwire.mjs` / `verify-firewall.sh` convention: could-not-check is not fine, and is not a pass either.

## Verification

- `npm test` — **exit 0**, and 13/13 suites also pass when run individually, on the rebased branch. Baseline before any change was 13/13 green, so the suite state is unchanged, not merely still-passing.
- **Both new gates watched failing on purpose.** With the signature check disabled, `a1_quarantine` fails on exactly the two forgery assertions and names them. With `rsync` hidden from `PATH`, `deploy_runner` exits 3 with its INCONCLUSIVE message. An alarm that has only ever passed proves nothing.
- **The console server was tested against live HTTP**, not read — the table above is `curl` status codes, and the `.env` body was checked for the canary before and after.
- `sh -n` clean on all eight shell scripts; the console module syntax-checks and its escaping was exercised against `<img onerror>` and an attribute-breakout payload.
- **Behaviour deliberately unchanged:** no lane semantics, no gate thresholds, no config schema, no wire format. The signature check is the one behavioural change, and it only ever removes events that were never authentic. Cost is one schnorr verification per public note, on a lane capped at 200/hour.

**Not touched, and visible from here:** `waggle-sealed` still runs as root and the bridge key still doubles as a persona (#134); `watch_authors` still has no consent gate (#131). Those need design and a box, not a review pass.

Drafted with assistance from [Claude Code](https://claude.com/claude-code).