### PR TITLE
refactor: one durable-store primitive behind all three dedup sets

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,14 +117,14 @@ that merely ran.** The suite was green through all of them.
 
 ## Tests
 
-`npm test` — 13 suites, against the real exported functions with synthetic events. No sockets,
+`npm test` — 14 suites, against the real exported functions with synthetic events. No sockets,
 no production state, no writes outside a temp dir.
 
-quarantine gating · deletion propagation · sealed-lane rate caps · grant admission · message
-rendering · deployed-build verification · return lane · return-lane scan · return-lane no-miss ·
-relay ingress · tripwire union · tripwire detection drill · deploy runner
+durable dedup store · quarantine gating · deletion propagation · sealed-lane rate caps · grant
+admission · message rendering · deployed-build verification · return lane · return-lane scan ·
+return-lane no-miss · relay ingress · tripwire union · tripwire detection drill · deploy runner
 
-CI runs them on push and PR. **If a run reports fewer than 13, the branch is on a stale base.**
+CI runs them on push and PR. **If a run reports fewer than 14, the branch is on a stale base.**
 The count of record is the `test` script in `package.json`; a prose count that disagrees with it
 is the prose being wrong.
 

--- a/README.md
+++ b/README.md
@@ -104,12 +104,12 @@ against what git says, because a stale build is invisible while every status sur
 
 ## Tests
 
-`npm test` runs 13 suites against the **real** exported functions with synthetic events — no
+`npm test` runs 14 suites against the **real** exported functions with synthetic events — no
 sockets, no production state:
 
-quarantine gating · deletion propagation · sealed-lane rate caps · grant admission · message
-rendering · deployed-build verification · return lane · return-lane scan · return-lane no-miss ·
-relay ingress · tripwire union · tripwire detection drill · deploy runner
+durable dedup store · quarantine gating · deletion propagation · sealed-lane rate caps · grant
+admission · message rendering · deployed-build verification · return lane · return-lane scan ·
+return-lane no-miss · relay ingress · tripwire union · tripwire detection drill · deploy runner
 
 The rendering suite is the one to read if you are reviewing. It tests what the bridge **refuses**,
 not only what it does: a hostile note tries to ping the approver, mint an `APPROVED BY` heading,

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -120,7 +120,7 @@ in [deploy/README.md](../deploy/README.md).
 - **Publish the agent relay list:** `node tools/publish_relay_list.mjs` (so the identity
   is discoverable).
 - **Admit a participant**, if you want one: `sh tools/grant-setup.sh`.
-- **Run the safety gates before you ship:** `npm test` — 13 suites driving the real
+- **Run the safety gates before you ship:** `npm test` — 14 suites driving the real
   routing functions with synthetic events (no sockets, no production state), all green.
 
 `waggle-init.mjs --check` rolls the config half of this into one readiness verdict; the

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "start": "node src/bridge.mjs",
     "dryrun": "FORWARD_MODE=dryrun node src/bridge.mjs",
     "lint": "eslint src tools tests",
-    "test": "node tests/a1_quarantine.mjs && node tests/a7_deletion.mjs && node tests/lane2_caps.mjs && node tests/nipda_admission.mjs && node tests/render_states.mjs && node tests/deploy_verify.mjs && node tests/return_lane.mjs && node tests/return_lane_scan.mjs && node tests/return_lane_nomiss.mjs && node tests/relay_ingress.mjs && node tests/tripwire_union.mjs && node tests/tripwire_detection.mjs && node tests/deploy_runner.mjs",
+    "test": "node tests/durable_store.mjs && node tests/a1_quarantine.mjs && node tests/a7_deletion.mjs && node tests/lane2_caps.mjs && node tests/nipda_admission.mjs && node tests/render_states.mjs && node tests/deploy_verify.mjs && node tests/return_lane.mjs && node tests/return_lane_scan.mjs && node tests/return_lane_nomiss.mjs && node tests/relay_ingress.mjs && node tests/tripwire_union.mjs && node tests/tripwire_detection.mjs && node tests/deploy_runner.mjs",
     "console": "node tools/serve-console.mjs"
   },
   "dependencies": {

--- a/src/bridge.mjs
+++ b/src/bridge.mjs
@@ -311,47 +311,75 @@ if (FORWARD_MODE === 'buzz' && !process.env.BUZZ_PRIVATE_KEY) {
 }
 
 // --- durable dedup ----------------------------------------------------------
-// Append-only log of forwarded event ids, loaded into memory on boot. On restart
-// we re-hydrate so a bounce (or SINCE backfill) never re-delivers a DM already
-// pushed. Pruned to SEEN_CAP most-recent on boot to bound the file.
-const seen = new Set()
-function loadSeen() {
-  if (!existsSync(SEEN_PATH)) { mkdirSync(dirname(SEEN_PATH), { recursive: true }); return }
-  const lines = readFileSync(SEEN_PATH, 'utf8').split('\n').filter(Boolean)
-  const kept = lines.slice(-SEEN_CAP)
-  for (const id of kept) seen.add(id)
-  log(`dedup: loaded ${seen.size} seen ids from ${SEEN_PATH}${lines.length > kept.length ? ` (pruned ${lines.length - kept.length})` : ''}`)
-}
-function markSeen(id) {
-  seen.add(id)
-  try { appendFileSync(SEEN_PATH, id + '\n') } catch (e) { err(`dedup: append failed for ${id}: ${e.message}`) }
+// Three lanes each keep a durable "already handled this" set, and all three want the same three
+// things: an in-memory Set for the hot check, an append-only file so a restart cannot re-deliver,
+// and a cap so that file cannot grow forever. They were written three times, and they drifted —
+// only two grew the claim/rollback split that #121 added after one wrap posted twice, 423ms
+// apart, because the entry check and the durable write sat on opposite sides of an async send.
+// Whether the third is safe without it is a timing argument someone had to re-derive by hand on
+// every visit, which is exactly the kind of reasoning that decays.
+//
+// One primitive makes the whole vocabulary available to every lane. Which parts a lane USES stays
+// that lane's decision, argued at its own call sites — this changes what is *available*, never
+// what any lane currently does:
+//
+//   has       the hot check
+//   claim     in-memory only — suppress a duplicate while an async send is in flight
+//   rollback  undo a claim, so a failed send retries instead of being silently suppressed
+//   commit    claim + durable append — survives a restart
+//
+// `mem` is the Set itself, exposed because the lanes (and the suites) check it directly.
+function durableSet({ path, cap, label, noun }) {
+  const mem = new Set()
+  return {
+    mem,
+    has: (k) => mem.has(k),
+    claim: (k) => { mem.add(k) },
+    rollback: (k) => { mem.delete(k) },
+    commit(k) {
+      mem.add(k)
+      // Truncated at 64 so a full event id still prints whole, while a long composite key
+      // (source × recipient) cannot flood the journal the tripwire reads.
+      try { appendFileSync(path, k + '\n') }
+      catch (e) { err(`${label}: append failed for ${String(k).slice(0, 64)}: ${e.message}`) }
+    },
+    load() {
+      // The mkdir on the missing-file path is what guarantees the directory exists for every
+      // later append, which is why commit() does not repeat it per write.
+      if (!existsSync(path)) { mkdirSync(dirname(path), { recursive: true }); return }
+      const lines = readFileSync(path, 'utf8').split('\n').filter(Boolean)
+      const kept = lines.slice(-cap)
+      for (const k of kept) mem.add(k)
+      log(`${label}: loaded ${mem.size} ${noun} from ${path}${lines.length > kept.length ? ` (pruned ${lines.length - kept.length})` : ''}`)
+    },
+  }
 }
 
-// Relay-lane dedup — same append-only, capped lifecycle as seen-ids, a SEPARATE file. Marked on any
-// DETERMINISTIC outcome (posted, a reject, or a decrypt/verify failure that will never become
-// valid) so a relay re-serving that wrap is cheap; NOT marked on a transient budget drop, which may
-// succeed on retry. A wrap id here is never mixed into `seen` — the two stores never collide.
-const relaySeen = new Set()
-function loadRelaySeen() {
-  if (!existsSync(RELAYSEEN_PATH)) { mkdirSync(dirname(RELAYSEEN_PATH), { recursive: true }); return }
-  const lines = readFileSync(RELAYSEEN_PATH, 'utf8').split('\n').filter(Boolean)
-  const kept = lines.slice(-RELAYSEEN_CAP)
-  for (const id of kept) relaySeen.add(id)
-  log(`relay-lane dedup: loaded ${relaySeen.size} seen wrap ids from ${RELAYSEEN_PATH}${lines.length > kept.length ? ` (pruned ${lines.length - kept.length})` : ''}`)
-}
-function markRelaySeen(id) {
-  relaySeen.add(id)
-  try { appendFileSync(RELAYSEEN_PATH, id + '\n') } catch (e) { err(`relay-lane dedup: append failed for ${id}: ${e.message}`) }
-}
-// Claim/rollback split, mirroring the return lane's addRlSeen/dropRlSeen (#121 finding #2).
-// The entry check `relaySeen.has(ev.id)` and the durable `markRelaySeen` sit on opposite sides of
-// an ASYNC buzz send. Without an in-memory claim taken synchronously at dispatch, every copy of
-// the same wrap arriving before the first send returns passes the check and posts again — and that
-// is not a rare race but the NORMAL case: a sender publishes to N relays and the bridge subscribes
-// to all of them. Observed on the lane's first live use: one wrap, two identical channel posts
-// 423ms apart. Claim on dispatch, persist on success, roll back on failure so it still retries.
-function addRelaySeen(id) { relaySeen.add(id) }
-function dropRelaySeen(id) { relaySeen.delete(id) }
+// DM + public lane dedup: forwarded event ids, re-hydrated on boot so a bounce (or a SINCE
+// backfill) never re-delivers something already pushed. Commit-before-dispatch on the public
+// lane is deliberate and stays that way — see routePublic: "never double-post" is chosen over
+// "never drop". The claim/rollback verbs exist here now; nothing calls them, on purpose.
+const seenStore = durableSet({ path: SEEN_PATH, cap: SEEN_CAP, label: 'dedup', noun: 'seen ids' })
+const seen = seenStore.mem
+const loadSeen = () => seenStore.load()
+const markSeen = (id) => seenStore.commit(id)
+
+// Relay-lane dedup — a SEPARATE file. Committed on any DETERMINISTIC outcome (posted, a reject, or
+// a decrypt/verify failure that will never become valid) so a relay re-serving that wrap is cheap;
+// NOT committed on a transient budget drop, which may succeed on retry. A wrap id here is never
+// mixed into `seen` — separate stores, they cannot collide.
+//
+// Claim/rollback (#121 finding #2): the entry check and the durable write sit on opposite sides of
+// an ASYNC buzz send, so without a claim taken synchronously at dispatch, every copy of the same
+// wrap arriving before the first send returns passes the check and posts again. That is not a rare
+// race but the NORMAL case — a sender publishes to N relays and the bridge subscribes to all of
+// them. Claim on dispatch, persist on success, roll back on failure so it still retries.
+const relaySeenStore = durableSet({ path: RELAYSEEN_PATH, cap: RELAYSEEN_CAP, label: 'relay-lane dedup', noun: 'seen wrap ids' })
+const relaySeen = relaySeenStore.mem
+const loadRelaySeen = () => relaySeenStore.load()
+const markRelaySeen = (id) => relaySeenStore.commit(id)
+const addRelaySeen = (id) => relaySeenStore.claim(id)
+const dropRelaySeen = (id) => relaySeenStore.rollback(id)
 
 // A7 posted-map: append-only JSONL, same lifecycle as seen-ids. One {id, author, buzz,
 // dest, ts} record per reposted public note, plus {id, deleted:true} once withdrawn — the
@@ -1063,28 +1091,20 @@ async function handleCommand(m) {
 // instant the roster grows past one. The composite key lets a message fan out to every mentioned
 // recipient, each carried exactly once; persistence makes that idempotent across a restart so a
 // bounce never re-delivers (finding #1). Same append-only/capped lifecycle as loadSeen/markSeen.
-const rlSeen = new Set()
-const rlKey = (srcId, recipHex) => String(srcId) + '\x1f' + String(recipHex)
-function loadRlSeen() {
-  if (!existsSync(RLSEEN_PATH)) { mkdirSync(dirname(RLSEEN_PATH), { recursive: true }); return }
-  const lines = readFileSync(RLSEEN_PATH, 'utf8').split('\n').filter(Boolean)
-  const kept = lines.slice(-RLSEEN_CAP)
-  for (const k of kept) rlSeen.add(k)
-  log(`return lane: loaded ${rlSeen.size} carried (source×recipient) keys from ${RLSEEN_PATH}${lines.length > kept.length ? ` (pruned ${lines.length - kept.length})` : ''}`)
-}
-// Persist-on-landed split (finding #2). addRlSeen suppresses a double-carry WITHIN a scan/overlap
+// Persist-on-landed split (finding #2). claim suppresses a double-carry WITHIN a scan/overlap
 // immediately, in memory; the DURABLE append happens only once the seal actually reached a relay —
-// markRlSeen, called on ≥1 accept. A silent 0/N is rolled back with dropRlSeen so #5's overlap
-// re-read re-carries it, and — because it never reached disk — a restart (loadRlSeen) re-carries it
-// too. The earlier commit-before-send would instead durably suppress a mention that was never
-// delivered: #1's own durability then made the loss permanent and invisible.
-function addRlSeen(key) { rlSeen.add(key) }
-function dropRlSeen(key) { rlSeen.delete(key) }
-function markRlSeen(key) {
-  rlSeen.add(key)
-  try { mkdirSync(dirname(RLSEEN_PATH), { recursive: true }); appendFileSync(RLSEEN_PATH, key + '\n') }
-  catch (e) { err(`return lane: dedup append failed for ${String(key).slice(0, 24)}…: ${e.message}`) }
-}
+// commit, called on ≥1 accept. A silent 0/N is rolled back so #5's overlap re-read re-carries it,
+// and — because it never reached disk — a restart re-carries it too. The earlier
+// commit-before-send would instead durably suppress a mention that was never delivered: #1's own
+// durability then made the loss permanent and invisible. This lane is the one that uses all four
+// verbs, which is why the primitive has them.
+const rlSeenStore = durableSet({ path: RLSEEN_PATH, cap: RLSEEN_CAP, label: 'return lane', noun: 'carried (source×recipient) keys' })
+const rlSeen = rlSeenStore.mem
+const rlKey = (srcId, recipHex) => String(srcId) + '\x1f' + String(recipHex)
+const loadRlSeen = () => rlSeenStore.load()
+const addRlSeen = (key) => rlSeenStore.claim(key)
+const dropRlSeen = (key) => rlSeenStore.rollback(key)
+const markRlSeen = (key) => rlSeenStore.commit(key)
 
 // Drop-log dedup (finding #2). The signer-gate err() in scanReturnLane fires before the
 // per-recipient rlSeen check, so without this a STATIC backlog of non-admitted signers re-logs
@@ -1626,7 +1646,7 @@ function connectPublic(url) {
 // Exported so a harness can drive the REAL routing functions (not a copy) with synthetic
 // events in dryrun, without opening any relay socket. Set WB_NO_BOOT=1 to import without
 // booting the live subscriber. No effect on normal `node src/bridge.mjs` runs.
-export { returnLaneSend, publishWrapToRelays, scanReturnLane, pollScanChannels, scanChannel, scanSince, bumpScanCursor, loadScanCursors, agentAuthoredBy, rlSeen, rlKey, loadRlSeen, markRlSeen, addRlSeen, dropRlSeen, route, routePublic, routeDelete, processGrantEvent, grantSet, forwardPublic, clampCreated, rateOk, bumpPubWatermark, loadPubWatermark, markSeen, seen, PUB, postedMap, recordPosted, parseBuzzEventId, resolveChannels, handleRelayIngress, relaySeen, markRelaySeen, addRelaySeen, dropRelaySeen, loadRelaySeen, relayRateOk, resolveRelayDest, relayDropTotalPreAuth, relayDropCounts }
+export { durableSet, returnLaneSend, publishWrapToRelays, scanReturnLane, pollScanChannels, scanChannel, scanSince, bumpScanCursor, loadScanCursors, agentAuthoredBy, rlSeen, rlKey, loadRlSeen, markRlSeen, addRlSeen, dropRlSeen, route, routePublic, routeDelete, processGrantEvent, grantSet, forwardPublic, clampCreated, rateOk, bumpPubWatermark, loadPubWatermark, markSeen, seen, PUB, postedMap, recordPosted, parseBuzzEventId, resolveChannels, handleRelayIngress, relaySeen, markRelaySeen, addRelaySeen, dropRelaySeen, loadRelaySeen, relayRateOk, resolveRelayDest, relayDropTotalPreAuth, relayDropCounts }
 
 // --- boot -------------------------------------------------------------------
 if (!process.env.WB_NO_BOOT) {

--- a/tests/durable_store.mjs
+++ b/tests/durable_store.mjs
@@ -1,0 +1,94 @@
+// durableSet — the shared dedup primitive behind `seen`, `relaySeen` and `rlSeen` (#151).
+//
+// The property this suite exists to hold is the one that cost a production incident (#121): a
+// CLAIM must not survive a restart, and a COMMIT must. Those two were the same call once, and a
+// mention that reached no relay was durably suppressed anyway — the loss was permanent because the
+// durability worked. Merging three copies of the store into one primitive is only safe if that
+// distinction is asserted somewhere, so it is asserted here rather than left to be re-derived.
+//
+// "Survives a restart" is tested the way a restart actually works: build a SECOND store over the
+// same file and load it. Nothing is stubbed — this drives the real exported durableSet.
+//
+// Run: node tests/durable_store.mjs   (exit 0 = pass, 1 = fail)
+
+import { mkdtempSync, existsSync, readFileSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+const dir = mkdtempSync(join(tmpdir(), 'wb-store-'))
+process.env.WB_NO_BOOT = '1'
+process.env.FORWARD_MODE = 'dryrun'
+process.env.SEEN_PATH = join(dir, 'seen.log')
+process.env.PUB_WATERMARK_PATH = join(dir, 'watermark')
+
+const { durableSet } = await import('../src/bridge.mjs')
+
+let fails = 0
+const ok = (name, cond) => { console.log(`${cond ? 'ok  ' : 'FAIL'} — ${name}`); if (!cond) fails++ }
+
+// Quiet the module's own logging so the suite output is only assertions.
+console.log = ((real) => (...a) => { if (String(a[0] ?? '').startsWith('ok  ') || String(a[0] ?? '').startsWith('FAIL')) real(...a) })(console.log)
+
+const mk = (file, cap = 1000) =>
+  durableSet({ path: join(dir, file), cap, label: 'test', noun: 'keys' })
+
+// --- claim is in-memory ONLY ---------------------------------------------------------------
+const s1 = mk('claim.log')
+s1.claim('a')
+ok('claim is visible in memory immediately', s1.has('a'))
+ok('claim writes NOTHING to disk', !existsSync(join(dir, 'claim.log')))
+
+// The load-bearing negative: a restart must NOT see a claim. This is #121's bug in one line —
+// if a claim persisted, a carry that reached no relay would be suppressed forever.
+const s1b = mk('claim.log')
+s1b.load()
+ok('a claim does NOT survive a restart', !s1b.has('a'))
+
+// --- commit is durable ---------------------------------------------------------------------
+const s2 = mk('commit.log')
+s2.commit('b')
+ok('commit is visible in memory', s2.has('b'))
+ok('commit reaches disk', existsSync(join(dir, 'commit.log')) &&
+  readFileSync(join(dir, 'commit.log'), 'utf8').includes('b'))
+const s2b = mk('commit.log')
+s2b.load()
+ok('a commit DOES survive a restart', s2b.has('b'))
+
+// --- rollback undoes a claim ---------------------------------------------------------------
+const s3 = mk('rollback.log')
+s3.claim('c')
+s3.rollback('c')
+ok('rollback clears the in-memory claim, so a failed send retries', !s3.has('c'))
+ok('rollback leaves no durable trace', !existsSync(join(dir, 'rollback.log')))
+
+// Rollback after a COMMIT is deliberately not a supported undo — it clears memory but the line is
+// already on disk, so the next restart brings it back. Asserted so the asymmetry is documented
+// behaviour rather than a surprise: roll back a claim, never a commit.
+const s4 = mk('committed-rollback.log')
+s4.commit('d')
+s4.rollback('d')
+ok('rollback after commit clears memory only', !s4.has('d'))
+const s4b = mk('committed-rollback.log')
+s4b.load()
+ok('...and the committed key still returns after a restart (commit is not undoable)', s4b.has('d'))
+
+// --- the cap bounds the file on load -------------------------------------------------------
+writeFileSync(join(dir, 'cap.log'), ['k1', 'k2', 'k3', 'k4', 'k5'].join('\n') + '\n')
+const s5 = mk('cap.log', 2)
+s5.load()
+ok('load keeps only the cap-most-recent keys', s5.mem.size === 2 && s5.has('k4') && s5.has('k5'))
+ok('load drops the oldest beyond the cap', !s5.has('k1'))
+
+// --- a missing file is not an error --------------------------------------------------------
+const s6 = mk('never-written.log')
+s6.load()
+ok('loading a store that has never been written is a no-op, not a throw', s6.mem.size === 0)
+
+// --- stores are independent ----------------------------------------------------------------
+// The three lanes must never collide: a wrap id in the relay store is not a "seen" event id.
+const a = mk('iso-a.log'), b = mk('iso-b.log')
+a.commit('shared-key')
+ok('a key committed to one store is invisible to another', !b.has('shared-key'))
+
+console.log(fails ? `\ndurable_store: ${fails} check(s) failed` : '\ndurable_store: all checks passed')
+process.exit(fails ? 1 : 0)


### PR DESCRIPTION
Closes #151. First of the four steps toward #154 (splitting `bridge.mjs`).

**Pure refactor** — no lane, gate, schema or wire format changed, and every call site keeps the behaviour it argued for.

## What was duplicated

Three lanes each kept a durable *"already handled this"* set, and all three wanted the same three things: an in-memory `Set` for the hot check, an append-only file so a restart cannot re-deliver, and a cap so the file cannot grow forever.

Written three times, they had **drifted**. Only `relaySeen` and `rlSeen` grew the claim/rollback split that #121 added after one wrap posted twice, 423ms apart — the entry check and the durable write sat on opposite sides of an async send. Whether `seen` is safe without it is a timing argument someone had to re-derive by hand on every visit, which is exactly the kind of reasoning that decays.

## What changed

`durableSet` gives every store the full vocabulary:

| verb | meaning |
|---|---|
| `has` | the hot check |
| `claim` | in-memory only — suppress a duplicate while an async send is in flight |
| `rollback` | undo a claim, so a failed send retries instead of being silently suppressed |
| `commit` | claim + durable append — survives a restart |

**Which verbs a lane *uses* stays that lane's decision, argued at its own call sites.** `seen` still commits before dispatch on the public lane, because *"never double-post"* is deliberately chosen there over *"never drop"*. The claim verbs now exist for it and **nothing calls them, on purpose**. This changes what is *available*, never what any lane does.

`postedMap` was listed in the issue but is **deliberately left alone**: it is a map of structured records with a tombstone marker and a secondary index (`stagingByBuzzId`), not a set of keys. Forcing it through a set primitive would make both worse.

## The suites were not edited

That was the contract in #151 — a refactor provable by the existing 13 going green **unchanged**, since any suite needing a change would mean a behaviour change. They pass unchanged. The only diff outside the store definitions is the definitions themselves; no call site moved.

## New suite, and what its negative control caught

`tests/durable_store.mjs` holds the property this consolidation turns on: **a claim must not survive a restart and a commit must** — tested the way a restart actually works, by building a second store over the same file and loading it. It also asserts that rollback-after-commit is *not* an undo, so that asymmetry is documented behaviour rather than a surprise.

Negative control: reintroducing #121's bug (making `claim` append to disk) fails the suite with three named assertions.

**Running it caught a second thing.** The first pass showed:

```
bug present -> suite exit: 1        (correct)
bug present -> npm test exit: 0     ← the new suite was not in the test script
```

An alarm that cannot fire. Wired in and re-run: `npm test` exits 1 with the bug and 0 without. Worth stating plainly because a new suite that isn't in `package.json` looks exactly like a passing one.

Suite count is now **14**; README, `CLAUDE.md` and `GETTING_STARTED.md` follow `package.json` as the count of record, per #138.

## A correction to my own estimate in #151

The issue predicted *"removes roughly 80 lines."* It doesn't. Measured:

```
code:    42 lines out,  38 in
comment: 19 lines out,  42 in
net:     +20
```

The mechanism did shrink. The file grew, because the reasoning the three copies each carried separately is now stated once, properly. **What this removes is the duplication and the drift risk, not the line count** — and I'd rather correct the estimate than quietly let it stand.

## Verification

- `npm test` — exit 0, 14/14
- `npm run lint` — exit 0
- Existing 13 suites pass **unchanged** (no edits to any of them)
- Negative control run, twice — including the one that exposed the unwired suite
- Confirmed no call site changed: the only removed lines matching the store verbs are their own `function` definitions

Drafted with assistance from [Claude Code](https://claude.com/claude-code).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jz1HxpLeG5DZkNigLDUJYL)_