### PR TITLE
refactor: one lane limiter, built twice, instead of the same function twice

### DIFF
--- a/src/bridge.mjs
+++ b/src/bridge.mjs
@@ -603,38 +603,54 @@ function clampCreated(ts, nowSec) {
 // A6: sliding-window rate limiters (public lane only). Every drop is LOGGED with a reason —
 // nothing is ever silently discarded. In-memory by design: a restart resets the windows, which
 // is safe because durable id-dedup (A2) still prevents re-delivery of any already-forwarded id.
-const rlReplier = new Map() // pubkey -> [tsMs...]
-const rlChannel = new Map() // inbox  -> [tsMs...]
-const rlLane = []           // [tsMs...] across the whole lane (hourly)
 const slide = (arr, nowMs, win) => { while (arr.length && arr[0] <= nowMs - win) arr.shift(); return arr }
-function rateOk(ev, dest, nowMs) {
-  const lane = slide(rlLane, nowMs, 3600_000)
-  if (lane.length >= PUB.lanePerHour) { err(`PUBLIC drop[rate]: lane cap ${PUB.lanePerHour}/h — ${ev.id.slice(0, 12)}…`); return false }
-  const perCh = slide(rlChannel.get(dest) || [], nowMs, 60_000)
-  if (perCh.length >= PUB.channelPerMin) { err(`PUBLIC drop[rate]: channel cap ${PUB.channelPerMin}/min for ${dest} — ${ev.id.slice(0, 12)}…`); return false }
-  const perR = slide(rlReplier.get(ev.pubkey) || [], nowMs, 60_000)
-  if (perR.length >= PUB.replierPerMin) { err(`PUBLIC drop[rate]: replier cap ${PUB.replierPerMin}/min for ${ev.pubkey.slice(0, 12)}… — ${ev.id.slice(0, 12)}…`); return false }
-  lane.push(nowMs); perCh.push(nowMs); rlChannel.set(dest, perCh); perR.push(nowMs); rlReplier.set(ev.pubkey, perR)
-  return true
+
+// One limiter, built twice. The public and relay lanes ran structurally identical checks — the
+// same three windows, the same `slide`, the same PUB.* caps, the same commit-on-pass ordering —
+// differing only in which counter maps they touched and how the drop line reads. That is an
+// argument for separate STATE, which the lanes genuinely need so neither can starve the other. It
+// was never an argument for separate LOGIC: a cap changed in one copy and not the other yields two
+// different policies with nothing to notice it, because each lane's suite exercises only its own.
+//
+// Every call to laneLimiter builds its OWN three counters, so the lanes stay exactly as independent
+// as they were. What they can no longer do is drift apart on policy.
+//
+// The drop lines are preserved byte-for-byte — operators grep these. `ref` is the trailing
+// identifier: the event id on the public lane, where the subject is the note's AUTHOR and the id
+// adds information; nothing on the relay lane, where the subject IS the sender and repeating it
+// would be noise, so the tail falls back to the subject itself exactly as before.
+function laneLimiter({ tag, subjectNoun }) {
+  const lane = [], byChannel = new Map(), bySubject = new Map()
+  return function ok(subject, dest, nowMs, ref = null) {
+    const who = String(subject).slice(0, 12)
+    const tail = ref ? ` — ${ref}` : ` — ${who}…`
+    const subjTail = ref ? ` — ${ref}` : ''   // its own line already names the subject
+    const l = slide(lane, nowMs, 3600_000)
+    if (l.length >= PUB.lanePerHour) { err(`${tag} drop[rate]: lane cap ${PUB.lanePerHour}/h${tail}`); return false }
+    const perCh = slide(byChannel.get(dest) || [], nowMs, 60_000)
+    if (perCh.length >= PUB.channelPerMin) { err(`${tag} drop[rate]: channel cap ${PUB.channelPerMin}/min for ${dest}${tail}`); return false }
+    const perS = slide(bySubject.get(subject) || [], nowMs, 60_000)
+    if (perS.length >= PUB.replierPerMin) { err(`${tag} drop[rate]: ${subjectNoun} cap ${PUB.replierPerMin}/min for ${who}…${subjTail}`); return false }
+    l.push(nowMs); perCh.push(nowMs); byChannel.set(dest, perCh); perS.push(nowMs); bySubject.set(subject, perS)
+    return true
+  }
 }
 
-// Relay-lane rate caps (DESIGN_RELAY_INGRESS MUST-FIX 2). rateOk above keys the replier cap on
-// ev.pubkey; on a gift wrap that is the EPHEMERAL key, fresh per wrap, so per-sender limiting there
-// is a no-op. The relay lane re-keys on the AUTHENTICATED seal.pubkey and so is POST-DECRYPT only —
-// a flood is bounded before this by the decrypt budget, not here. Separate counter maps so neither
-// lane starves the other. Same PUB.* caps as the public lane (§3: reuse, no new cap).
-const relayRlLane = []
-const relayRlChannel = new Map()
-const relayRlSender = new Map()
+const publicLimiter = laneLimiter({ tag: 'PUBLIC', subjectNoun: 'replier' })
+// Public lane. Signature unchanged: it passes the whole event because its drop line names the note
+// as well as the author.
+function rateOk(ev, dest, nowMs) {
+  return publicLimiter(ev.pubkey, dest, nowMs, `${ev.id.slice(0, 12)}…`)
+}
+
+// Relay lane (DESIGN_RELAY_INGRESS MUST-FIX 2). The public lane keys its subject cap on ev.pubkey;
+// on a gift wrap that is the EPHEMERAL key, fresh per wrap, so per-sender limiting there is a
+// no-op. This lane re-keys on the AUTHENTICATED seal.pubkey and so is POST-DECRYPT only — a flood
+// is bounded before it by the decrypt budget, not here. Same PUB.* caps (§3: reuse, no new cap),
+// its own counters.
+const relayLimiter = laneLimiter({ tag: 'RELAY', subjectNoun: 'sender' })
 function relayRateOk(sender, dest, nowMs) {
-  const lane = slide(relayRlLane, nowMs, 3600_000)
-  if (lane.length >= PUB.lanePerHour) { err(`RELAY drop[rate]: lane cap ${PUB.lanePerHour}/h — ${sender.slice(0, 12)}…`); return false }
-  const perCh = slide(relayRlChannel.get(dest) || [], nowMs, 60_000)
-  if (perCh.length >= PUB.channelPerMin) { err(`RELAY drop[rate]: channel cap ${PUB.channelPerMin}/min for ${dest} — ${sender.slice(0, 12)}…`); return false }
-  const perS = slide(relayRlSender.get(sender) || [], nowMs, 60_000)
-  if (perS.length >= PUB.replierPerMin) { err(`RELAY drop[rate]: sender cap ${PUB.replierPerMin}/min for ${sender.slice(0, 12)}…`); return false }
-  lane.push(nowMs); perCh.push(nowMs); relayRlChannel.set(dest, perCh); perS.push(nowMs); relayRlSender.set(sender, perS)
-  return true
+  return relayLimiter(sender, dest, nowMs)
 }
 
 // §7 decrypt-budget window + the pre-decrypt drop counter. The counter is LOUD by design: it is the

--- a/tests/relay_ingress.mjs
+++ b/tests/relay_ingress.mjs
@@ -49,7 +49,7 @@ process.env.WB_STUB_SEND = '1'
 process.env.WB_NO_BOOT = '1'
 
 const bridge = await import('../src/bridge.mjs')
-const { handleRelayIngress, route, grantSet, relaySeen, addRelaySeen, dropRelaySeen, relayDropCounts, relayDropTotalPreAuth, resolveRelayDest, PUB } = bridge
+const { handleRelayIngress, route, grantSet, relaySeen, addRelaySeen, dropRelaySeen, relayDropCounts, relayDropTotalPreAuth, resolveRelayDest, rateOk, relayRateOk, PUB } = bridge
 
 let fails = 0
 const ok = (n, c) => { console.log(`${c ? 'ok  ' : 'FAIL'} — ${n}`); if (!c) fails++ }
@@ -238,6 +238,32 @@ ok('resolveRelayDest rejects empty', resolveRelayDest('') === null)
     else if (ack(d)) rejects++
   }
   ok('same-sender cap bites at replier_per_min (5 post, 6th rejected)', posts === 5 && rejects === 1)
+}
+
+// --- the two lanes must not share counters (#152) -------------------------------------------
+// The relay lane keeps its own three windows precisely so a public-lane flood cannot starve an
+// admitted agent, and vice versa. Both lanes read the SAME PUB.* caps, so that independence lives
+// entirely in the state being separate — which nothing asserted until now. It became worth stating
+// when the two limiters were merged into one factory: the whole point of building it twice is that
+// each call owns its counters, and a refactor that accidentally shared them would still pass every
+// other check in this file.
+// It must be the CHANNEL window that is saturated, not the per-subject one. Filling one subject's
+// window and then querying a different subject passes whether or not the lanes share state, so that
+// version of this check proves nothing — it was written that way first and the negative control
+// caught it by refusing to fail. The channel window is the state both lanes would actually collide
+// on, so that is the one to fill.
+{
+  const nowMs = Date.now()
+  const dest = 'shared-channel-uuid'
+  // Distinct authors, so the per-replier cap never bites before the per-channel one does.
+  let publicAccepted = 0
+  for (let i = 0; i < PUB.channelPerMin + 2; i++) {
+    const pubkey = String(i).padStart(64, 'c')
+    if (rateOk({ id: String(i).padEnd(64, '0'), pubkey }, dest, nowMs)) publicAccepted++
+  }
+  ok('  public lane saturates its per-channel window', publicAccepted === PUB.channelPerMin)
+  // Same channel, relay lane. Independent counters mean this is untouched by the flood above.
+  ok('  a saturated public channel does NOT block the relay lane', relayRateOk('d'.repeat(64), dest, nowMs))
 }
 
 console.log(fails ? `\n${fails} FAIL` : '\nall passed')


### PR DESCRIPTION
Closes #152. Second of the four steps toward #154.

**Independent of #155** — different region of `bridge.mjs`, branched off `main`, so the two can merge in either order.

## The duplication

`rateOk` and `relayRateOk` were structurally identical: the same three windows, the same `slide`, the same `PUB.*` caps, the same commit-on-pass ordering. They differed only in which counter maps they touched and how the drop line reads.

That is an argument for separate **state** — the lanes genuinely need it, so neither can starve the other. It was never an argument for separate **logic**. A cap changed in one copy and not the other yields two different rate policies with nothing to notice it, because each lane's suite exercises only its own.

`laneLimiter` builds its own three counters per call, so the lanes stay exactly as independent as they were. What they can no longer do is drift apart on policy.

## Drop lines preserved byte-for-byte

Operators grep these, so I verified rather than assumed — drove both lanes to saturation and compared the emitted lines against the format strings in git history:

```
PUBLIC drop[rate]: replier cap 5/min for cccccccccccc… — 600000000000…
PUBLIC drop[rate]: channel cap 20/min for chan-2 — 120000000000…
RELAY  drop[rate]: sender cap 5/min for 60e72dfb89b4…
```

The `ref` parameter is why: the event id on the public lane, where the subject is the note's *author* and the id adds information; nothing on the relay lane, where the subject **is** the sender and repeating it would be noise.

## The control this PR adds — and the fact that my first version of it was useless

#152 asked for an assertion that the lanes are independent, since separate state is the whole reason the duplication existed and nothing tested it.

**My first version proved nothing.** It saturated one author's per-*subject* window, then queried a different subject — which passes whether or not the lanes share state. The negative control is what exposed it:

```
lanes made to share a limiter -> npm test exit: 0   ← should have been 1
```

An alarm that cannot fire. Rewritten to saturate the per-**channel** window, which is the state the two lanes would actually collide on:

```
lanes sharing  -> relay_ingress exit 1, npm test exit 1   ✓ fires
restored       -> exit 0                                   ✓ passes
```

That is the check that would have caught this refactor going wrong. The first one was not it, and it would have sat in the suite looking like coverage.

## Verification

- `npm test` — exit 0; suites otherwise unedited (the only change is the added control in `relay_ingress.mjs`)
- `npm run lint` — exit 0
- Drop-line format compared against git history, not assumed
- Negative control run on the real failure mode, after the first attempt failed to fire

## Note on suite count

This PR deliberately adds its control to the existing `relay_ingress.mjs` rather than a new suite. #155 already moves the count 13 → 14, and a second new suite here would mean both branches editing the same count in three docs — a guaranteed conflict for no benefit. The property belongs with the relay lane's other cap tests anyway.

Drafted with assistance from [Claude Code](https://claude.com/claude-code).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jz1HxpLeG5DZkNigLDUJYL)_