### PR TITLE
deploy-runner: fix the two defects that would break its first tick (#157, #158)

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -124,22 +124,40 @@ alarms):
 
 The runner removes *standing* write; installing it is a *bounded, one-time* privileged act.
 
-1. **Hub clone** the box pulls into (never a lane tree): `git clone <repo> /opt/waggle-hub`,
-   owned by the deploy identity. The runner only `fetch`es and `checkout --detach`s here.
+**One hub clone per lane** (`/opt/waggle-hub-read`, `/opt/waggle-hub-sealed`) — not one
+shared hub. The two instances run as different users and a git worktree cannot be fetched
+and `checkout --detach`ed by both; they also tick on the same cadence, so a shared worktree
+could be rsynced by one instance while the other had just moved it to a different commit
+(#158). Each hub is owned by exactly the user its instance runs as.
+
+0. **Verify before installing** — the grant the runner depends on, which predates the repo
+   rename (#112): `sudo -l -U bridge` must show `systemctl restart waggle-read.service`
+   *under that exact unit name*. If it still names `west-bridge-read.service`, reinstall
+   `deploy/sudoers-bridge` (`visudo -cf` it first) or the runner's restart step is denied.
+1. **Hub clone** the lane pulls into (never a lane tree):
+   `git clone <repo> /opt/waggle-hub-read && chown -R bridge:bridge /opt/waggle-hub-read`.
+   The runner only `fetch`es and `checkout --detach`s here.
 2. **Units:** `sudo cp deploy/deploy-runner@.{service,timer} /etc/systemd/system/` then
    `sudo systemctl daemon-reload`.
-3. **read lane:** `sudo systemctl enable --now deploy-runner@read.timer`. It runs as
+3. **Rehearse one tick by hand, before any timer is enabled.** `DRY_RUN=1` resolves the
+   target commit and runs the CI-green gate while changing nothing:
+   `sudo -u bridge env DRY_RUN=1 WB_HUB=/opt/waggle-hub-read /bin/sh
+   /opt/waggle-hub-read/deploy/deploy-runner.sh read`. Then run it for real, once, and read
+   the output — a first deploy is the wrong thing to discover from a timer's journal.
+4. **read lane:** `sudo systemctl enable --now deploy-runner@read.timer`. It runs as
    `bridge`, which already owns `/opt/waggle-read` and holds the scoped `sudo systemctl
    restart waggle-read.service` grant (`deploy/sudoers-bridge`). No new authority.
-4. **sealed lane — get it off root in the same pass.** `/opt/waggle-sealed` is administered
+5. **sealed lane — get it off root in the same pass.** `/opt/waggle-sealed` is administered
    as **root** today; do not deploy it as root. Create a scoped `deploy` user that owns the
-   sealed tree + hub and holds *only* `sudo systemctl restart waggle-sealed.service`, add the
-   drop-in from the unit header (`User=deploy`), then
+   sealed tree and `/opt/waggle-hub-sealed`, holding *only* `sudo systemctl restart
+   waggle-sealed.service`, add the drop-in from the unit header (`User=deploy`), then
    `sudo systemctl enable --now deploy-runner@sealed.timer`. Now neither lane is deployed by
    root, and no principal holds a general shell on production.
-5. Confirm: `systemctl list-timers 'deploy-runner@*'`.
+6. Confirm — by reading the result, not the exit code: `systemctl list-timers
+   'deploy-runner@*'`, `cat /opt/waggle-<lane>/DEPLOYED_SHA`, and a green
+   `verify-deployed.sh <lane> /opt/waggle-<lane> <sha>`.
 
-For a **private** repo, drop a read-only token in `/opt/waggle-hub/deploy-runner.env`
+For a **private** repo, drop a read-only token in `/opt/waggle-hub-<lane>/deploy-runner.env`
 (`GH_TOKEN=…`, `0600`, never committed) — a read cap, still no write authority on the box.
 
 Nothing arms until it passes a review and a green `verify-deployed.sh` against the box.

--- a/deploy/deploy-runner@.service
+++ b/deploy/deploy-runner@.service
@@ -1,6 +1,6 @@
 # waggle pull-based deploy runner (issue #129), templated per lane: %i = read | sealed.
-# Driven by deploy-runner@.timer. Oneshot: each tick fetches main into the hub clone, and
-# IF a new commit is CI-green, ships it into /opt/waggle-%i, records the SHA, and runs
+# Driven by deploy-runner@.timer. Oneshot: each tick fetches main into the lane's hub clone,
+# and IF a new commit is CI-green, ships it into /opt/waggle-%i, records the SHA, and runs
 # verify-deployed.sh — alarming (FAILED unit) on drift. No inbound credential to the box.
 #
 #   sudo cp deploy/deploy-runner@.{service,timer} /etc/systemd/system/
@@ -12,9 +12,9 @@
 #   read   -> runs as 'bridge', which already holds scoped `sudo systemctl restart
 #             waggle-read.service` (deploy/sudoers-bridge) and owns /opt/waggle-read.
 #   sealed -> /opt/waggle-sealed runs as ROOT today; do NOT run its deploy as root. Create a
-#             scoped 'deploy' user that owns the sealed tree + hub and holds ONLY
-#             `sudo systemctl restart waggle-sealed.service`, then add an override so this
-#             instance runs as that user:
+#             scoped 'deploy' user that owns /opt/waggle-sealed + /opt/waggle-hub-sealed and
+#             holds ONLY `sudo systemctl restart waggle-sealed.service`, then add an override
+#             so this instance runs as that user:
 #               /etc/systemd/system/deploy-runner@sealed.service.d/override.conf
 #                 [Service]
 #                 User=deploy
@@ -22,7 +22,15 @@
 #             Getting sealed off a root deploy path is the same-pass hardening the issue asks
 #             for — landing it here means neither lane is deployed by root.
 #
-# Optional /opt/waggle-hub/deploy-runner.env (0600, NEVER committed) — only needed if the
+# ONE HUB PER LANE — /opt/waggle-hub-%i, not a shared /opt/waggle-hub (#158). The two
+# instances run as DIFFERENT users (above) and a git worktree cannot be fetched and
+# `checkout --detach`ed by both. They also tick on the same 3-minute cadence, so concurrent
+# runs are ordinary: sharing one worktree would let one instance rsync a tree the other had
+# just moved to a different commit, and DEPLOYED_SHA would then record a commit that was
+# resolved but not shipped. A clone per lane removes both problems; each hub is owned by
+# exactly the user its instance runs as.
+#
+# Optional /opt/waggle-hub-%i/deploy-runner.env (0600, NEVER committed) — only needed if the
 # repo is private (a READ-only token, still no write authority on the box):
 #   GH_TOKEN=<read-only PAT>
 [Unit]
@@ -34,19 +42,25 @@ Wants=network-online.target
 Type=oneshot
 User=bridge
 Group=bridge
-WorkingDirectory=/opt/waggle-hub
+WorkingDirectory=/opt/waggle-hub-%i
 Environment=PATH=/usr/local/bin:/usr/bin:/bin
-Environment=WB_HUB=/opt/waggle-hub
+Environment=WB_HUB=/opt/waggle-hub-%i
+# ProtectHome=yes (below) makes $HOME unreachable, and npm's default cache lives at
+# $HOME/.npm — so `npm ci` fails outright without this, taking the deploy down AFTER the
+# rsync has landed but BEFORE the restart and the DEPLOYED_SHA write (#157). Observed, with
+# the negative control: an *unwritable* home still passes, an *inaccessible* one does not.
+# The cache goes inside the hub, which is already a ReadWritePath — no sandbox loosening.
+Environment=npm_config_cache=/opt/waggle-hub-%i/.npm-cache
 # The env file is optional; '-' means "do not fail if it is absent" (public repo needs none).
-EnvironmentFile=-/opt/waggle-hub/deploy-runner.env
-ExecStart=/bin/sh /opt/waggle-hub/deploy/deploy-runner.sh %i
+EnvironmentFile=-/opt/waggle-hub-%i/deploy-runner.env
+ExecStart=/bin/sh /opt/waggle-hub-%i/deploy/deploy-runner.sh %i
 # The runner restarts the lane via the scoped `sudo systemctl restart waggle-%i.service`
 # grant, so privilege escalation must be allowed for that one exact command.
 NoNewPrivileges=no
 ProtectHome=yes
 PrivateTmp=yes
-# Writable: the hub clone it fetches/checks out, and the lane tree it ships into. Nothing
-# else — config.json/.env/data inside the tree are never in the ship list, so they are not
-# touched even though the tree is writable.
+# Writable: the lane's own hub clone it fetches/checks out (and caches npm in), and the lane
+# tree it ships into. Nothing else — config.json/.env/data inside the tree are never in the
+# ship list, so they are not touched even though the tree is writable.
 ProtectSystem=strict
-ReadWritePaths=/opt/waggle-hub /opt/waggle-%i
+ReadWritePaths=/opt/waggle-hub-%i /opt/waggle-%i


### PR DESCRIPTION
Closes #157. Closes #158.

Groundwork for bootstrapping the runner. **Both defects are pre-install** — the unit has never been installed, so nothing in production changes here. They want fixing *before* the one-time privileged step, so that step installs a unit that works on its first tick instead of surfacing these from a timer's journal, half-way through a deploy, in a session that costs a breakglass to open.

No code changed: one systemd unit and the bootstrap docs. Suite green (exit 0).

## #157 — `npm ci` cannot run under `ProtectHome=yes`

`bridge`'s home is `/home/bridge`, so the sandbox makes npm's default cache (`$HOME/.npm`) unreachable, and the install step is step 4 of every deploy. The failure lands **after** the rsync but **before** the restart and the `DEPLOYED_SHA` write: new code on the tree, old process still running, no recorded provenance, and an alarm that says `dependency install failed` without saying why.

Observed on the bridge host, with the tree's own lockfile:

```
$ env HOME=/nonexistent-protecthome npm ci --omit=dev --no-audit --no-fund
npm error The operation was rejected by your operating system.
npm error Log files were not written due to an error writing to the directory: /nonexistent-protecthome/.npm/_logs
```

Negative control, same command with the fix's cache path: `added 14 packages in 3s`.

**Worth knowing before anyone re-tests this:** my first attempt used `HOME=/home/bridge` and **passed**. An unwritable home is not the same condition as an inaccessible one, and that run would have been a false all-clear.

Fixed with `Environment=npm_config_cache=/opt/waggle-hub-%i/.npm-cache` — inside a path the unit already has write access to. No sandbox loosening, no new `ReadWritePaths` entry.

## #158 — one hub per lane

The unit hardcoded `/opt/waggle-hub` for every instance, while its own header requires the two instances to run as **different users** (`read` as `bridge`, `sealed` as a scoped `deploy` user — the point of #129). A git worktree cannot be fetched and `checkout --detach`ed by both.

The sharper half is a race: the timer ticks **every 3 minutes for both instances**, so concurrent runs are ordinary. The runner checks out a SHA and then rsyncs from the worktree, so two instances interleaving there means one can ship a tree the other just moved. `DEPLOYED_SHA` would record the commit that instance *resolved*, not the one it *shipped*. `verify-deployed.sh` runs immediately after and would catch it as drift — so it alarms rather than passing silently, but the alarm would read as an unexplained mismatch.

`/opt/waggle-hub-%i` gives each instance a clone owned by exactly the user it runs as. Costs one extra clone on a box with 40G free.

## README bootstrap

Two steps added whose absence would cost a privileged session, plus per-lane hub paths throughout:

- **Step 0, verify before installing:** `sudo -l -U bridge` must show the restart grant under the name `waggle-read.service`. That grant was installed before the repo rename and the installed units still carry pre-rename strings (#112) — if it still names `west-bridge-read.service`, the runner's restart is denied and the first deploy fails at the last step. I could not check this myself (`/etc/sudoers.d` is root-only, correctly), so it is written as the first thing the privileged session does.
- **Step 3, rehearse one tick by hand** with `DRY_RUN=1`, then one real run read by eye, before any timer is enabled. A first deploy is the wrong thing to discover from a journal.

## What was verified, and what was not

- Unit parses clean under `systemd-analyze verify` **on the target host**, with a negative control confirming it reports a bogus directive rather than passing silently. Its exit code is worthless — it returns 0 even for a missing file — so the printed-warning channel is the signal.
- Runner rehearsed end-to-end on the box in `DRY_RUN`: hub clone over the live firewall, fetch, ref resolve, and the real check-runs query all work; egress to `api.github.com`, `github.com` and `registry.npmjs.org` is open. Negative controls: a commit CI never ran waits, an injected `failure` refuses, and `verify-deployed.sh` reports drift loudly (exit 1) against the live tree.
- **Not verified:** the `bridge` sudoers grant (root-only to read — hence step 0), and the sealed lane's `deploy` user, which does not exist yet. The sealed instance stays un-enabled until that pass.

Drafted with assistance from [Claude Code](https://claude.com/claude-code)