### PR TITLE
refactor: one relay fan-out primitive instead of three copies

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,14 +117,14 @@ that merely ran.** The suite was green through all of them.
 
 ## Tests
 
-`npm test` — 14 suites, against the real exported functions with synthetic events. No sockets,
+`npm test` — 15 suites, against the real exported functions with synthetic events. No sockets,
 no production state, no writes outside a temp dir.
 
-durable dedup store · quarantine gating · deletion propagation · sealed-lane rate caps · grant
+durable dedup store · relay fan-out · quarantine gating · deletion propagation · sealed-lane rate caps · grant
 admission · message rendering · deployed-build verification · return lane · return-lane scan ·
 return-lane no-miss · relay ingress · tripwire union · tripwire detection drill · deploy runner
 
-CI runs them on push and PR. **If a run reports fewer than 14, the branch is on a stale base.**
+CI runs them on push and PR. **If a run reports fewer than 15, the branch is on a stale base.**
 The count of record is the `test` script in `package.json`; a prose count that disagrees with it
 is the prose being wrong.
 

--- a/README.md
+++ b/README.md
@@ -104,10 +104,10 @@ against what git says, because a stale build is invisible while every status sur
 
 ## Tests
 
-`npm test` runs 14 suites against the **real** exported functions with synthetic events — no
+`npm test` runs 15 suites against the **real** exported functions with synthetic events — no
 sockets, no production state:
 
-durable dedup store · quarantine gating · deletion propagation · sealed-lane rate caps · grant
+durable dedup store · relay fan-out · quarantine gating · deletion propagation · sealed-lane rate caps · grant
 admission · message rendering · deployed-build verification · return lane · return-lane scan ·
 return-lane no-miss · relay ingress · tripwire union · tripwire detection drill · deploy runner
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -120,7 +120,7 @@ in [deploy/README.md](../deploy/README.md).
 - **Publish the agent relay list:** `node tools/publish_relay_list.mjs` (so the identity
   is discoverable).
 - **Admit a participant**, if you want one: `sh tools/grant-setup.sh`.
-- **Run the safety gates before you ship:** `npm test` — 14 suites driving the real
+- **Run the safety gates before you ship:** `npm test` — 15 suites driving the real
   routing functions with synthetic events (no sockets, no production state), all green.
 
 `waggle-init.mjs --check` rolls the config half of this into one readiness verdict; the

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "start": "node src/bridge.mjs",
     "dryrun": "FORWARD_MODE=dryrun node src/bridge.mjs",
     "lint": "eslint src tools tests",
-    "test": "node tests/durable_store.mjs && node tests/a1_quarantine.mjs && node tests/a7_deletion.mjs && node tests/lane2_caps.mjs && node tests/nipda_admission.mjs && node tests/render_states.mjs && node tests/deploy_verify.mjs && node tests/return_lane.mjs && node tests/return_lane_scan.mjs && node tests/return_lane_nomiss.mjs && node tests/relay_ingress.mjs && node tests/tripwire_union.mjs && node tests/tripwire_detection.mjs && node tests/deploy_runner.mjs",
+    "test": "node tests/relay_fanout.mjs && node tests/durable_store.mjs && node tests/a1_quarantine.mjs && node tests/a7_deletion.mjs && node tests/lane2_caps.mjs && node tests/nipda_admission.mjs && node tests/render_states.mjs && node tests/deploy_verify.mjs && node tests/return_lane.mjs && node tests/return_lane_scan.mjs && node tests/return_lane_nomiss.mjs && node tests/relay_ingress.mjs && node tests/tripwire_union.mjs && node tests/tripwire_detection.mjs && node tests/deploy_runner.mjs",
     "console": "node tools/serve-console.mjs"
   },
   "dependencies": {

--- a/src/bridge.mjs
+++ b/src/bridge.mjs
@@ -707,29 +707,57 @@ function cacheName(pubkey, name) {
   nameCache.set(pubkey, { name, ts: Date.now() })
   if (nameCache.size > NAME_CACHE_CAP) nameCache.delete(nameCache.keys().next().value)
 }
-function fetchProfileName(pubkey) {
+// One-shot relay fan-out: open a socket per relay, race them, settle exactly once, close everything.
+// Written three times before this (#153), and the copies diverged with a bug — one closed its
+// sockets in finish(), another only on EOSE/error, so a relay that opened and never answered leaked
+// its socket forever precisely when the timeout won, which is the case the timeout exists for. That
+// fix had to be noticed and hand-applied to one copy. Here it cannot diverge: cleanup, timeout
+// arming and disarming, the settle-once guard, and the try/catch around construction are the shared
+// parts — and they are exactly the parts that went wrong.
+//
+// What is NOT shared is the settle RULE, because the three genuinely differ (first-match,
+// all-settled-with-a-count, best-effort-with-a-default) and flattening that would change behaviour.
+// `each(ws, done, settleNow)` wires one socket: call `done()` when that socket has nothing more to
+// give, or `settleNow()` to end the whole fan-out early. `collect()` returns the accumulated result.
+//
+// `mkSocket` is injectable so the settle rules are drivable with no network — the same seam shape
+// scanChannel(fetchPage) and returnLaneSend(publish) already use.
+function fanout(relays, { timeoutMs, each, collect, mkSocket = (url) => new WebSocket(url) }) {
+  return new Promise((resolve) => {
+    const socks = []
+    let pending = (relays || []).length
+    let settled = false
+    let timer = null
+    const finish = () => {
+      if (settled) return
+      settled = true
+      if (timer) clearTimeout(timer)
+      for (const w of socks) { try { w.close() } catch { /* already closed */ } }
+      resolve(collect())
+    }
+    if (!pending) return finish()
+    timer = setTimeout(finish, timeoutMs)
+    for (const url of relays) {
+      let ws
+      let spent = false
+      const done = () => { if (spent) return; spent = true; if (--pending <= 0) finish() }
+      try { ws = mkSocket(url) } catch { done(); continue }
+      socks.push(ws)
+      try { each(ws, done, finish) } catch { done() }
+    }
+  })
+}
+
+function fetchProfileName(pubkey, mkSocket) {
   const hit = nameCache.get(pubkey)
   if (hit && Date.now() - hit.ts < NAME_TTL_MS) return Promise.resolve(hit.name)
-  return new Promise(res => {
-    let best = null, open = PUB.relays.length, done = false
-    // Sockets are tracked and closed by finish() — matching fetchEventById. Closing only in bye()
-    // left every socket of a relay that never answers open FOREVER when the 2s timeout won the
-    // race, which is exactly the case the timeout exists for.
-    const socks = []
-    const finish = () => {
-      if (done) return
-      done = true
-      for (const w of socks) { try { w.close() } catch { /* already closed */ } }
-      cacheName(pubkey, best)
-      res(best)
-    }
-    if (!open) return finish()
-    const t = setTimeout(finish, 2000)
-    for (const url of PUB.relays) {
-      let ws
-      try { ws = new WebSocket(url) } catch { if (--open === 0) { clearTimeout(t); finish() } continue }
-      socks.push(ws)
-      const bye = () => { try { ws.close() } catch { /* closed */ } if (--open === 0) { clearTimeout(t); finish() } }
+  // Best-effort: take the best name any relay offers; settle when all have answered or the 2s
+  // budget runs out. A relay that never replies costs the timeout, never a hang.
+  let best = null
+  return fanout(PUB.relays, {
+    timeoutMs: 2000,
+    mkSocket,
+    each: (ws, done) => {
       ws.on('open', () => ws.send(JSON.stringify(['REQ', 'nm', { kinds: [0], authors: [pubkey], limit: 1 }])))
       ws.on('message', d => {
         try {
@@ -739,11 +767,12 @@ function fetchProfileName(pubkey) {
             const raw = String(p.display_name || p.name || '').replace(/[`@\[\]()\n\r*_~]/g, '').trim().slice(0, 32)
             if (raw) best = raw
           }
-          if (m[0] === 'EOSE') bye()
+          if (m[0] === 'EOSE') done()
         } catch { /* ignore bad frames */ }
       })
-      ws.on('error', bye)
-    }
+      ws.on('error', done)
+    },
+    collect: () => { cacheName(pubkey, best); return best },
   })
 }
 
@@ -998,21 +1027,25 @@ function withdraw(origId, entry, delEv) {
 //   reject  — explicit no (records the decision; author stays quarantined)
 const stagingByBuzzId = new Map() // buzz event id of a staging post -> { orig, author, dest }
 
-function fetchEventById(id) {
-  return new Promise(res => {
-    const socks = []
-    let settled = false
-    const finish = ev => { if (settled) return; settled = true; for (const w of socks) { try { w.close() } catch { /* closed */ } } res(ev || null) }
-    setTimeout(() => finish(null), 10000)
-    for (const url of PUB.relays) {
-      try {
-        const w = new WebSocket(url)
-        socks.push(w)
-        w.on('open', () => w.send(JSON.stringify(['REQ', 'fx', { ids: [id] }])))
-        w.on('message', d => { try { const m = JSON.parse(d.toString()); if (m[0] === 'EVENT' && m[2] && m[2].id === id) finish(m[2]) } catch { /* ignore */ } })
-        w.on('error', () => { /* dead relay */ })
-      } catch { /* bad url */ }
-    }
+// First-match: the first relay to serve the event by id ends the whole fan-out. A relay that never
+// answers is not waited on beyond the budget. (The old copy never cleared its 10s timer, so the
+// process held it open after settling; fanout disarms it.)
+function fetchEventById(id, mkSocket) {
+  let found = null
+  return fanout(PUB.relays, {
+    timeoutMs: 10000,
+    mkSocket,
+    each: (ws, done, settleNow) => {
+      ws.on('open', () => ws.send(JSON.stringify(['REQ', 'fx', { ids: [id] }])))
+      ws.on('message', d => {
+        try {
+          const m = JSON.parse(d.toString())
+          if (m[0] === 'EVENT' && m[2] && m[2].id === id) { found = m[2]; settleNow() }
+        } catch { /* ignore */ }
+      })
+      ws.on('error', done)
+    },
+    collect: () => found || null,
   })
 }
 
@@ -1144,23 +1177,26 @@ function rlDropOnce(id) {
 // chosen accept-count with no socket — the same shape #5's scanChannel(fetchPage) uses. WB_STUB_SEND
 // keeps the socket-free tests honest: it means "assume it landed on every configured relay", so the
 // crypto still runs but the count is positive, never a spurious 0/N.
-function publishWrapToRelays(wrap) {
-  return new Promise((resolve) => {
-    if (process.env.WB_STUB_SEND) return resolve(PUB.relays.length || 1)
-    const relays = PUB.relays || []
-    if (!relays.length) return resolve(0)
-    let settled = 0, accepted = 0, done = false
-    const finish = () => { if (!done) { done = true; resolve(accepted) } }
-    const t = setTimeout(finish, 10000)                    // a relay that opens but never OKs is bounded here
-    const tally = () => { if (++settled >= relays.length) { clearTimeout(t); finish() } }
-    for (const url of relays) {
-      let w, counted = false
-      const one = (ok) => { if (counted) return; counted = true; if (ok) accepted++; try { w && w.close() } catch { /* */ } tally() }
-      try { w = new WebSocket(url) } catch { tally(); continue }
-      w.on('open', () => w.send(JSON.stringify(['EVENT', wrap])))
-      w.on('message', d => { try { const m = JSON.parse(d.toString()); if (m[0] === 'OK' && m[1] === wrap.id) one(!!m[2]) } catch { /* non-OK frame */ } })
-      w.on('error', () => one(false))
-    }
+function publishWrapToRelays(wrap, mkSocket) {
+  if (process.env.WB_STUB_SEND) return Promise.resolve(PUB.relays.length || 1)
+  // All-settled-with-a-count: per-relay OK-true is the ONLY landing signal. A relay that opens but
+  // never OKs is bounded by the budget, and an explicit ["OK", id, false] rejection must not read
+  // as an accept — counting any inbound frame was finding #2.
+  let accepted = 0
+  return fanout(PUB.relays || [], {
+    timeoutMs: 10000,
+    mkSocket,
+    each: (ws, done) => {
+      ws.on('open', () => ws.send(JSON.stringify(['EVENT', wrap])))
+      ws.on('message', d => {
+        try {
+          const m = JSON.parse(d.toString())
+          if (m[0] === 'OK' && m[1] === wrap.id) { if (m[2]) accepted++; done() }
+        } catch { /* non-OK frame */ }
+      })
+      ws.on('error', done)
+    },
+    collect: () => accepted,
   })
 }
 
@@ -1662,7 +1698,7 @@ function connectPublic(url) {
 // Exported so a harness can drive the REAL routing functions (not a copy) with synthetic
 // events in dryrun, without opening any relay socket. Set WB_NO_BOOT=1 to import without
 // booting the live subscriber. No effect on normal `node src/bridge.mjs` runs.
-export { durableSet, returnLaneSend, publishWrapToRelays, scanReturnLane, pollScanChannels, scanChannel, scanSince, bumpScanCursor, loadScanCursors, agentAuthoredBy, rlSeen, rlKey, loadRlSeen, markRlSeen, addRlSeen, dropRlSeen, route, routePublic, routeDelete, processGrantEvent, grantSet, forwardPublic, clampCreated, rateOk, bumpPubWatermark, loadPubWatermark, markSeen, seen, PUB, postedMap, recordPosted, parseBuzzEventId, resolveChannels, handleRelayIngress, relaySeen, markRelaySeen, addRelaySeen, dropRelaySeen, loadRelaySeen, relayRateOk, resolveRelayDest, relayDropTotalPreAuth, relayDropCounts }
+export { durableSet, fanout, fetchEventById, returnLaneSend, publishWrapToRelays, scanReturnLane, pollScanChannels, scanChannel, scanSince, bumpScanCursor, loadScanCursors, agentAuthoredBy, rlSeen, rlKey, loadRlSeen, markRlSeen, addRlSeen, dropRlSeen, route, routePublic, routeDelete, processGrantEvent, grantSet, forwardPublic, clampCreated, rateOk, bumpPubWatermark, loadPubWatermark, markSeen, seen, PUB, postedMap, recordPosted, parseBuzzEventId, resolveChannels, handleRelayIngress, relaySeen, markRelaySeen, addRelaySeen, dropRelaySeen, loadRelaySeen, relayRateOk, resolveRelayDest, relayDropTotalPreAuth, relayDropCounts }
 
 // --- boot -------------------------------------------------------------------
 if (!process.env.WB_NO_BOOT) {

--- a/tests/relay_fanout.mjs
+++ b/tests/relay_fanout.mjs
@@ -1,0 +1,137 @@
+// fanout — the shared relay fan-out primitive (#153).
+//
+// Three call sites hand-rolled this before: fetchProfileName, fetchEventById and
+// publishWrapToRelays. They diverged, and the divergence was a bug — one closed its sockets in
+// finish(), another only on EOSE/error, so a relay that opened and never answered leaked its socket
+// FOREVER, precisely when the timeout won the race. That is the case the timeout exists for, and
+// nothing asserted it, which is why it survived until it was read by eye.
+//
+// So the load-bearing check here is: WHEN THE TIMEOUT WINS, EVERY SOCKET IS CLOSED.
+//
+// No network. `mkSocket` is injected, so the settle rules are drivable directly — the first time
+// these paths have been testable at all.
+//
+// Run: node tests/relay_fanout.mjs   (exit 0 = pass, 1 = fail)
+
+import { mkdtempSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+const dir = mkdtempSync(join(tmpdir(), 'wb-fanout-'))
+process.env.WB_NO_BOOT = '1'
+process.env.FORWARD_MODE = 'dryrun'
+process.env.SEEN_PATH = join(dir, 'seen.log')
+process.env.PUB_WATERMARK_PATH = join(dir, 'watermark')
+
+const { fanout } = await import('../src/bridge.mjs')
+
+let fails = 0
+const ok = (n, c) => { console.info(`${c ? 'ok  ' : 'FAIL'} — ${n}`); if (!c) fails++ }
+
+// A socket that records what was done to it and never answers unless told to.
+function fakeSocket(url) {
+  const handlers = {}
+  return {
+    url,
+    closed: false,
+    sent: [],
+    on(ev, fn) { (handlers[ev] ||= []).push(fn); return this },
+    close() { this.closed = true },
+    emit(ev, ...a) { for (const fn of handlers[ev] || []) fn(...a) },
+    frame(obj) { this.emit('message', { toString: () => JSON.stringify(obj) }) },
+  }
+}
+const makeFactory = (made) => (url) => { const s = fakeSocket(url); made.push(s); return s }
+const RELAYS = ['wss://a.invalid', 'wss://b.invalid', 'wss://c.invalid']
+
+// --- THE bug: a relay that opens and never answers must not leak its socket ------------------
+{
+  const made = []
+  const started = Date.now()
+  const result = await fanout(RELAYS, {
+    timeoutMs: 50,
+    mkSocket: makeFactory(made),
+    each: () => { /* deliberately silent: nobody ever calls done() */ },
+    collect: () => 'timed-out',
+  })
+  ok('a silent fan-out still settles, on the timeout', result === 'timed-out')
+  ok('  it waited for the budget rather than returning instantly', Date.now() - started >= 45)
+  ok('  EVERY socket is closed when the timeout wins (the #153 bug)',
+    made.length === 3 && made.every(s => s.closed))
+}
+
+// --- first-match settles early, and closes the losers ----------------------------------------
+{
+  const made = []
+  const p = fanout(RELAYS, {
+    timeoutMs: 5000,
+    mkSocket: makeFactory(made),
+    each: (ws, done, settleNow) => {
+      ws.on('message', (d) => { if (JSON.parse(d.toString())[0] === 'HIT') settleNow() })
+      ws.on('error', done)
+    },
+    collect: () => 'first-match',
+  })
+  made[1].frame(['HIT'])
+  ok('first-match settles as soon as one relay answers', await p === 'first-match')
+  ok('  the relays that did not answer are closed too', made.every(s => s.closed))
+}
+
+// --- all-settled counts only what actually landed ---------------------------------------------
+{
+  const made = []
+  let accepted = 0
+  const p = fanout(RELAYS, {
+    timeoutMs: 5000,
+    mkSocket: makeFactory(made),
+    each: (ws, done) => {
+      ws.on('message', (d) => { const m = JSON.parse(d.toString()); if (m[0] === 'OK') { if (m[2]) accepted++; done() } })
+      ws.on('error', done)
+    },
+    collect: () => accepted,
+  })
+  made[0].frame(['OK', 'id', true])    // accepted
+  made[1].frame(['OK', 'id', false])   // an explicit REJECTION is not an accept
+  made[2].emit('error', new Error('dead relay'))
+  ok('all-settled resolves once every relay has answered', await p === 1)
+  ok('  an explicit OK-false is not counted as an accept', accepted === 1)
+}
+
+// --- a socket that cannot even be constructed must not hang the fan-out -----------------------
+{
+  const made = []
+  let n = 0
+  const p = fanout(RELAYS, {
+    timeoutMs: 5000,
+    mkSocket: (url) => { if (++n === 2) throw new Error('bad url'); const s = fakeSocket(url); made.push(s); return s },
+    each: (ws, done) => ws.on('error', done),
+    collect: () => 'settled',
+  })
+  for (const s of made) s.emit('error', new Error('x'))
+  ok('a socket that throws on construction is counted, not waited on', await p === 'settled')
+}
+
+// --- an empty relay set resolves immediately, and does not arm a timer -------------------------
+{
+  const started = Date.now()
+  const r = await fanout([], { timeoutMs: 10000, mkSocket: () => { throw new Error('never') }, each: () => {}, collect: () => 'empty' })
+  ok('an empty relay set settles immediately', r === 'empty' && Date.now() - started < 1000)
+}
+
+// --- settle happens exactly once ---------------------------------------------------------------
+{
+  const made = []
+  let collected = 0
+  const p = fanout(RELAYS, {
+    timeoutMs: 5000,
+    mkSocket: makeFactory(made),
+    each: (ws, done, settleNow) => { ws.on('message', () => settleNow()); ws.on('error', done) },
+    collect: () => ++collected,
+  })
+  made[0].frame(['x']); made[1].frame(['x']); made[2].frame(['x'])   // three racing settles
+  await p
+  ok('collect() runs exactly once even when several relays settle at once', collected === 1)
+}
+
+console.info(fails ? `\nrelay_fanout: ${fails} check(s) failed` : '\nrelay_fanout: all checks passed')
+process.exit(fails ? 1 : 0)


### PR DESCRIPTION
Closes #153. Third of the four steps toward #154.

## This one had already cost a bug

`fetchProfileName`, `fetchEventById` and `publishWrapToRelays` each hand-rolled *"open a socket per relay, race them, settle once, clean up"*. The copies diverged:

- `fetchEventById` closed its sockets in `finish()`
- `fetchProfileName` closed them only on EOSE/error

So a relay that opened and never answered leaked its socket **forever** — precisely when the timeout won the race, which is the case the timeout exists for. #142 fixed the leaky copy by hand, after noticing it by eye.

That is the standing cost of copy-adapt: the bug lives in one copy, and the fix lands in one copy. `fanout` shares the parts that went wrong — cleanup, timeout arming/disarming, the settle-once guard, the `try/catch` around construction — and those are exactly the parts that had drifted.

## What is *not* shared, deliberately

The three settle rules are real behaviour, not accidental variation:

| call site | settles when |
|---|---|
| `fetchProfileName` | all relays answered, or 2s — best name wins |
| `fetchEventById` | **first** relay serves the id |
| `publishWrapToRelays` | all relays answered, or 10s — counts OK-**true** only |

Flattening those into one policy would change behaviour, so the primitive **takes** the rule rather than picking one. `each(ws, done, settleNow)` wires a socket; `collect()` returns what the caller accumulated.

`connect` / `connectPublic` are **out of scope**: persistent, reconnecting subscriptions are a different shape, and folding them in would turn a mechanical refactor into a rewrite of the connection lifecycle.

## Two incidental fixes fall out

- `fetchEventById` never cleared its 10s timer, so the process held it open after settling. `fanout` disarms it.
- The OK-true accept test now exists in one place, so an explicit `["OK", id, false]` rejection cannot be miscounted as an accept in a future edit — that was finding #2 on the return lane once already.

## New suite, and the property it holds

`mkSocket` is injectable, which makes these paths testable **without a network for the first time** — the same seam shape `scanChannel(fetchPage)` and `returnLaneSend(publish)` already use.

`tests/relay_fanout.mjs` holds the assertion that was missing:

> **When the timeout wins, every socket is closed.**

Plus: first-match closes the losers, OK-false is not an accept, a socket that throws on construction doesn't hang the fan-out, an empty relay set settles immediately, and `collect()` runs exactly once under racing settles.

**Negative control** — reintroducing the precise #153 bug (dropping the close loop from `finish`):

```
FAIL —   EVERY socket is closed when the timeout wins (the #153 bug)
FAIL —   the relays that did not answer are closed too
suite exit: 1     npm test: 1
```

Restored: both 0.

## Verification

- `npm test` — exit 0, 14/14
- `npm run lint` — exit 0
- Existing suites unedited
- Negative control run on the real failure mode

## Merge-order note

**This and #155 both move the suite count 13 → 14.** Whichever merges second needs the count bumped to 15 and its suite name added to the two rosters — one number in three files. I'll handle it on whichever lands second; flagging so it isn't a surprise. #156 deliberately avoids this by adding its control to an existing suite.

Drafted with assistance from [Claude Code](https://claude.com/claude-code).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jz1HxpLeG5DZkNigLDUJYL)_