### PR TITLE
refactor: split the leaf modules out of bridge.mjs, and test that it boots

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,14 +117,14 @@ that merely ran.** The suite was green through all of them.
 
 ## Tests
 
-`npm test` — 15 suites, against the real exported functions with synthetic events. No sockets,
+`npm test` — 16 suites, against the real exported functions with synthetic events. No sockets,
 no production state, no writes outside a temp dir.
 
-durable dedup store · relay fan-out · quarantine gating · deletion propagation · sealed-lane rate caps · grant
+boot · durable dedup store · relay fan-out · quarantine gating · deletion propagation · sealed-lane rate caps · grant
 admission · message rendering · deployed-build verification · return lane · return-lane scan ·
 return-lane no-miss · relay ingress · tripwire union · tripwire detection drill · deploy runner
 
-CI runs them on push and PR. **If a run reports fewer than 15, the branch is on a stale base.**
+CI runs them on push and PR. **If a run reports fewer than 16, the branch is on a stale base.**
 The count of record is the `test` script in `package.json`; a prose count that disagrees with it
 is the prose being wrong.
 

--- a/README.md
+++ b/README.md
@@ -104,10 +104,10 @@ against what git says, because a stale build is invisible while every status sur
 
 ## Tests
 
-`npm test` runs 15 suites against the **real** exported functions with synthetic events — no
+`npm test` runs 16 suites against the **real** exported functions with synthetic events — no
 sockets, no production state:
 
-durable dedup store · relay fan-out · quarantine gating · deletion propagation · sealed-lane rate caps · grant
+boot · durable dedup store · relay fan-out · quarantine gating · deletion propagation · sealed-lane rate caps · grant
 admission · message rendering · deployed-build verification · return lane · return-lane scan ·
 return-lane no-miss · relay ingress · tripwire union · tripwire detection drill · deploy runner
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -120,7 +120,7 @@ in [deploy/README.md](../deploy/README.md).
 - **Publish the agent relay list:** `node tools/publish_relay_list.mjs` (so the identity
   is discoverable).
 - **Admit a participant**, if you want one: `sh tools/grant-setup.sh`.
-- **Run the safety gates before you ship:** `npm test` — 15 suites driving the real
+- **Run the safety gates before you ship:** `npm test` — 16 suites driving the real
   routing functions with synthetic events (no sockets, no production state), all green.
 
 `waggle-init.mjs --check` rolls the config half of this into one readiness verdict; the

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "start": "node src/bridge.mjs",
     "dryrun": "FORWARD_MODE=dryrun node src/bridge.mjs",
     "lint": "eslint src tools tests",
-    "test": "node tests/relay_fanout.mjs && node tests/durable_store.mjs && node tests/a1_quarantine.mjs && node tests/a7_deletion.mjs && node tests/lane2_caps.mjs && node tests/nipda_admission.mjs && node tests/render_states.mjs && node tests/deploy_verify.mjs && node tests/return_lane.mjs && node tests/return_lane_scan.mjs && node tests/return_lane_nomiss.mjs && node tests/relay_ingress.mjs && node tests/tripwire_union.mjs && node tests/tripwire_detection.mjs && node tests/deploy_runner.mjs",
+    "test": "node tests/boot.mjs && node tests/relay_fanout.mjs && node tests/durable_store.mjs && node tests/a1_quarantine.mjs && node tests/a7_deletion.mjs && node tests/lane2_caps.mjs && node tests/nipda_admission.mjs && node tests/render_states.mjs && node tests/deploy_verify.mjs && node tests/return_lane.mjs && node tests/return_lane_scan.mjs && node tests/return_lane_nomiss.mjs && node tests/relay_ingress.mjs && node tests/tripwire_union.mjs && node tests/tripwire_detection.mjs && node tests/deploy_runner.mjs",
     "console": "node tools/serve-console.mjs"
   },
   "dependencies": {

--- a/src/bridge.mjs
+++ b/src/bridge.mjs
@@ -41,6 +41,12 @@ import { createHash } from 'node:crypto'
 import { readFileSync, writeFileSync, appendFileSync, existsSync, mkdirSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
+// Extracted leaf modules (#154). Each is dependency-free of config and ambient state, which is why
+// these four came out first — the split is staged, not big-bang.
+import { log, err } from './log.mjs'
+import { durableSet } from './stores.mjs'
+import { fanout } from './fanout.mjs'
+import { defuseRefs, defuseMarkup, quoted, renderQuarantined, renderReleased } from './render.mjs'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const ROOT = resolve(__dirname, '..')
@@ -73,8 +79,6 @@ const SINCE = Math.floor(Date.now() / 1000) - SINCE_SECS
 const CHANNEL_SINCE_SECS = process.env.CHANNEL_SINCE_SECS != null ? Number(process.env.CHANNEL_SINCE_SECS) : 3600 // 1h
 const CHANNEL_SINCE = Math.floor(Date.now() / 1000) - CHANNEL_SINCE_SECS
 
-const log = (...a) => console.log(new Date().toISOString(), ...a)
-const err = (...a) => console.error(new Date().toISOString(), ...a)
 
 // --- config -----------------------------------------------------------------
 if (!existsSync(CONFIG_PATH)) {
@@ -310,50 +314,6 @@ if (FORWARD_MODE === 'buzz' && !process.env.BUZZ_PRIVATE_KEY) {
   err('WARN: FORWARD_MODE=buzz but BUZZ_PRIVATE_KEY is unset — buzz sends will fail auth. Set the bridge identity.')
 }
 
-// --- durable dedup ----------------------------------------------------------
-// Three lanes each keep a durable "already handled this" set, and all three want the same three
-// things: an in-memory Set for the hot check, an append-only file so a restart cannot re-deliver,
-// and a cap so that file cannot grow forever. They were written three times, and they drifted —
-// only two grew the claim/rollback split that #121 added after one wrap posted twice, 423ms
-// apart, because the entry check and the durable write sat on opposite sides of an async send.
-// Whether the third is safe without it is a timing argument someone had to re-derive by hand on
-// every visit, which is exactly the kind of reasoning that decays.
-//
-// One primitive makes the whole vocabulary available to every lane. Which parts a lane USES stays
-// that lane's decision, argued at its own call sites — this changes what is *available*, never
-// what any lane currently does:
-//
-//   has       the hot check
-//   claim     in-memory only — suppress a duplicate while an async send is in flight
-//   rollback  undo a claim, so a failed send retries instead of being silently suppressed
-//   commit    claim + durable append — survives a restart
-//
-// `mem` is the Set itself, exposed because the lanes (and the suites) check it directly.
-function durableSet({ path, cap, label, noun }) {
-  const mem = new Set()
-  return {
-    mem,
-    has: (k) => mem.has(k),
-    claim: (k) => { mem.add(k) },
-    rollback: (k) => { mem.delete(k) },
-    commit(k) {
-      mem.add(k)
-      // Truncated at 64 so a full event id still prints whole, while a long composite key
-      // (source × recipient) cannot flood the journal the tripwire reads.
-      try { appendFileSync(path, k + '\n') }
-      catch (e) { err(`${label}: append failed for ${String(k).slice(0, 64)}: ${e.message}`) }
-    },
-    load() {
-      // The mkdir on the missing-file path is what guarantees the directory exists for every
-      // later append, which is why commit() does not repeat it per write.
-      if (!existsSync(path)) { mkdirSync(dirname(path), { recursive: true }); return }
-      const lines = readFileSync(path, 'utf8').split('\n').filter(Boolean)
-      const kept = lines.slice(-cap)
-      for (const k of kept) mem.add(k)
-      log(`${label}: loaded ${mem.size} ${noun} from ${path}${lines.length > kept.length ? ` (pruned ${lines.length - kept.length})` : ''}`)
-    },
-  }
-}
 
 // DM + public lane dedup: forwarded event ids, re-hydrated on boot so a bounce (or a SINCE
 // backfill) never re-delivers something already pushed. Commit-before-dispatch on the public
@@ -707,46 +667,6 @@ function cacheName(pubkey, name) {
   nameCache.set(pubkey, { name, ts: Date.now() })
   if (nameCache.size > NAME_CACHE_CAP) nameCache.delete(nameCache.keys().next().value)
 }
-// One-shot relay fan-out: open a socket per relay, race them, settle exactly once, close everything.
-// Written three times before this (#153), and the copies diverged with a bug — one closed its
-// sockets in finish(), another only on EOSE/error, so a relay that opened and never answered leaked
-// its socket forever precisely when the timeout won, which is the case the timeout exists for. That
-// fix had to be noticed and hand-applied to one copy. Here it cannot diverge: cleanup, timeout
-// arming and disarming, the settle-once guard, and the try/catch around construction are the shared
-// parts — and they are exactly the parts that went wrong.
-//
-// What is NOT shared is the settle RULE, because the three genuinely differ (first-match,
-// all-settled-with-a-count, best-effort-with-a-default) and flattening that would change behaviour.
-// `each(ws, done, settleNow)` wires one socket: call `done()` when that socket has nothing more to
-// give, or `settleNow()` to end the whole fan-out early. `collect()` returns the accumulated result.
-//
-// `mkSocket` is injectable so the settle rules are drivable with no network — the same seam shape
-// scanChannel(fetchPage) and returnLaneSend(publish) already use.
-function fanout(relays, { timeoutMs, each, collect, mkSocket = (url) => new WebSocket(url) }) {
-  return new Promise((resolve) => {
-    const socks = []
-    let pending = (relays || []).length
-    let settled = false
-    let timer = null
-    const finish = () => {
-      if (settled) return
-      settled = true
-      if (timer) clearTimeout(timer)
-      for (const w of socks) { try { w.close() } catch { /* already closed */ } }
-      resolve(collect())
-    }
-    if (!pending) return finish()
-    timer = setTimeout(finish, timeoutMs)
-    for (const url of relays) {
-      let ws
-      let spent = false
-      const done = () => { if (spent) return; spent = true; if (--pending <= 0) finish() }
-      try { ws = mkSocket(url) } catch { done(); continue }
-      socks.push(ws)
-      try { each(ws, done, finish) } catch { done() }
-    }
-  })
-}
 
 function fetchProfileName(pubkey, mkSocket) {
   const hit = nameCache.get(pubkey)
@@ -776,64 +696,6 @@ function fetchProfileName(pubkey, mkSocket) {
   })
 }
 
-// --- Presentation. Follows TRUST — but a quarantined message still has to be READ, because a
-// human is being asked to judge it. An earlier cut wrapped untrusted text in a code fence:
-// safe, and unusable. Fences don't wrap, so the message ran off the edge behind a line-number
-// gutter and truncated mid-sentence — we were asking for a decision about content the approver
-// could not see. The guard was doing its job at the expense of the job.
-//
-// So: NEUTRALISE rather than ENCASE. The escaping below was always what made untrusted text
-// safe; the fence was belt-and-braces charging legibility for it.
-const ZWSP = '​'
-// A zero-width space after @ and nostr: — the reference RENDERS but never resolves to a real
-// ping. Applied to every reposted body, vouched or not: nobody gets to summon a member.
-export const defuseRefs = (s) => String(s)
-  .replace(/@(?=[\w])/g, `@${ZWSP}`)
-  .replace(/\bnostr:/gi, `nostr${ZWSP}:`)
-// A zero-width space before line-leading markdown, so an unvouched sender can't mint headings,
-// rules, lists, tables or nested fences that imitate our own chrome. The impersonation that
-// matters is a quarantined note dressed up as an approval notice. Quarantined text only — a
-// vouched identity keeps its formatting.
-export const defuseMarkup = (s) => String(s)
-  .replace(/```/g, `\`${ZWSP}\`\``)
-  .replace(/^(\s*)([#>\-*+`|=~_]|\d+[.)])/gm, `$1${ZWSP}$2`)
-export const quoted = (s) => String(s).replace(/\r/g, '').split('\n').map(l => `> ${l}`).join('\n')
-
-// One unmistakable state line, then the MESSAGE — readable, wrapping, set apart as a quote —
-// then provenance and the actions. The old order buried the thing being judged under five
-// lines of instructions, which is backwards for a screen whose only job is a human decision.
-export function renderQuarantined({ body, mention = '', name, npub, when, claim = '', why, id }) {
-  return `${mention}⏳ **QUARANTINED** — external Nostr reply, held out of every channel until you approve it.\n\n` +
-    quoted(defuseMarkup(defuseRefs(body))) + '\n\n' +
-    `**from** ${name ? `**${name}** · ` : ''}\`${npub}\`  ·  ${when}${claim}  ·  _${why}_\n` +
-    `Reply **approve** · **follow** · **mute** · **reject** — or \`waggle-approve ${id}\``
-}
-
-// A vouched identity — released, granted, or a followed author. Reads as an ordinary message:
-// flowing text, no code bubble, no gutter. A8 (native foreign-signed rendering) is what finally
-// puts the participant's OWN avatar and name on it; until then this is a bridge-authored
-// message that reads as cleanly as a repost can.
-// `liveRefs` decides whether the body's @mentions survive (#94). Presentation follows trust, and
-// defuseMarkup already states the rule this completes: "a vouched identity keeps its formatting."
-// That exception was implemented for markup and never for refs, so EVERY reposted body had its
-// mentions killed — a signed, revocably-granted participant's included. The cost was not
-// cosmetic: an admitted agent could be carried into the room and still not wake a single
-// colleague, which is the entire point of being admitted. That is what pushed operators onto a
-// path that signs as the bridge instead. #94 diagnosed it exactly and was closed on a screenshot
-// taken from that other path, where defuseRefs never runs.
-//
-// DEFAULT FALSE — fail closed. Only a live NIP-DA grant (signed, scoped, revocable by a 441)
-// buys live refs. A mirrored feed does not: `watch_authors` streams an author's ENTIRE public
-// feed inward, so honouring refs there would let any watched note summon the room. Nor does a
-// standing follow (reply-trust is strictly narrower than admission), nor content a human released
-// from quarantine — approving a stranger's note means "this may be published", never "this may
-// summon people".
-export function renderReleased({ body, name, npubShort, liveRefs = false }) {
-  return `**${name || npubShort}**  ·  \`${npubShort}\`  ·  _via waggle_\n\n${liveRefs ? body : defuseRefs(body)}`
-}
-
-// Repost a PLAINTEXT public note into a Buzz channel. `dest` is the community inbox for a
-// trusted (allowlisted) note, or the STAGING inbox for a quarantined external reply (A1).
 // No unwrap label, no key — already-public content.
 async function forwardPublic(ev, why, dest, quarantine) {
   const author = ev.pubkey ? ev.pubkey.slice(0, 16) : '?'
@@ -1698,7 +1560,7 @@ function connectPublic(url) {
 // Exported so a harness can drive the REAL routing functions (not a copy) with synthetic
 // events in dryrun, without opening any relay socket. Set WB_NO_BOOT=1 to import without
 // booting the live subscriber. No effect on normal `node src/bridge.mjs` runs.
-export { durableSet, fanout, fetchEventById, returnLaneSend, publishWrapToRelays, scanReturnLane, pollScanChannels, scanChannel, scanSince, bumpScanCursor, loadScanCursors, agentAuthoredBy, rlSeen, rlKey, loadRlSeen, markRlSeen, addRlSeen, dropRlSeen, route, routePublic, routeDelete, processGrantEvent, grantSet, forwardPublic, clampCreated, rateOk, bumpPubWatermark, loadPubWatermark, markSeen, seen, PUB, postedMap, recordPosted, parseBuzzEventId, resolveChannels, handleRelayIngress, relaySeen, markRelaySeen, addRelaySeen, dropRelaySeen, loadRelaySeen, relayRateOk, resolveRelayDest, relayDropTotalPreAuth, relayDropCounts }
+export { durableSet, fanout, defuseRefs, defuseMarkup, quoted, renderQuarantined, renderReleased, fetchEventById, returnLaneSend, publishWrapToRelays, scanReturnLane, pollScanChannels, scanChannel, scanSince, bumpScanCursor, loadScanCursors, agentAuthoredBy, rlSeen, rlKey, loadRlSeen, markRlSeen, addRlSeen, dropRlSeen, route, routePublic, routeDelete, processGrantEvent, grantSet, forwardPublic, clampCreated, rateOk, bumpPubWatermark, loadPubWatermark, markSeen, seen, PUB, postedMap, recordPosted, parseBuzzEventId, resolveChannels, handleRelayIngress, relaySeen, markRelaySeen, addRelaySeen, dropRelaySeen, loadRelaySeen, relayRateOk, resolveRelayDest, relayDropTotalPreAuth, relayDropCounts }
 
 // --- boot -------------------------------------------------------------------
 if (!process.env.WB_NO_BOOT) {

--- a/src/fanout.mjs
+++ b/src/fanout.mjs
@@ -1,0 +1,48 @@
+// Extracted from bridge.mjs by #154. Behaviour is byte-identical; only the file boundary is new.
+//
+// Takes its relay list as an argument and its socket factory as an injectable, so it knows nothing
+// about config. That is what makes it testable without a network (tests/relay_fanout.mjs).
+import WebSocket from 'ws'
+
+// One-shot relay fan-out: open a socket per relay, race them, settle exactly once, close everything.
+// Written three times before this (#153), and the copies diverged with a bug — one closed its
+// sockets in finish(), another only on EOSE/error, so a relay that opened and never answered leaked
+// its socket forever precisely when the timeout won, which is the case the timeout exists for. That
+// fix had to be noticed and hand-applied to one copy. Here it cannot diverge: cleanup, timeout
+// arming and disarming, the settle-once guard, and the try/catch around construction are the shared
+// parts — and they are exactly the parts that went wrong.
+//
+// What is NOT shared is the settle RULE, because the three genuinely differ (first-match,
+// all-settled-with-a-count, best-effort-with-a-default) and flattening that would change behaviour.
+// `each(ws, done, settleNow)` wires one socket: call `done()` when that socket has nothing more to
+// give, or `settleNow()` to end the whole fan-out early. `collect()` returns the accumulated result.
+//
+// `mkSocket` is injectable so the settle rules are drivable with no network — the same seam shape
+// scanChannel(fetchPage) and returnLaneSend(publish) already use.
+function fanout(relays, { timeoutMs, each, collect, mkSocket = (url) => new WebSocket(url) }) {
+  return new Promise((resolve) => {
+    const socks = []
+    let pending = (relays || []).length
+    let settled = false
+    let timer = null
+    const finish = () => {
+      if (settled) return
+      settled = true
+      if (timer) clearTimeout(timer)
+      for (const w of socks) { try { w.close() } catch { /* already closed */ } }
+      resolve(collect())
+    }
+    if (!pending) return finish()
+    timer = setTimeout(finish, timeoutMs)
+    for (const url of relays) {
+      let ws
+      let spent = false
+      const done = () => { if (spent) return; spent = true; if (--pending <= 0) finish() }
+      try { ws = mkSocket(url) } catch { done(); continue }
+      socks.push(ws)
+      try { each(ws, done, finish) } catch { done() }
+    }
+  })
+}
+
+export { fanout }

--- a/src/log.mjs
+++ b/src/log.mjs
@@ -1,0 +1,9 @@
+// Timestamped console logging, shared by every lane.
+//
+// Extracted from bridge.mjs by #154 — the first thing every other module needs, so it must be the
+// module with no dependencies of its own. ISO-8601 on every line because these journals are read
+// by the tripwire and correlated against relay timestamps; a bare message cannot be lined up.
+const log = (...a) => console.log(new Date().toISOString(), ...a)
+const err = (...a) => console.error(new Date().toISOString(), ...a)
+
+export { log, err }

--- a/src/render.mjs
+++ b/src/render.mjs
@@ -1,0 +1,62 @@
+// Extracted from bridge.mjs by #154. Behaviour is byte-identical; only the file boundary is new.
+//
+// Pure string transformation: no config, no I/O, no ambient state. That is why it is the safest
+// module to lift out first, and why the render_states suite can drive it directly.
+// --- Presentation. Follows TRUST — but a quarantined message still has to be READ, because a
+// human is being asked to judge it. An earlier cut wrapped untrusted text in a code fence:
+// safe, and unusable. Fences don't wrap, so the message ran off the edge behind a line-number
+// gutter and truncated mid-sentence — we were asking for a decision about content the approver
+// could not see. The guard was doing its job at the expense of the job.
+//
+// So: NEUTRALISE rather than ENCASE. The escaping below was always what made untrusted text
+// safe; the fence was belt-and-braces charging legibility for it.
+const ZWSP = '​'
+// A zero-width space after @ and nostr: — the reference RENDERS but never resolves to a real
+// ping. Applied to every reposted body, vouched or not: nobody gets to summon a member.
+export const defuseRefs = (s) => String(s)
+  .replace(/@(?=[\w])/g, `@${ZWSP}`)
+  .replace(/\bnostr:/gi, `nostr${ZWSP}:`)
+// A zero-width space before line-leading markdown, so an unvouched sender can't mint headings,
+// rules, lists, tables or nested fences that imitate our own chrome. The impersonation that
+// matters is a quarantined note dressed up as an approval notice. Quarantined text only — a
+// vouched identity keeps its formatting.
+export const defuseMarkup = (s) => String(s)
+  .replace(/```/g, `\`${ZWSP}\`\``)
+  .replace(/^(\s*)([#>\-*+`|=~_]|\d+[.)])/gm, `$1${ZWSP}$2`)
+export const quoted = (s) => String(s).replace(/\r/g, '').split('\n').map(l => `> ${l}`).join('\n')
+
+// One unmistakable state line, then the MESSAGE — readable, wrapping, set apart as a quote —
+// then provenance and the actions. The old order buried the thing being judged under five
+// lines of instructions, which is backwards for a screen whose only job is a human decision.
+export function renderQuarantined({ body, mention = '', name, npub, when, claim = '', why, id }) {
+  return `${mention}⏳ **QUARANTINED** — external Nostr reply, held out of every channel until you approve it.\n\n` +
+    quoted(defuseMarkup(defuseRefs(body))) + '\n\n' +
+    `**from** ${name ? `**${name}** · ` : ''}\`${npub}\`  ·  ${when}${claim}  ·  _${why}_\n` +
+    `Reply **approve** · **follow** · **mute** · **reject** — or \`waggle-approve ${id}\``
+}
+
+// A vouched identity — released, granted, or a followed author. Reads as an ordinary message:
+// flowing text, no code bubble, no gutter. A8 (native foreign-signed rendering) is what finally
+// puts the participant's OWN avatar and name on it; until then this is a bridge-authored
+// message that reads as cleanly as a repost can.
+// `liveRefs` decides whether the body's @mentions survive (#94). Presentation follows trust, and
+// defuseMarkup already states the rule this completes: "a vouched identity keeps its formatting."
+// That exception was implemented for markup and never for refs, so EVERY reposted body had its
+// mentions killed — a signed, revocably-granted participant's included. The cost was not
+// cosmetic: an admitted agent could be carried into the room and still not wake a single
+// colleague, which is the entire point of being admitted. That is what pushed operators onto a
+// path that signs as the bridge instead. #94 diagnosed it exactly and was closed on a screenshot
+// taken from that other path, where defuseRefs never runs.
+//
+// DEFAULT FALSE — fail closed. Only a live NIP-DA grant (signed, scoped, revocable by a 441)
+// buys live refs. A mirrored feed does not: `watch_authors` streams an author's ENTIRE public
+// feed inward, so honouring refs there would let any watched note summon the room. Nor does a
+// standing follow (reply-trust is strictly narrower than admission), nor content a human released
+// from quarantine — approving a stranger's note means "this may be published", never "this may
+// summon people".
+export function renderReleased({ body, name, npubShort, liveRefs = false }) {
+  return `**${name || npubShort}**  ·  \`${npubShort}\`  ·  _via waggle_\n\n${liveRefs ? body : defuseRefs(body)}`
+}
+
+// Repost a PLAINTEXT public note into a Buzz channel. `dest` is the community inbox for a
+// trusted (allowlisted) note, or the STAGING inbox for a quarantined external reply (A1).

--- a/src/stores.mjs
+++ b/src/stores.mjs
@@ -1,0 +1,53 @@
+// Extracted from bridge.mjs by #154. Behaviour is byte-identical; only the file boundary is new.
+//
+// Depends only on node:fs, node:path and the logger — no config, no lane knowledge.
+import { readFileSync, appendFileSync, existsSync, mkdirSync } from 'node:fs'
+import { dirname } from 'node:path'
+import { log, err } from './log.mjs'
+
+// --- durable dedup ----------------------------------------------------------
+// Three lanes each keep a durable "already handled this" set, and all three want the same three
+// things: an in-memory Set for the hot check, an append-only file so a restart cannot re-deliver,
+// and a cap so that file cannot grow forever. They were written three times, and they drifted —
+// only two grew the claim/rollback split that #121 added after one wrap posted twice, 423ms
+// apart, because the entry check and the durable write sat on opposite sides of an async send.
+// Whether the third is safe without it is a timing argument someone had to re-derive by hand on
+// every visit, which is exactly the kind of reasoning that decays.
+//
+// One primitive makes the whole vocabulary available to every lane. Which parts a lane USES stays
+// that lane's decision, argued at its own call sites — this changes what is *available*, never
+// what any lane currently does:
+//
+//   has       the hot check
+//   claim     in-memory only — suppress a duplicate while an async send is in flight
+//   rollback  undo a claim, so a failed send retries instead of being silently suppressed
+//   commit    claim + durable append — survives a restart
+//
+// `mem` is the Set itself, exposed because the lanes (and the suites) check it directly.
+function durableSet({ path, cap, label, noun }) {
+  const mem = new Set()
+  return {
+    mem,
+    has: (k) => mem.has(k),
+    claim: (k) => { mem.add(k) },
+    rollback: (k) => { mem.delete(k) },
+    commit(k) {
+      mem.add(k)
+      // Truncated at 64 so a full event id still prints whole, while a long composite key
+      // (source × recipient) cannot flood the journal the tripwire reads.
+      try { appendFileSync(path, k + '\n') }
+      catch (e) { err(`${label}: append failed for ${String(k).slice(0, 64)}: ${e.message}`) }
+    },
+    load() {
+      // The mkdir on the missing-file path is what guarantees the directory exists for every
+      // later append, which is why commit() does not repeat it per write.
+      if (!existsSync(path)) { mkdirSync(dirname(path), { recursive: true }); return }
+      const lines = readFileSync(path, 'utf8').split('\n').filter(Boolean)
+      const kept = lines.slice(-cap)
+      for (const k of kept) mem.add(k)
+      log(`${label}: loaded ${mem.size} ${noun} from ${path}${lines.length > kept.length ? ` (pruned ${lines.length - kept.length})` : ''}`)
+    },
+  }
+}
+
+export { durableSet }

--- a/tests/boot.mjs
+++ b/tests/boot.mjs
@@ -1,0 +1,86 @@
+// Boot suite — does `node src/bridge.mjs` actually start? (#154)
+//
+// Every other suite sets WB_NO_BOOT=1, which is correct for them: they drive exported functions
+// and must not open sockets. The consequence is that until this file existed, **the boot block was
+// never executed by CI at all** — module-level initialisation, store load order, config resolution
+// and the gate-summary logging were all unexercised.
+//
+// That gap is exactly the risk of splitting bridge.mjs into modules (#154). A missing export, a
+// circular import, or a store loaded before the directory it writes into exists would leave every
+// other suite green and the process dead on the box. `verify-deployed.sh` would not catch it
+// either — it compares file hashes, and a tree that matches git perfectly can still fail to boot.
+//
+// So this spawns the real entry point as a child process, with SEALED_LANES=off and dryrun so it
+// opens nothing, and asserts it initialises and exits cleanly.
+//
+// Run: node tests/boot.mjs   (exit 0 = pass, 1 = fail)
+
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, writeFileSync, mkdirSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const REPO = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const dir = mkdtempSync(join(tmpdir(), 'wb-boot-'))
+const data = join(dir, 'data')
+mkdirSync(data, { recursive: true })
+
+const CFG = join(dir, 'config.json')
+writeFileSync(CFG, JSON.stringify({
+  relays: [], recipients: [{ name: 'A', npub_hex: 'aa', inbox: '11111111-1111-1111-1111-111111111111' }],
+  public: {
+    relays: [], inbox: '22222222-2222-2222-2222-222222222222',
+    staging_inbox: '33333333-3333-3333-3333-333333333333',
+    watch_authors: [], watch_events: [], approvers: [], grantors: [],
+    scan_authors: [], scan_channels: [], relay_channels: [], return_lane: [],
+  },
+}))
+
+let fails = 0
+const ok = (n, c) => { console.log(`${c ? 'ok  ' : 'FAIL'} — ${n}`); if (!c) fails++ }
+
+// Public lane only, no relays configured, dryrun: it initialises, finds nothing to listen on, and
+// drains. Every state path points into the temp dir, so production state is untouched.
+const env = {
+  ...process.env,
+  CONFIG_PATH: CFG,
+  FORWARD_MODE: 'dryrun',
+  SEALED_LANES: 'off',
+  SEEN_PATH: join(data, 'seen.log'),
+  RLSEEN_PATH: join(data, 'return-lane-seen.log'),
+  RELAYSEEN_PATH: join(data, 'relay-lane-seen.log'),
+  POSTED_MAP_PATH: join(data, 'posted-map.log'),
+  PUB_WATERMARK_PATH: join(data, 'pub-watermark'),
+  SCAN_WATERMARK_PATH: join(data, 'scan-watermark.json'),
+  SEND_JOURNAL_PATH: join(data, 'send-journal.log'),
+}
+delete env.WB_NO_BOOT   // the entire point of this suite
+
+let out = '', code = 0
+try {
+  out = execFileSync(process.execPath, ['src/bridge.mjs'], {
+    cwd: REPO, env, encoding: 'utf8', timeout: 20000, stdio: ['ignore', 'pipe', 'pipe'],
+  })
+} catch (e) {
+  code = e.status ?? 1
+  out = (e.stdout || '') + (e.stderr || '')
+}
+
+ok('`node src/bridge.mjs` boots and exits cleanly', code === 0)
+// A module that fails to resolve, or a circular import, surfaces here and nowhere else.
+ok('  no module-resolution or import failure', !/ERR_MODULE_NOT_FOUND|Cannot find module|ERR_REQUIRE_CYCLE/.test(out))
+ok('  no uncaught exception during initialisation', !/^\s*(TypeError|ReferenceError|SyntaxError)/m.test(out))
+ok('  no FATAL', !/FATAL/.test(out))
+
+// Boot-order evidence: these lines only print if initialisation actually reached them, in order.
+ok('  reaches the banner (config parsed, recipients resolved)', /waggle — mode=dryrun/.test(out))
+ok('  reaches the public-lane summary (PUB built, channels resolved)', /public read lane -> inbox/.test(out))
+ok('  reaches the gate summary (rate caps + A7 wired)', /gates: staging=/.test(out))
+
+if (fails) {
+  console.error('\n--- child output ---')
+  console.error(out.split('\n').slice(0, 25).join('\n'))
+}
+console.log(fails ? `\nboot: ${fails} check(s) failed` : '\nboot: all checks passed')
+process.exit(fails ? 1 : 0)


### PR DESCRIPTION
Partial for #154 — **stage one of the split, deliberately not the whole thing.** Leaves #154 open.

## What comes out, and why these four

Four modules, chosen because each has **zero coupling to config or ambient state**. That makes the seam provable rather than argued:

| module | lines | why it was safe to lift |
|---|---|---|
| `log.mjs` | 9 | no dependencies of its own — everything else needs it |
| `render.mjs` | 62 | pure string transformation; no config, no I/O |
| `stores.mjs` | 53 | `durableSet` — takes path/cap as arguments |
| `fanout.mjs` | 48 | takes its relay list and socket factory as arguments |

`bridge.mjs`: **1748 → 1610**.

## What is deliberately *not* here

**Extracting config/`PUB`.** That is the real work — 80 `PUB.` references as ambient module state — and it is the risky part. Doing it in the same PR as four mechanical lifts would make neither reviewable, and #154's own sequencing argument is that the cheap parts come first. The issue stays open for it.

So this PR does not close #154 and does not claim to. It moves 138 lines and proves the seam holds.

## The suites were not edited

Everything the tests import from `bridge.mjs` is re-exported. That is the whole point: **a split that needs a suite touched is a rewrite, not a split.** 15 existing suites pass unchanged.

## The gap this closes matters more than the line count

Every other suite sets `WB_NO_BOOT=1` — correctly, since they drive exported functions and must not open sockets. The consequence:

> **Until this PR, the boot block was never executed by CI at all.**

Module-level initialisation, store load order, and config resolution were entirely unexercised. That is *exactly* what a module split breaks — and `verify-deployed.sh` would not catch it, because it compares file hashes, and a tree that matches git perfectly can still be dead on arrival.

`tests/boot.mjs` spawns the real entry point as a child process and asserts it initialises and exits cleanly, reaching the banner, the public-lane summary and the gate summary in order.

**Two negative controls, both run:**

| injected fault | result |
|---|---|
| unresolvable import (`./stores-GONE.mjs`) | boot suite exit 1, `npm test` exit 1 ✓ |
| module resolves but is missing a named export | boot suite exit 1, `npm test` exit 1 ✓ |

**The second one did not fire on its first attempt.** My `perl` targeted `export { defuseRefs`, but `render.mjs` uses inline `export const` — so it matched nothing, exited 0, and my fallback never ran. The suite was fine; *my test of the test* was broken. Re-run against the real declaration, it fails as it should. Recording it because a control that silently no-ops looks identical to one that passes.

## The failure that would only appear on the box

Verified explicitly: all four new files are **tracked** and inside the deploy ship list's `src` expansion.

```
staged src/ →  bridge.mjs  fanout.mjs  log.mjs  render.mjs  stores.mjs
```

A deploy shipping `bridge.mjs` without `log.mjs` would produce a tree that passes every hash check and does not boot. That is the specific thing `tests/boot.mjs` now guards.

## Verification

- `npm test` — exit 0, **16/16**
- `npm run lint` — exit 0
- 15 pre-existing suites pass **unedited**
- Booted the real entry point by hand before writing the suite, then automated it
- Ship-list membership confirmed against `git ls-tree`, not assumed

Suite count 15 → 16, per #138's rule that `package.json` is the count of record.

Drafted with assistance from [Claude Code](https://claude.com/claude-code).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jz1HxpLeG5DZkNigLDUJYL)_