### PR TITLE
security: reject non-loopback Host on the console server (#145)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,14 +117,14 @@ that merely ran.** The suite was green through all of them.
 
 ## Tests
 
-`npm test` — 16 suites, against the real exported functions with synthetic events. No sockets,
+`npm test` — 17 suites, against the real exported functions with synthetic events. No sockets,
 no production state, no writes outside a temp dir.
 
 boot · durable dedup store · relay fan-out · quarantine gating · deletion propagation · sealed-lane rate caps · grant
 admission · message rendering · deployed-build verification · return lane · return-lane scan ·
-return-lane no-miss · relay ingress · tripwire union · tripwire detection drill · deploy runner
+return-lane no-miss · relay ingress · tripwire union · tripwire detection drill · deploy runner · console Host check
 
-CI runs them on push and PR. **If a run reports fewer than 16, the branch is on a stale base.**
+CI runs them on push and PR. **If a run reports fewer than 17, the branch is on a stale base.**
 The count of record is the `test` script in `package.json`; a prose count that disagrees with it
 is the prose being wrong.
 

--- a/README.md
+++ b/README.md
@@ -104,12 +104,12 @@ against what git says, because a stale build is invisible while every status sur
 
 ## Tests
 
-`npm test` runs 16 suites against the **real** exported functions with synthetic events — no
+`npm test` runs 17 suites against the **real** exported functions with synthetic events — no
 sockets, no production state:
 
 boot · durable dedup store · relay fan-out · quarantine gating · deletion propagation · sealed-lane rate caps · grant
 admission · message rendering · deployed-build verification · return lane · return-lane scan ·
-return-lane no-miss · relay ingress · tripwire union · tripwire detection drill · deploy runner
+return-lane no-miss · relay ingress · tripwire union · tripwire detection drill · deploy runner · console Host check
 
 The rendering suite is the one to read if you are reviewing. It tests what the bridge **refuses**,
 not only what it does: a hostile note tries to ping the approver, mint an `APPROVED BY` heading,

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -120,7 +120,7 @@ in [deploy/README.md](../deploy/README.md).
 - **Publish the agent relay list:** `node tools/publish_relay_list.mjs` (so the identity
   is discoverable).
 - **Admit a participant**, if you want one: `sh tools/grant-setup.sh`.
-- **Run the safety gates before you ship:** `npm test` — 16 suites driving the real
+- **Run the safety gates before you ship:** `npm test` — 17 suites driving the real
   routing functions with synthetic events (no sockets, no production state), all green.
 
 `waggle-init.mjs --check` rolls the config half of this into one readiness verdict; the

--- a/package.json
+++ b/package.json
@@ -5,15 +5,20 @@
   "type": "module",
   "description": "Non-custodial, quarantine-gated two-way bridge between a walled Buzz community and public Nostr.",
   "license": "MIT",
-  "repository": { "type": "git", "url": "git+https://github.com/JAFairweather/waggle.git" },
-  "bugs": { "url": "https://github.com/JAFairweather/waggle/issues" },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/JAFairweather/waggle.git"
+  },
+  "bugs": {
+    "url": "https://github.com/JAFairweather/waggle/issues"
+  },
   "homepage": "https://github.com/JAFairweather/waggle#readme",
   "main": "src/bridge.mjs",
   "scripts": {
     "start": "node src/bridge.mjs",
     "dryrun": "FORWARD_MODE=dryrun node src/bridge.mjs",
     "lint": "eslint src tools tests",
-    "test": "node tests/boot.mjs && node tests/relay_fanout.mjs && node tests/durable_store.mjs && node tests/a1_quarantine.mjs && node tests/a7_deletion.mjs && node tests/lane2_caps.mjs && node tests/nipda_admission.mjs && node tests/render_states.mjs && node tests/deploy_verify.mjs && node tests/return_lane.mjs && node tests/return_lane_scan.mjs && node tests/return_lane_nomiss.mjs && node tests/relay_ingress.mjs && node tests/tripwire_union.mjs && node tests/tripwire_detection.mjs && node tests/deploy_runner.mjs",
+    "test": "node tests/boot.mjs && node tests/relay_fanout.mjs && node tests/durable_store.mjs && node tests/a1_quarantine.mjs && node tests/a7_deletion.mjs && node tests/lane2_caps.mjs && node tests/nipda_admission.mjs && node tests/render_states.mjs && node tests/deploy_verify.mjs && node tests/return_lane.mjs && node tests/return_lane_scan.mjs && node tests/return_lane_nomiss.mjs && node tests/relay_ingress.mjs && node tests/tripwire_union.mjs && node tests/tripwire_detection.mjs && node tests/deploy_runner.mjs && node tests/console_host.mjs",
     "console": "node tools/serve-console.mjs"
   },
   "dependencies": {

--- a/tests/console_host.mjs
+++ b/tests/console_host.mjs
@@ -1,0 +1,96 @@
+// console_host.mjs — the console must refuse a request whose `Host` is not loopback (#145).
+//
+// Why this test exists: binding to 127.0.0.1 answers "which interface accepts the connection",
+// which is NOT "which origin is talking to me". Under DNS rebinding a hostile page re-resolves its
+// own domain to 127.0.0.1 and issues same-origin requests; the connection really does arrive on
+// loopback, so the bind is satisfied and the page reads every response. The `Host` header is the
+// only thing in the request that still distinguishes the operator from the attacker.
+//
+// The console is the SIGNING surface — its promise is "here is exactly what you are about to sign".
+// That promise rests on the operator controlling the page, so reachability from a hostile origin is
+// worth denying there even after #142 removed the secrets from behind it.
+//
+// Drives the real exported `handler` and `hostAllowed` with synthetic requests. No sockets (the
+// server only listens when run as a program), no production state.
+
+import { hostAllowed, handler } from '../tools/serve-console.mjs'
+
+let failures = 0
+const check = (name, cond, detail = '') => {
+  if (cond) return console.log(`  ok   ${name}`)
+  failures++
+  console.log(`  FAIL ${name}${detail ? ` — ${detail}` : ''}`)
+}
+
+console.log('console Host check (#145)')
+
+// ---- the predicate, against the port the console actually documents -------------------------
+
+check('the documented entry point is allowed', hostAllowed('127.0.0.1:8080', 8080))
+check('localhost is allowed (the other spelling operators type)', hostAllowed('localhost:8080', 8080))
+check('IPv6 loopback is allowed', hostAllowed('[::1]:8080', 8080))
+check('case is not significant', hostAllowed('LocalHost:8080', 8080))
+check('a trailing DNS root dot is the same host', hostAllowed('localhost.:8080', 8080))
+
+// The attack this exists to stop: the browser sends the attacker's own domain.
+check('a rebound attacker domain is refused', !hostAllowed('evil.com:8080', 8080))
+check('a suffixed look-alike is refused', !hostAllowed('localhost.evil.com:8080', 8080),
+  'a prefix/startsWith test would accept this — it is an ordinary registrable domain')
+check('a prefixed look-alike is refused', !hostAllowed('notlocalhost:8080', 8080))
+check('an embedded loopback name is refused', !hostAllowed('evil.com/127.0.0.1:8080', 8080))
+check('a different port is refused', !hostAllowed('127.0.0.1:9999', 8080),
+  'another local service on another port is not this console')
+
+// Default closed when we cannot tell.
+check('a missing Host is refused', !hostAllowed(undefined, 8080))
+check('an empty Host is refused', !hostAllowed('', 8080))
+check('a non-string Host is refused', !hostAllowed({ toString: () => '127.0.0.1:8080' }, 8080))
+
+// The bare (portless) form is only right when 80 really is the port.
+check('bare loopback is refused on a non-default port', !hostAllowed('127.0.0.1', 8080),
+  'the browser omits the port only when it is the scheme default')
+check('bare loopback is allowed when the port IS 80', hostAllowed('127.0.0.1', 80))
+check('a rebound domain is still refused on port 80', !hostAllowed('evil.com', 80))
+
+// ---- the handler: the refusal must actually happen, not merely be computable ------------------
+
+// Minimal ServerResponse stand-in — records what the handler did.
+function fakeRes() {
+  const r = { code: null, headers: null, body: '', ended: false }
+  r.writeHead = (code, headers) => { r.code = code; r.headers = headers; return r }
+  r.end = (body) => { r.body = body ? String(body) : ''; r.ended = true; return r }
+  return r
+}
+const call = async (host, url = '/console/') => {
+  const res = fakeRes()
+  await handler({ url, headers: host === undefined ? {} : { host } }, res)
+  return res
+}
+
+const rebound = await call('evil.com:8080')
+check('handler: a rebound Host gets 403', rebound.code === 403, `got ${rebound.code}`)
+// Both of the following assert on the 403 *specifically*. An earlier draft tested `/no-store/` on
+// whatever came back and `/Host/i` on the body — and both passed with the guard deleted, because a
+// served 200 also sets no-store and the console page happens to contain the word "host". A check
+// that cannot fail is not evidence, so they are pinned to the refusal response itself.
+check('handler: the refusal is not cached', rebound.code === 403 && /no-store/.test(JSON.stringify(rebound.headers || {})))
+check('handler: the refusal says why', rebound.code === 403 && /unrecognised Host/.test(rebound.body),
+  `body was ${JSON.stringify(rebound.body.slice(0, 60))}`)
+
+// The negative control this repo insists on: prove the guard can PASS, or a hard-coded 403 would
+// score identically. A check that only ever refuses is as useless as one that only ever allows.
+const good = await call('127.0.0.1:8080')
+check('handler: the documented Host still serves the console', good.code === 200,
+  `got ${good.code} — if this fails the guard is refusing everything, which "passes" every refusal test`)
+check('handler: and serves actual bytes', good.body.length > 0 || good.ended)
+
+// The path guard from #142 must still bite, and must bite AFTER the host check — a rebound page
+// must not be able to probe the filesystem through the traversal response.
+const traversalFromBadHost = await call('evil.com:8080', '/console/../../.env')
+check('handler: traversal from a bad Host is refused as a Host failure', traversalFromBadHost.code === 403)
+const traversalFromGoodHost = await call('127.0.0.1:8080', '/console/../../.env')
+check('handler: traversal from a good Host is still refused', traversalFromGoodHost.code === 403 || traversalFromGoodHost.code === 404,
+  `got ${traversalFromGoodHost.code} — #142 doc-root guard must survive this change`)
+
+console.log(failures ? `\nconsole_host: ${failures} check(s) failed` : '\nall checks passed')
+process.exit(failures ? 1 : 0)

--- a/tools/serve-console.mjs
+++ b/tools/serve-console.mjs
@@ -25,7 +25,35 @@ const PORT = Number(process.env.PORT || 8080)
 const TYPES = { '.html': 'text/html; charset=utf-8', '.mjs': 'text/javascript; charset=utf-8',
   '.js': 'text/javascript; charset=utf-8', '.css': 'text/css', '.json': 'application/json', '.svg': 'image/svg+xml' }
 
-createServer(async (req, res) => {
+// #145 — DNS rebinding. Binding to 127.0.0.1 decides WHICH INTERFACE accepts a connection; it
+// decides nothing about WHICH ORIGIN the browser believes it is talking to. A hostile page can
+// re-resolve its own domain to 127.0.0.1 and then issue *same-origin* requests here: the connection
+// genuinely arrives on loopback, so the bind is satisfied, and the attacker's script reads every
+// response. Loopback binding is not a weak defence against this — it is the wrong instrument.
+//
+// `Host` is what separates the two cases, because it carries the name the browser used. An operator
+// who typed the documented URL sends `127.0.0.1:8080`; a rebound page sends its own domain. The
+// attacker cannot forge it — a browser sets `Host` from the origin it fetched, so sending
+// `127.0.0.1` would require the page to genuinely be on 127.0.0.1, which is what we are allowing.
+//
+// Exact match, not a prefix or substring: `startsWith('localhost')` also accepts
+// `localhost.evil.com`, an ordinary registrable domain an attacker can point wherever they like.
+export function hostAllowed(host, port) {
+  // HTTP/1.1 requires Host. Absent means we cannot tell which origin this is — default closed.
+  if (typeof host !== 'string' || host === '') return false
+  // A trailing dot is the DNS root form of the SAME name and some clients send it, but it is also a
+  // stock allowlist bypass. Normalise it away rather than letting one host have two spellings.
+  const h = host.toLowerCase().replace(/\.(?=:|$)/, '')
+  // A browser omits the port only when it is the scheme default, so the bare form is accepted only
+  // when 80 is genuinely what we are listening on.
+  return ['127.0.0.1', 'localhost', '[::1]'].some(n => h === `${n}:${port}` || (port === 80 && h === n))
+}
+
+export const handler = async (req, res) => {
+  if (!hostAllowed(req.headers?.host, PORT)) {
+    res.writeHead(403, { 'Content-Type': 'text/plain; charset=utf-8', 'Cache-Control': 'no-store' })
+    return res.end('forbidden: unrecognised Host — reach the console as 127.0.0.1 or localhost\n')
+  }
   const url = (req.url || '/').split('?')[0]
   // Decode first, so a percent-encoded separator cannot hide from the normalisation below. A
   // malformed escape throws here rather than rejecting inside the handler and hanging the request.
@@ -46,8 +74,18 @@ createServer(async (req, res) => {
     res.writeHead(200, { 'Content-Type': TYPES[extname(file)] || 'application/octet-stream', 'Cache-Control': 'no-store' })
     res.end(body)
   } catch { res.writeHead(404); res.end('not found') }
-}).listen(PORT, '127.0.0.1', () => {
-  console.log(`\n  waggle console  →  http://127.0.0.1:${PORT}/console/\n`)
-  console.log('  Bound to loopback: served from this machine only, so nobody else chooses the')
-  console.log('  JavaScript that shows you what you are about to sign. Ctrl-C when finished.\n')
-})
+}
+
+// Only listen when run as a program. Importing this file — which the test does, to drive `handler`
+// with synthetic requests — must not open a socket: the suite's standing rule is no sockets and no
+// production state, and a test that binds 8080 fails on any machine already serving the console.
+const invokedDirectly = process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+if (invokedDirectly) {
+  createServer(handler).listen(PORT, '127.0.0.1', () => {
+    console.log(`\n  waggle console  →  http://127.0.0.1:${PORT}/console/\n`)
+    console.log('  Bound to loopback: served from this machine only, so nobody else chooses the')
+    console.log('  JavaScript that shows you what you are about to sign. Ctrl-C when finished.\n')
+    console.log(`  Requests are accepted only as 127.0.0.1:${PORT} or localhost:${PORT} — a page that`)
+    console.log('  rebinds its own domain to loopback gets 403, not the console.\n')
+  })
+}


### PR DESCRIPTION
Closes #145.

## The reasoning

Binding to `127.0.0.1` decides **which interface accepts a connection**, not **which origin is talking**. Under DNS rebinding a hostile page re-resolves its own domain to `127.0.0.1` and issues *same-origin* requests: the connection genuinely arrives on loopback, so the bind is satisfied and the attacker's script reads every response. Loopback binding isn't a weak defence against this — it's the wrong instrument.

`Host` is what still separates the two cases, because it carries the name the browser used, and a browser sets it from the origin it actually fetched. An attacker **cannot** send `127.0.0.1` without genuinely being on 127.0.0.1 — which is exactly the case we're allowing.

## The fix

Exact-match allowlist over `{127.0.0.1, localhost, [::1]}` at the listening port.

- **Exact match, not a prefix.** `startsWith('localhost')` also accepts `localhost.evil.com` — an ordinary registrable domain an attacker can point wherever they like. There's a test for that specific string.
- **Trailing DNS root dot normalised**, so one host doesn't get two spellings (a stock allowlist bypass).
- **Missing / empty / non-string `Host` is refused.** HTTP/1.1 requires it; not being able to tell which origin this is isn't permission.
- **The bare portless form is accepted only when 80 really is the port**, since that's the only time a browser omits it.

The server now listens **only when invoked directly**, so importing it for the test opens no socket — the suite's no-sockets rule, and a test that bound 8080 would fail on any machine already running the console.

Deliberately *only* the Host check. #145 notes that bundling behavioural change into a security fix makes both harder to review, and that's the same lesson #142 recorded.

## Verification

**Negative controls in both directions**, which is the part I'd want a reviewer to check:

| control | expected | result |
|---|---|---|
| guard removed (`if (false)`) | refusal checks fail | ✅ 4 failed |
| guard refuses everything (`if (true)`) | the allow check fails | ✅ 1 failed |
| restored | all pass | ✅ 23/23 |

The second direction matters because **an always-refuse guard passes every refusal test**. It also earned its keep immediately: it caught two checks of my own that were too loose to notice a *deleted* guard — a served 200 also sets `no-store`, and the console page happens to contain the word "host", so both passed with the guard gone. Both are now pinned to the 403 itself. A check that cannot fail isn't evidence.

**Live over a real socket** (the unit test drives a fake response, so it doesn't prove the server works), on a `PORT` override:

```
127.0.0.1:8099          -> 200
localhost:8099          -> 200
Host: evil.com:8099     -> 403
Host: localhost.evil.com -> 403
```

That's the "does not break the documented entry point or the `PORT` override" the issue asks to confirm — both confirmed rather than assumed.

`npm run lint` clean · `npm test` **17/17 green**.

## Notes

- New suite is `tests/console_host.mjs`. Counts and rosters moved **16 → 17** in the same commit, so the stale-base threshold in `CLAUDE.md` stays true.
- Which is worth a flag: this is the **third** hand-sync of that constant in two days (13 → 16 → 17). The CI assert proposed in #138 is still unbuilt, and this PR is more evidence for it. Happy to open it as its own issue and PR — say the word.
- Wants review from Dennis on one judgement call: I allow `localhost` as well as `127.0.0.1`, on the grounds that a browser can only send `Host: localhost` if the user typed it. If that reasoning is wrong, the allowlist should shrink to `127.0.0.1` alone. Handing it up rather than blocking, per `CLAUDE.md`.

---

Drafted with assistance from [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pj7AyMK4XPsib7tdR8P8JB)_