### PR TITLE
docs: CLAUDE.md — say that merging to main deploys to production

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,10 +82,19 @@ not in the source you edited.
 
 ## How work happens here
 
+- **⚠ Merging to `main` deploys.** The pull-based deploy runner (`deploy/README.md`) polls `main`
+  and ships the first CI-green commit it finds to the production bridge, within minutes and with no
+  human step in between: **"merged + CI green" *is* the authorisation.** The review bar and the
+  merge button are therefore the same lever. Open a PR and let the maintainer merge it; do not
+  merge your own work unless asked, and never merge anything you would not want running in
+  production that minute. If something must land without shipping, that is what pinning `WB_REF`
+  to a tag is for.
 - **Issues-first.** Every item becomes a GitHub issue before code.
 - **Check open PRs before starting an issue.** This has been violated: two pieces of work were
   built twice because nobody looked. `gh pr list --state open` costs nothing.
-- **Code lands via PR that the maintainer merges.** Doc-only may go to `main` with an issue ref.
+- **Code lands via PR that the maintainer merges.** Doc-only may go to `main` with an issue ref —
+  though today even a docs-only commit triggers a deploy tick and restarts the lane (#162), so it
+  is less free than it sounds.
 - **Commit trailer is exactly `Co-Authored-By: Claude <noreply@anthropic.com>`** — no model
   identifiers anywhere, trailer included. PR bodies end *"Drafted with assistance from
   [Claude Code](https://claude.com/claude-code)"*.


### PR DESCRIPTION
`deploy/README.md` documents the runner's design, but nothing in the contributor-facing standards said that **merging is releasing**. Since the runner was bootstrapped on 2026-08-01, "merged + CI green" is the authorisation to ship — no human step between the merge button and the production bridge.

Someone reading `CLAUDE.md` alone would treat a merge as bookkeeping. That is exactly how it read for the first week of this project, and it is now the single most consequential thing to know before touching this repo.

Two changes, both to *How work happens here*:

1. A leading bullet stating that merging deploys, that the review bar and the merge button are the same lever, and that `WB_REF`-to-a-tag is the way to land something without shipping it.
2. A qualifier on the existing doc-only-to-`main` allowance — the runner's only change test is a SHA comparison, so even a docs-only commit rsyncs, `npm ci`s and restarts the lane (**#162**).

**Not merging this myself**, deliberately — that is the rule it documents. Note that merging it will itself restart the lane, per #162; harmless, but it is the behaviour the second bullet describes, demonstrated on its own PR.

Drafted with assistance from [Claude Code](https://claude.com/claude-code)