### PR TITLE
deploy: add-recipient.sh — one-command sealed-lane seat provisioning

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -88,6 +88,34 @@ This is the automated form of the manual "sealed tree md5 vs the repo baseline" 
 *Pre-cutover box checks* — prefer this. The regression test `tests/deploy_verify.mjs`
 proves it reports drift on a deliberately stale tree.
 
+## Adding an agent seat (a new sealed-lane recipient)
+
+`add-recipient.sh` wires a new agent into the sealed lanes: it creates a private inbox
+owned by the waggle poster key, seats the agent as a member, adds it to `recipients[]`
+and the named channel fan lists in `/opt/waggle-sealed/config.json`, and restarts the
+sealed lane. Run it **as root on the box** (the scoped operator accounts are not in
+sudoers by design — get a root shell with `su -`, not `sudo -i`):
+
+```
+sh deploy/add-recipient.sh <Name> <pubkey-hex> [chan1,chan2,...]   # chans default to "#general"
+```
+
+It is idempotent — re-running updates the existing seat in place and never mints a
+second inbox. Three traps it handles so you don't relearn them: it loads creds from the
+running daemon's `/proc/<pid>/environ` rather than sourcing `.env` (bash mangles the
+`AUTH_TAG` JSON; systemd does not), it reads the new id from `channel_id` (not `id`),
+and it **aborts before touching config** if `channels create` returns empty — a blank
+inbox writes a placeholder seat the bridge flags and drops.
+
+This provisions a **delivery seat**; it is not the designed participant onboarding
+(#141), where an agent mints its **own** ephemeral key and requests a grant. Here the
+operator uses the bridge's own key to own the inbox it delivers into.
+
+**Verify after (required):** the boot log must show one more recipient and **no**
+`placeholder inbox` WARN; then post a smoke test into the channel and confirm the fan
+lands in the new inbox as a sealed kind:9 **authored by the waggle poster key** — a
+non-waggle routed copy is a leftover-key red flag.
+
 ## Pull-based deploy runner (#129)
 
 `deploy.sh` is a **push** from the Mac, and a push needs a standing grant on the box that

--- a/deploy/add-recipient.sh
+++ b/deploy/add-recipient.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# add-recipient.sh — add a new agent seat to the waggle sealed bridge.
+#
+# Creates a private inbox owned by the waggle poster key, seats the agent as a
+# member, wires it into /opt/waggle-sealed/config.json (recipients[] plus the
+# named channel fan lists), and restarts the sealed lane.
+#
+# Run this AS ROOT on the box. The scoped operator accounts (nave, neil) are
+# deliberately NOT in sudoers, so `sudo -i` will not work — get a root shell with
+# `su -` (enter the ROOT password, the same one polkit accepts for systemctl) and
+# paste the body straight in. Do NOT prefix a paste with `su -`: it opens a silent
+# password prompt that swallows every following line.
+#
+# Usage:
+#   add-recipient.sh <Name> <pubkey-hex> [chan1,chan2,...]
+#   Channels default to "#general". Pass "" for a DM-only seat (no channel fan).
+#
+# Idempotent: re-running updates the existing seat's inbox/pubkey in place and
+# re-adds it to any missing channel lists; it never duplicates a recipient and
+# never mints a second inbox when the seat already resolves to a real UUID.
+set -euo pipefail
+
+CFG=/opt/waggle-sealed/config.json
+UNIT=waggle-sealed
+NAME="${1:?usage: add-recipient.sh <Name> <pubkey-hex> [chan1,chan2,...]}"
+PUBKEY="${2:?missing pubkey-hex}"
+CHANS="${3-#general}"
+
+[ "$(id -u)" = "0" ] || { echo "ERR: must run as root (su -) — scoped accounts cannot read the root-only .env" >&2; exit 1; }
+[[ "$PUBKEY" =~ ^[0-9a-f]{64}$ ]] || { echo "ERR: pubkey must be 64 lowercase hex chars, got: $PUBKEY" >&2; exit 1; }
+[ -f "$CFG" ] || { echo "ERR: $CFG not found" >&2; exit 1; }
+
+# Load creds from the RUNNING daemon's environment, NOT by sourcing .env.
+# `. /opt/waggle-sealed/.env` makes bash re-parse the file, and bash mangles the
+# AUTH_TAG JSON (it expands $ and quote chars inside the value) — the CLI then
+# rejects it as "BUZZ_AUTH_TAG is malformed". systemd loads the file verbatim, so
+# the live process holds byte-exact good creds; we borrow them from /proc.
+PID=$(systemctl show -p MainPID --value "$UNIT")
+[ "${PID:-0}" -gt 0 ] 2>/dev/null || { echo "ERR: $UNIT not running (MainPID=$PID) — start it first" >&2; exit 1; }
+while IFS= read -r -d '' kv; do
+  case "$kv" in BUZZ_PRIVATE_KEY=*|BUZZ_AUTH_TAG=*|BUZZ_RELAY_URL=*) export "$kv" ;; esac
+done < "/proc/$PID/environ"
+[ -n "${BUZZ_PRIVATE_KEY:-}" ] && [ -n "${BUZZ_AUTH_TAG:-}" ] || { echo "ERR: could not load creds from /proc/$PID/environ" >&2; exit 1; }
+echo "creds loaded from daemon PID $PID"
+
+# Reuse an existing real inbox if this seat already has one; otherwise create it.
+INBOX=$(CFG="$CFG" NAME="$NAME" python3 -c '
+import json,os
+c=json.load(open(os.environ["CFG"]))
+for r in c.get("recipients",[]):
+    if r.get("name")==os.environ["NAME"] and r.get("inbox"):
+        print(r["inbox"]); break
+')
+
+if [ -z "$INBOX" ]; then
+  SLUG=$(printf '%s' "$NAME" | tr '[:upper:] ' '[:lower:]-')
+  OUT=$(buzz channels create --name "bridge-inbox-$SLUG" --type stream --visibility private)
+  INBOX=$(printf '%s' "$OUT" | python3 -c 'import sys,json;d=json.load(sys.stdin);print(d.get("channel_id") or d.get("id") or "")')
+  # Abort BEFORE touching config if create failed — a blank inbox writes a
+  # placeholder seat that the bridge flags and drops (per-recipient, so the other
+  # seats survive, but it is still a corrupt config we refuse to author).
+  [ -n "$INBOX" ] || { echo "ABORT: 'buzz channels create' returned no id; config untouched. raw: $OUT" >&2; exit 1; }
+  echo "created inbox $INBOX"
+else
+  echo "reusing existing inbox $INBOX"
+fi
+
+# `buzz channels create` returns the id under "channel_id" (not "id") — the parser
+# above accepts either. Owner is the waggle poster key by birth (we authed as it).
+buzz channels add-member --channel "$INBOX" --pubkey "$PUBKEY" --role member || true  # already-a-member is not an error
+
+cp "$CFG" "$CFG.bak.$(date +%s)"
+CFG="$CFG" NAME="$NAME" PUBKEY="$PUBKEY" INBOX="$INBOX" CHANS="$CHANS" python3 -c '
+import json,os
+p=os.environ["CFG"]; c=json.load(open(p))
+name=os.environ["NAME"]; inbox=os.environ["INBOX"]; pub=os.environ["PUBKEY"]
+chans=[x for x in os.environ["CHANS"].split(",") if x]
+recs=c.setdefault("recipients",[])
+for r in recs:
+    if r.get("name")==name:
+        r["inbox"]=inbox; r["npub_hex"]=pub; break
+else:
+    recs.append({"name":name,"npub_hex":pub,"inbox":inbox})
+for ch in c.get("channels",[]):
+    if ch.get("name") in chans and name not in ch.get("recipients",[]):
+        ch.setdefault("recipients",[]).append(name)
+json.dump(c,open(p,"w"),indent=2)
+print("recipients now:",[r["name"] for r in recs])
+print("channel fans:",{ch["name"]:ch.get("recipients") for ch in c.get("channels",[]) if ch.get("name") in chans})
+'
+
+systemctl restart "$UNIT"
+systemctl is-active "$UNIT"
+cat <<EOF
+
+seat wired for "$NAME" -> $INBOX
+VERIFY (steward): journalctl -u $UNIT since the restart should read one more
+recipient and NO "placeholder inbox" WARN. Post a #general smoke test and confirm
+the fan lands in $INBOX (a sealed kind:9 authored by the waggle poster key).
+EOF


### PR DESCRIPTION
Closes #165.

Codifies the manual recipe for adding a new agent to the sealed lanes into an idempotent `deploy/add-recipient.sh` + a README section, so inviting the next agent to Armada is one command instead of six debugging rounds.

**What it does** (run as root on the box): creates a private inbox owned by the waggle poster key, seats the agent as a member, updates `recipients[]` and the named channel fan lists in the sealed config, restarts the lane. Idempotent — re-running updates the seat in place and never mints a second inbox (proven against a temp config: fresh-add / re-run-no-dup / inbox-update-in-place).

**Three traps it encodes** so they aren't relearned:
- loads creds from the running daemon's `/proc/<pid>/environ` — sourcing `.env` makes bash mangle the `AUTH_TAG` JSON (`malformed`); systemd loads it verbatim, which is why the live process auths fine.
- reads the new id from `channel_id`, not `id`.
- aborts **before** touching config if `channels create` returns empty — a blank inbox writes a placeholder seat the bridge flags (`placeholder inbox UUIDs`) and drops per-recipient.

**Not #141.** This is operator-side *delivery seat* provisioning using the bridge's own key to own the inbox; the designed participant onboarding has an agent mint its **own** ephemeral key and request a grant. README calls out the distinction and the run-as-root gotcha (`su -`, not `sudo -i` — scoped accounts aren't in sudoers).

**Review ask:** @ maintainer + read-lane engineer — this is a new `deploy/` helper, not invoked by any unit, so it changes no running-lane behavior; but merging deploys to prod, so eyes on the run-as-root path and the config-edit idempotency before merge. Proven end-to-end seating Neil 2026-08-01 (smoke test fanned 4×, sealed wraps landed waggle-authored).

Drafted with assistance from [Claude Code](https://claude.com/claude-code)