### PR TITLE
feat(egress): waggle carries, it never authors — the A3 chokepoints, both transports (#134)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,14 +117,14 @@ that merely ran.** The suite was green through all of them.
 
 ## Tests
 
-`npm test` — 17 suites, against the real exported functions with synthetic events. No sockets,
+`npm test` — 19 suites, against the real exported functions with synthetic events. No sockets,
 no production state, no writes outside a temp dir.
 
-boot · durable dedup store · relay fan-out · quarantine gating · deletion propagation · sealed-lane rate caps · grant
+boot · egress catalogue · egress ban · durable dedup store · relay fan-out · quarantine gating · deletion propagation · sealed-lane rate caps · grant
 admission · message rendering · deployed-build verification · return lane · return-lane scan ·
 return-lane no-miss · relay ingress · tripwire union · tripwire detection drill · deploy runner · console Host check
 
-CI runs them on push and PR. **If a run reports fewer than 17, the branch is on a stale base.**
+CI runs them on push and PR. **If a run reports fewer than 19, the branch is on a stale base.**
 The count of record is the `test` script in `package.json`; a prose count that disagrees with it
 is the prose being wrong.
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ against what git says, because a stale build is invisible while every status sur
 
 ## Tests
 
-`npm test` runs 17 suites against the **real** exported functions with synthetic events — no
+`npm test` runs 19 suites against the **real** exported functions with synthetic events — no
 sockets, no production state:
 
 boot · durable dedup store · relay fan-out · quarantine gating · deletion propagation · sealed-lane rate caps · grant

--- a/docs/DESIGN_EGRESS_CHOKEPOINT.md
+++ b/docs/DESIGN_EGRESS_CHOKEPOINT.md
@@ -1,6 +1,6 @@
 # Design: the egress chokepoint — waggle carries, it never authors
 
-**Status:** proposed · **Tracks:** #134 A3, the structural half of the sev-1
+**Status:** BUILT — §6 steps 2–5 implemented in #168 (INV-A3-1…5 hold, both transports); step 6 is a host change and step 7 is a maintainer call · **Tracks:** #134 A3, the structural half of the sev-1
 **Review:** adversarial review returned on #140 — **verdict: sound, build it**, with five must-fixes; **this revision folds all five in**, plus his second-transport finding (§1.0). Re-review of the folded text is welcome but not gating.
 **Verified against:** `src/bridge.mjs`, read line by line for every egress site, 2026-07-31; re-verified against `main` @ `af7122f` on 2026-08-01.
 The refactors of #151–#153 have since moved every line in that file without touching an egress site, so citations here are by **function name, not line number** — see §1.1.
@@ -98,11 +98,28 @@ output" — carrying untrusted text is the entire product. The real line:
 
 | | who wrote it | how it may appear |
 |---|---|---|
-| **carried body** | an external author, signature-verified | **only** inside a renderer that provably neutralizes it — quoted, inert, attributed to its author |
+| **carried body** | an external author, signature-verified | only inside a renderer that neutralizes it **to the degree its trust tier earns** — see below. Always quoted or attributed to its author, never as waggle's own voice |
 | **machine notice** | the source code | a fixed template, with **typed** data in slots |
 | **free prose** | a caller at runtime | **nowhere. No path.** |
 
-Row 1 is not a weakening. `renderReleased` is already the strongest thing here: the `render_states`
+**Neutralization is tiered, and that is deliberate** *(the maintainer's ruling, 2026-08-01 — an
+earlier draft of this row said "provably neutralizes it" flat, which read as though a vouched body
+were defanged as hard as a quarantined one; the code has never done that, and should not)*:
+
+- **Quarantined** — refs *and* markup defused. An unvouched note cannot mint headings, rules, lists
+  or nested fences, because the impersonation that matters is a pending note dressed up as an
+  approval notice.
+- **Vouched** (released, granted, followed, mirrored) — refs defused unless a live grant earns
+  them (#94); **markup preserved on purpose.** A vouched identity keeps its formatting: reading as
+  an ordinary message rather than a machine log is the entire point of releasing something, and
+  trust is trust.
+
+So a vouched author *can* render a heading or a fence. That is an accepted consequence of the trust
+tier, not an oversight — they still cannot ping the room without a grant, so the residue is
+chrome-imitation by an identity someone already vouched for. A3 governs what **waggle** may author;
+it does not re-litigate what a trusted participant may format.
+
+Row 1 is not a weakening. `renderQuarantined` is already the strongest thing here: the `render_states`
 suite tests what it **refuses** — a hostile note trying to ping the approver, mint an `APPROVED BY`
 heading, break its quote, open a code fence — and it must come out inert *and still readable*.
 Row 3 is the one with no legitimate instance, and it is the one to delete.
@@ -145,7 +162,12 @@ design: not a check that can be skipped, but a vocabulary with no word for the f
 
 A template language with a `{message}` slot is the original hole with extra steps. So:
 
-**The slot-type set is CLOSED.** These eight are the whole vocabulary:
+**The slot-type set is CLOSED.** The table below IS the vocabulary — deliberately stated as a list
+rather than a count. An earlier revision said "these eight are the whole vocabulary" over a table
+listing nine names (`id`/`npub`/`hex` is one row of three), and a number in prose falls out of sync
+with the list beneath it every time the list changes. The closed-ness is what carries the
+guarantee, and the catalogue test enforces membership against the code, so nothing depends on a
+number being right:
 
 | slot type | admits | escaper |
 |---|---|---|
@@ -154,13 +176,32 @@ A template language with a `{message}` slot is the original hole with extra step
 | `count` / `ts` | number | format only |
 | `enum` | one of a literal set (`approve`\|`follow`\|`mute`\|`reject`\|…) | reject on mismatch |
 | `inline_token` | short operator-supplied text, rendered **inside backticks** | strip backticks, newlines, `@`, and `*`/`_`; hard length cap; never leaves the code span |
+| `display_name` | an **external** author's `kind:0` name, rendered as chrome (bold, attribution line) | strip backticks, `@`, brackets, parens, newlines, `*`/`_`/`~`; hard cap |
+| `handle` | an **operator-configured** Buzz handle, rendered as a **live** `@mention` | reject anything that is not a bare handle |
 | `carried_body` | **untrusted** external content | `renderReleased` / `renderQuarantined` neutralization, unchanged |
+| `wrapJson` | a sealed envelope, embedded in a fence | reject on any newline (INV-A3-4) |
+
+**`display_name` and `handle` were added on 2026-08-01** under this section's own "a new type is a
+deliberate spec change" rule, and they are a matched pair — the reason for two is the reason either
+is safe:
+
+- **`display_name` carries a value its subject controls.** An author's `kind:0` name is
+  attacker-chosen and lands in waggle's *chrome*, not inside the quoted body — so `inline_token` is
+  the wrong type for it, since that type's contract is "never leaves the code span". The identical
+  strip already ran at the fetch site, which is why this was never a live hole; but it lived there
+  **by convention**, and a future caller sourcing a name from config or a cache would have got no
+  guard at all. Moving it into the type is this document's own thesis applied to the one untrusted
+  value that renders as chrome rather than as content.
+- **`handle` carries a value the operator controls, and must stay live.** A quarantine header opens
+  with `@approver` precisely so the approver is woken. Keeping it a *separate* type from
+  `display_name` is what guarantees an external value can never reach the slot that preserves its
+  `@`.
 
 **Closing the *type* set is what makes this structural rather than conventional.** The first draft
 said "no template may have a prose slot" and left it to reviewers to notice one. Instead, the
-catalogue test asserts **every slot of every template declares one of the eight types above** — so a
+catalogue test asserts **every slot of every template declares one of the types above** — so a
 future `detail: string` fails by construction, as an *unknown slot type*, with no reviewer required.
-Adding a ninth type is then a deliberate spec change, which is exactly the friction wanted.
+Adding a type is then a deliberate spec change, which is exactly the friction wanted.
 
 `inline_token` exists **only** because `handleCommand`'s unrecognized-verb reply already echoes
 operator input, and deleting
@@ -183,7 +224,7 @@ variable verb, by `spawn('sh', ['-c', …])` — and it is **structurally blind 
 (§1.0), which never spells `buzz` at all. Ban the *imports and signer symbols* instead:
 
 1. **An import/symbol ban test.** Only `egress.mjs` may import `child_process`; only the Nostr chokepoint (§2.5) may call `finalizeEvent` or reference `BRIDGE_SK`. Any other module touching those fails the suite. No argv reshaping evades this, and it covers **both** transports rather than one.
-2. **A catalogue test.** Every template rendered with hostile slot values: assert no slot escapes its frame, and assert **every slot declares one of the eight closed types** (§2.2).
+2. **A catalogue test.** Every template rendered with hostile slot values: assert no slot escapes its frame, and assert **every slot declares one of the closed types** (§2.2).
 
 **Honest residual, stated rather than papered over:** `require('child_' + 'process')` still slips a
 static check, and a determined author with commit access can always route around a lint rule. An
@@ -229,7 +270,7 @@ fixed.
 - **INV-A3-2** — Exactly one function per transport invokes a signer: one for Buzz, one for Nostr. No third.
 - **INV-A3-3** — No caller can reach either with a caller-composed string. Enforced by type shape, not by review.
 - **INV-A3-4** — `wrapJson` is single-line by contract (§2.4).
-- **INV-A3-5** — Every slot of every template declares one of the eight closed types (§2.2). A ninth requires a spec change.
+- **INV-A3-5** — Every slot of every template declares one of the closed types (§2.2). A new one requires a spec change.
 
 ---
 
@@ -312,7 +353,7 @@ into this revision.
 
 The first draft's four open questions, with the answers now folded into the design:
 
-1. **Does the typed catalogue hold, or just relocate the hole?** *It relocates it unless the slot **type** set is closed.* Draft-me proposed "assert no template has an unconstrained slot," which still needs a reviewer to judge *unconstrained*. **Answered by §2.2:** eight types, closed; an unknown type fails by construction. This was the sharpest correction — it converts §7-Q1 from convention back into structure.
+1. **Does the typed catalogue hold, or just relocate the hole?** *It relocates it unless the slot **type** set is closed.* Draft-me proposed "assert no template has an unconstrained slot," which still needs a reviewer to judge *unconstrained*. **Answered by §2.2:** a closed type set; an unknown type fails by construction. This was the sharpest correction — it converts §7-Q1 from convention back into structure.
 2. **Is A3 worth landing without A4?** *Yes — and it earns only the qualified sentence.* **Answered by §3.1:** the qualifier must appear at every restatement site, because three unqualified copies read as corroboration. A4 (#54) earns the bare word.
 3. **Nostr chokepoint now or next?** *Neither — it was mis-scoped as a footnote.* **Answered by §1.0 / §2.5:** it is a second transport, and §2.3's import ban covers it from day one. INV-A3-2 is false until it lands.
 4. **Steward identity with A3 or after?** Still open (§6 step 7) — the one question review left to the maintainer.

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -120,7 +120,7 @@ in [deploy/README.md](../deploy/README.md).
 - **Publish the agent relay list:** `node tools/publish_relay_list.mjs` (so the identity
   is discoverable).
 - **Admit a participant**, if you want one: `sh tools/grant-setup.sh`.
-- **Run the safety gates before you ship:** `npm test` — 17 suites driving the real
+- **Run the safety gates before you ship:** `npm test` — 19 suites driving the real
   routing functions with synthetic events (no sockets, no production state), all green.
 
 `waggle-init.mjs --check` rolls the config half of this into one readiness verdict; the

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "start": "node src/bridge.mjs",
     "dryrun": "FORWARD_MODE=dryrun node src/bridge.mjs",
     "lint": "eslint src tools tests",
-    "test": "node tests/boot.mjs && node tests/relay_fanout.mjs && node tests/durable_store.mjs && node tests/a1_quarantine.mjs && node tests/a7_deletion.mjs && node tests/lane2_caps.mjs && node tests/nipda_admission.mjs && node tests/render_states.mjs && node tests/deploy_verify.mjs && node tests/return_lane.mjs && node tests/return_lane_scan.mjs && node tests/return_lane_nomiss.mjs && node tests/relay_ingress.mjs && node tests/tripwire_union.mjs && node tests/tripwire_detection.mjs && node tests/deploy_runner.mjs && node tests/console_host.mjs",
+    "test": "node tests/boot.mjs && node tests/egress_catalogue.mjs && node tests/egress_ban.mjs && node tests/relay_fanout.mjs && node tests/durable_store.mjs && node tests/a1_quarantine.mjs && node tests/a7_deletion.mjs && node tests/lane2_caps.mjs && node tests/nipda_admission.mjs && node tests/render_states.mjs && node tests/deploy_verify.mjs && node tests/return_lane.mjs && node tests/return_lane_scan.mjs && node tests/return_lane_nomiss.mjs && node tests/relay_ingress.mjs && node tests/tripwire_union.mjs && node tests/tripwire_detection.mjs && node tests/deploy_runner.mjs && node tests/console_host.mjs",
     "console": "node tools/serve-console.mjs"
   },
   "dependencies": {

--- a/src/bridge.mjs
+++ b/src/bridge.mjs
@@ -36,7 +36,7 @@ import WebSocket from 'ws'
 import { verifyEvent, finalizeEvent, generateSecretKey, getEventHash, getPublicKey } from 'nostr-tools/pure'
 import * as nip44 from 'nostr-tools/nip44'
 import * as nip19 from 'nostr-tools/nip19'
-import { execFile } from 'node:child_process'
+import { emit, query } from './egress.mjs'
 import { createHash } from 'node:crypto'
 import { readFileSync, writeFileSync, appendFileSync, existsSync, mkdirSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
@@ -282,8 +282,7 @@ function resolveChannels(cb) {
   const pending = PUB ? [PUB.inbox, PUB.staging, ...PUB.scanChannels, ...PUB.relayChannels].filter(v => v && !UUID_RE.test(v)) : []
   if (!pending.length) return cb()
   if (FORWARD_MODE !== 'buzz') { err(`WARN: channel name(s) ${pending.join(', ')} left unresolved in ${FORWARD_MODE} mode`); return cb() }
-  execFile('buzz', ['channels', 'list'], (e, so) => {
-    if (e) { err(`FATAL: cannot resolve channel names — 'buzz channels list' failed: ${e.message}`); process.exit(1) }
+  query('channels_list').then((so) => {
     const byName = new Map()
     try {
       for (const c of JSON.parse(String(so).slice(String(so).indexOf('[')))) {
@@ -302,6 +301,12 @@ function resolveChannels(cb) {
     PUB.scanChannels = PUB.scanChannels.map((v, i) => one(v, `scan_channel[${i}]`))
     PUB.relayChannels = PUB.relayChannels.map((v, i) => one(v, `relay_channel[${i}]`))
     cb()
+  }).catch((e) => {
+    // Unresolvable channel names are FATAL in buzz mode — booting with a name we could not
+    // resolve would route nowhere, silently. Default closed: refuse to start rather than run
+    // half-addressed. (process.exit inside `one` throws past this catch by design; re-exit.)
+    err(`FATAL: cannot resolve channel names — 'buzz channels list' failed: ${e.message}`)
+    process.exit(1)
   })
 }
 
@@ -519,23 +524,19 @@ function forward(rec, ev, src) {
   // runtime lacks that root cannot open it; say so, rather than "go unwrap," so a missing
   // Concord grant reads as a provisioning gap instead of a bad route. (Cost six confused
   // rounds with a team member, 2026-07-24, before this said so.)
-  const label = src && src.channel
-    ? `New Concord channel post on **${src.channel}** — its outer \`p\` tag is a random decoy, not a recipient. ` +
-      `Decrypt with the plane key you derive from the **${src.channel} community_root** ` +
-      `(publicChannel(root, channel_id, epoch).conv); do NOT re-seal. If your runtime holds no Concord grant for ` +
-      `this channel, you cannot open it yet — that's a provisioning gap, flag it and hold:`
-    : `New Armada DM — sealed, unwrap with your key:`
   if (FORWARD_MODE !== 'buzz') {
     log(`FORWARD[dryrun] -> ${rec.name} inbox ${rec.inbox}: ${src && src.channel ? `channel ${src.channel}` : 'DM'} 1059 ${ev.id.slice(0, 12)}… (${JSON.stringify(ev).length} B)`)
     return
   }
-  const content = `@${rec.name}\n\n${label}\n\n\`\`\`json\n${JSON.stringify(ev)}\n\`\`\`\n`
   if (process.env.WB_STUB_SEND) { log(`FORWARD[stub] -> ${rec.name} inbox ${rec.inbox}: 1059 ${ev.id.slice(0, 12)}…`); return }
-  execFile('buzz', ['messages', 'send', '--channel', rec.inbox, '--content', content], (e, so, se) => {
-    if (e) return err(`FORWARD[buzz] ERR -> ${rec.name}: ${se || e.message}`)
+  emit({
+    template: 'sealed_envelope',
+    dest: rec.inbox,
+    slots: { name: rec.name, channel: (src && src.channel) || undefined, wrapJson: JSON.stringify(ev) },
+  }).then(({ stdout }) => {
     log(`FORWARD[buzz] ok -> ${rec.name} inbox: ${src && src.channel ? `${src.channel} ` : 'DM '}1059 ${ev.id.slice(0, 12)}…`)
-    journalSend(parseBuzzEventId(so), { kind: 9, dest: rec.inbox, lane: 'sealed' })
-  })
+    journalSend(parseBuzzEventId(stdout), { kind: 9, dest: rec.inbox, lane: 'sealed' })
+  }).catch(e => err(`FORWARD[buzz] ERR -> ${rec.name}: ${e.message}`))
 }
 
 function route(ev) {
@@ -705,9 +706,6 @@ async function forwardPublic(ev, why, dest, quarantine) {
   const agent = PUB ? ((PUB.returnLane.find(r => r.npub_hex === String(ev.pubkey || '').toLowerCase()) || {}).npub_hex || null) : null
   const nowSec = Math.floor(Date.now() / 1000)
   const { clamped, outOfRange } = clampCreated(ev.created_at, nowSec)
-  const when = new Date(clamped * 1000).toISOString()
-  const claim = outOfRange && ev.created_at
-    ? `  ·  ⚠︎ author-claimed \`${new Date((Number(ev.created_at) || 0) * 1000).toISOString()}\` (clamped)` : ''
   if (FORWARD_MODE !== 'buzz') {
     log(`PUBLIC[dryrun] -> ${quarantine ? 'STAGING' : 'inbox'} ${dest}: kind1 ${ev.id.slice(0, 12)}… by ${author}… (${why})${outOfRange ? ' [clamped]' : ''} :: ${JSON.stringify((ev.content || '').slice(0, 80))}`)
     return
@@ -715,7 +713,6 @@ async function forwardPublic(ev, why, dest, quarantine) {
   // Reposted content is untrusted public text. It is delivered as a fenced block so a note
   // that happens to contain "@Name" or markdown can't inject a Buzz mention/format.
   const body = String(ev.content || '')
-  const mention = quarantine && PUB.approverMention ? `@${PUB.approverMention} ` : ''
   // Friendly author identity: display name from the author's public kind:0 (UNTRUSTED text —
   // sanitized, rendered outside the fence) plus the npub, which is what a reader can
   // actually paste into a client. Best-effort with a 2s budget; falls back to npub alone.
@@ -730,9 +727,22 @@ async function forwardPublic(ev, why, dest, quarantine) {
   // same act that removes admission — no second switch to forget. Every other reason a note
   // reaches here (mirrored feed, standing follow, human-released quarantine) stays defused.
   const liveRefs = !quarantine && !!ev.pubkey && grantSet.has(String(ev.pubkey).toLowerCase())
-  const content = quarantine
-    ? renderQuarantined({ body, mention, name, npub: npub || ev.pubkey, when, claim, why, id: ev.id })
-    : renderReleased({ body, name, npubShort, liveRefs })
+  const descriptor = quarantine
+    ? {
+      template: 'quarantine_header',
+      dest,
+      slots: {
+        body,
+        approver: (quarantine && PUB.approverMention) || undefined,
+        name,
+        npub: npub || ev.pubkey,
+        ts: clamped,
+        claimedTs: outOfRange && ev.created_at ? Number(ev.created_at) : undefined,
+        why,
+        id: ev.id,
+      },
+    }
+    : { template: 'released_post', dest, slots: { body, name, npubShort, liveRefs } }
   // Test seam: exercise the full buzz-mode path (markSeen/watermark/posted-map) without a
   // network send. The synthetic buzz id (orig id reversed — still 64 hex, still unique)
   // exercises the same capture shape the live path records.
@@ -741,16 +751,15 @@ async function forwardPublic(ev, why, dest, quarantine) {
     recordPosted({ id: ev.id, author: ev.pubkey, buzz: ev.id.split('').reverse().join(''), dest, q: !!quarantine, ts: nowSec, agent })
     return
   }
-  execFile('buzz', ['messages', 'send', '--channel', dest, '--content', content], (e, so, se) => {
-    if (e) return err(`PUBLIC[buzz] ERR -> ${dest}: ${se || e.message}`)
+  return emit(descriptor).then(({ stdout }) => {
     log(`PUBLIC[buzz] ok -> ${quarantine ? 'STAGING' : 'inbox'} ${dest}: kind1 ${ev.id.slice(0, 12)}… by ${author}… (${why})`)
     // A7: record the repost so the author's later kind:5 can withdraw it. A null buzz id
     // (stdout didn't carry one) degrades to the follow-up-tombstone tier — logged, safe.
-    const buzzId = parseBuzzEventId(so)
+    const buzzId = parseBuzzEventId(stdout)
     if (!buzzId) err(`A7 warn[no-id]: could not capture buzz event id for ${ev.id.slice(0, 12)}… — withdrawal will use follow-up tier`)
     recordPosted({ id: ev.id, author: ev.pubkey, buzz: buzzId, dest, q: !!quarantine, ts: nowSec, agent })
     journalSend(buzzId, { kind: 9, dest, lane: 'public' })
-  })
+  }).catch(e => err(`PUBLIC[buzz] ERR -> ${dest}: ${e.message}`))
 }
 
 function routePublic(ev) {
@@ -859,23 +868,17 @@ function routeDelete(ev) {
 // when we never captured a buzz id or both mutations fail.
 function withdraw(origId, entry, delEv) {
   const done = (tier) => { recordWithdrawn(origId); log(`A7 ok[${tier}]: withdrew ${origId.slice(0, 12)}… per kind5 ${delEv.id.slice(0, 12)}…`) }
-  const tombstone =
-    `🗑 **Withdrawn by author** — NIP-09 deletion\n` +
-    `author \`${entry.author}\` · original \`${origId}\` · delete \`${delEv.id}\`\n` +
-    `_Content removed at the author's request._\n`
+  const stone = { author: entry.author, origId, delId: delEv.id }
   if (process.env.WB_STUB_SEND) { done(entry.buzz ? 'stub-delete' : 'stub-post'); return }
-  const followUp = () => execFile('buzz', ['messages', 'send', '--channel', entry.dest, '--content', tombstone], (e3) => {
-    if (e3) return err(`A7 ERR[all-tiers]: could not withdraw ${origId.slice(0, 12)}…: ${e3.message}`)
-    done('follow-up')
-  })
+  const followUp = () => emit({ template: 'a7_tombstone', dest: entry.dest, slots: stone })
+    .then(() => done('follow-up'))
+    .catch(e3 => err(`A7 ERR[all-tiers]: could not withdraw ${origId.slice(0, 12)}…: ${e3.message}`))
   if (!entry.buzz) return followUp()
-  execFile('buzz', ['messages', 'delete', '--event', entry.buzz, '--reason-code', 'nip09', '--public-reason', 'withdrawn by author (NIP-09)'], (e1) => {
-    if (!e1) return done('delete')
-    execFile('buzz', ['messages', 'edit', '--event', entry.buzz, '--content', tombstone], (e2) => {
-      if (!e2) return done('edit')
-      followUp()
-    })
-  })
+  emit({ template: 'a7_delete', targetId: entry.buzz, slots: {} })
+    .then(() => done('delete'))
+    .catch(() => emit({ template: 'a7_tombstone_edit', targetId: entry.buzz, slots: stone })
+      .then(() => done('edit'))
+      .catch(() => followUp()))
 }
 
 // --- In-Buzz approval console -------------------------------------------------
@@ -920,10 +923,13 @@ function mutateConfig(fn) {
   } catch (e) { err(`commands: config write failed: ${e.message}`); return false }
 }
 
-function replyInStaging(parentBuzzId, text) {
-  execFile('buzz', ['messages', 'send', '--channel', PUB.staging, '--reply-to', parentBuzzId, '--content', text], (e) => {
-    if (e) err(`commands: confirmation reply failed: ${e.message}`)
-  })
+// A3: this took a `text: string` until #134, and its unrecognized-verb caller passed runtime
+// operator input straight through — the free-text path that already had a live caller, not a
+// hypothetical one. It now takes a VERB from the catalogue's closed set; the words live in
+// egress.mjs where no caller can reach them.
+function replyInStaging(parentBuzzId, verb, slots = {}) {
+  emit({ template: verb, dest: PUB.staging, parentId: parentBuzzId, slots })
+    .catch(e => err(`commands: confirmation reply failed: ${e.message}`))
 }
 
 async function handleCommand(m) {
@@ -941,7 +947,7 @@ async function handleCommand(m) {
       const stTry = parentTry && stagingByBuzzId.get(String(parentTry).toLowerCase())
       if (stTry && (stTry.q || stTry.dest !== PUB.inbox) && !seen.has('cmd:' + m.id)) {
         markSeen('cmd:' + m.id)
-        replyInStaging(m.id, `unrecognized command \`${raw}\` — try **approve** (or release), **follow**, **mute**, or **reject**.`)
+        replyInStaging(m.id, 'console_ack', { verb: 'unrecognized', echo: raw })
       }
     }
     return
@@ -952,12 +958,12 @@ async function handleCommand(m) {
   markSeen('cmd:' + m.id) // commit-before-dispatch: a crash can never double-execute a command
   log(`command '${word}' from approver ${m.pubkey.slice(0, 12)}… on ${st.orig.slice(0, 12)}…`)
 
-  if (word === 'reject') return replyInStaging(m.id, `🚫 rejected — no action taken; the author remains quarantined.`)
+  if (word === 'reject') return replyInStaging(m.id, 'console_ack', { verb: 'rejected' })
 
   if (word === 'mute') {
     if (!PUB.muted.includes(st.author)) PUB.muted.push(st.author)
     mutateConfig(c => { c.public.muted_authors = Array.from(new Set([...(c.public.muted_authors || []), st.author])) })
-    return replyInStaging(m.id, `🔇 muted \`${st.author.slice(0, 12)}…\` — their replies will no longer reach staging.`)
+    return replyInStaging(m.id, 'console_ack', { verb: 'muted', author: st.author })
   }
 
   // approve / watch — release the note (refusing duplicates), then grant trust if asked.
@@ -965,20 +971,21 @@ async function handleCommand(m) {
   const alreadyReleased = prior && !prior.deleted && prior.dest === PUB.inbox && !prior.q
   if (!alreadyReleased) {
     const ev = await fetchEventById(st.orig)
-    if (!ev) return replyInStaging(m.id, `⚠️ could not fetch the original from any relay — nothing released.`)
+    if (!ev) return replyInStaging(m.id, 'console_ack', { verb: 'no_original' })
     let ok = false
     try { ok = verifyEvent(ev) } catch { ok = false }
-    if (!ok) return replyInStaging(m.id, `⚠️ signature verification FAILED — refusing to release.`)
-    if (!rateOk(ev, PUB.inbox, Date.now())) return replyInStaging(m.id, `⚠️ rate cap would be exceeded — try again later.`)
+    if (!ok) return replyInStaging(m.id, 'console_ack', { verb: 'bad_signature' })
+    if (!rateOk(ev, PUB.inbox, Date.now())) return replyInStaging(m.id, 'console_ack', { verb: 'rate_capped' })
     forwardPublic(ev, 'released from quarantine', PUB.inbox, false)
   }
-  let granted = ''
+  let granted = false
   if (word === 'follow') {
     if (!PUB.trustedRepliers.includes(st.author)) PUB.trustedRepliers.push(st.author)
     mutateConfig(c => { c.public.trusted_repliers = Array.from(new Set([...(c.public.trusted_repliers || []), st.author])) })
-    granted = ` · standing follow granted (their replies now skip the queue)`
+    granted = true
   }
-  replyInStaging(m.id, `✅ ${alreadyReleased ? 'already released earlier' : 'released to the community channel'}${granted}`)
+  replyInStaging(m.id, alreadyReleased ? 'console_ack_already' : 'console_ack',
+    alreadyReleased ? { granted } : { verb: 'released', granted })
 }
 
 // --- Return lane (#40) ------------------------------------------------------------------------
@@ -1126,7 +1133,6 @@ async function postRelay(ev, sender, dest, wantCh, body) {
   let npub = null
   try { npub = nip19.npubEncode(sender) } catch { npub = null }
   const npubShort = npub ? `${npub.slice(0, 10)}…${npub.slice(-5)}` : sender.slice(0, 12) + '…'
-  const content = renderReleased({ body, name, npubShort, liveRefs: true })
   const nowSec = Math.floor(Date.now() / 1000)
   const ackOk = (buzzId) => returnLaneSend(sender, JSON.stringify({ ok: true, channel: dest, buzz_event_id: buzzId || null, ts: nowSec }), { lane: 'relay-ack' })
   if (FORWARD_MODE !== 'buzz') {
@@ -1142,10 +1148,7 @@ async function postRelay(ev, sender, dest, wantCh, body) {
     log(`RELAY[stub] -> ${dest}: from ${sender.slice(0, 12)}…`)
     return
   }
-  execFile('buzz', ['messages', 'send', '--channel', dest, '--content', content], (e, so, se) => {
-    // A channel waggle is not a member of fails HERE with a distinct RELAY[buzz] ERR — it can never
-    // masquerade as a §7 drop, and it is NOT marked seen, so it retries rather than dropping.
-    if (e) { dropRelaySeen(ev.id); err(`RELAY[buzz] ERR -> ${dest}: ${se || e.message} — claim rolled back, will retry`); return }
+  return emit({ template: 'released_post', dest, slots: { body, name, npubShort, liveRefs: true } }).then(({ stdout: so }) => {
     // commit-AFTER-send (#114 finding-3): mark the wrap carried only once the kind:9 posted, so a
     // transient failure retries. Residual: a crash after this post but before the mark re-posts on
     // restart — kind:9 has no idempotency key, so the dup-on-crash residual stands (§6).
@@ -1155,6 +1158,11 @@ async function postRelay(ev, sender, dest, wantCh, body) {
     journalSend(buzzId, { kind: 9, dest, lane: 'relay' })
     ackOk(buzzId)
     log(`RELAY[buzz] ok -> ${dest}: from ${sender.slice(0, 12)}… (wrap ${ev.id.slice(0, 12)}…)`)
+  }).catch(e => {
+    // A channel waggle is not a member of fails HERE with a distinct RELAY[buzz] ERR — it can never
+    // masquerade as a §7 drop, and it is NOT marked seen, so it retries rather than dropping.
+    dropRelaySeen(ev.id)
+    err(`RELAY[buzz] ERR -> ${dest}: ${e.message} — claim rolled back, will retry`)
   })
 }
 function handleRelayIngress(ev) {
@@ -1280,8 +1288,7 @@ async function scanReturnLane(msgs, opts = {}) {
 
 let cmdCursor = 0
 function pollCommands() {
-  execFile('buzz', ['messages', 'get', '--channel', PUB.staging, '--limit', '30'], (e, so) => {
-    if (e) return err(`commands: staging read failed: ${e.message}`)
+  query('messages_get', { channel: PUB.staging, limit: 30 }).then((so) => {
     let msgs
     try { msgs = JSON.parse(String(so).slice(String(so).indexOf('['))) } catch { return err('commands: unparseable staging read') }
     for (const m of msgs) { if ((m.created_at || 0) >= cmdCursor - 300) handleCommand(m).catch(er => err(`commands: ${er.message}`)) }
@@ -1323,14 +1330,11 @@ function bumpScanCursor(ch, ts) {
 // no-miss logic is drivable by a test with synthetic pages — the scan test drives scanReturnLane
 // directly; this lets #5 drive the window and pagination the same way, no socket.
 function scanFetchPage(ch, floor, before, cb) {
-  const args = ['messages', 'get', '--channel', ch, '--limit', String(SCAN_PAGE_LIMIT), '--since', String(floor)]
-  if (before) args.push('--before', String(before))
-  execFile('buzz', args, (e, so) => {
-    if (e) return cb(e)
+  query('messages_get', { channel: ch, limit: SCAN_PAGE_LIMIT, since: floor, before: before || undefined }).then((so) => {
     let msgs
     try { msgs = JSON.parse(String(so).slice(String(so).indexOf('['))) } catch { return cb(new Error('unparseable read')) }
     cb(null, msgs)
-  })
+  }).catch(e => cb(e))
 }
 
 // Drain one scan channel: page back from newest to the cursor floor, then route the whole set once

--- a/src/bridge.mjs
+++ b/src/bridge.mjs
@@ -33,10 +33,12 @@
 // `since`, so a since=now subscription silently drops fresh DMs. We default the
 // lookback to 48h and lean on durable id-dedup to make re-delivery a no-op.
 import WebSocket from 'ws'
-import { verifyEvent, finalizeEvent, generateSecretKey, getEventHash, getPublicKey } from 'nostr-tools/pure'
-import * as nip44 from 'nostr-tools/nip44'
+// Only verifyEvent remains here: every signing symbol moved to nostr_egress.mjs with the key
+// (A3 §2.5). Verification is a public-key operation and belongs wherever input is judged.
+import { verifyEvent } from 'nostr-tools/pure'
 import * as nip19 from 'nostr-tools/nip19'
 import { emit, query } from './egress.mjs'
+import { bridgePubkey, hasBridgeKey, openSeal, openRumor, sealAndWrap } from './nostr_egress.mjs'
 import { createHash } from 'node:crypto'
 import { readFileSync, writeFileSync, appendFileSync, existsSync, mkdirSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
@@ -153,12 +155,9 @@ function journalSend(id, meta) {
 // The bridge's own identity, used to SEAL outbound return-lane mail. A NIP-17 seal names its
 // real sender, so this has to be the bridge's key — the wrap around it is signed by a throwaway,
 // which is why this traffic never appears on the wire as the poster key.
-const BRIDGE_SK = (() => {
-  const raw = process.env.BUZZ_PRIVATE_KEY
-  if (!raw) return null
-  try { return raw.startsWith('nsec1') ? nip19.decode(raw).data : Uint8Array.from(Buffer.from(raw, 'hex')) } catch { return null }
-})()
-const BRIDGE_PK = BRIDGE_SK ? getPublicKey(BRIDGE_SK) : null
+// A3 §2.5: the key itself lives in nostr_egress.mjs — signing is not the only thing it does (the
+// relay lane unseals with it too), so one module owns it and hands out capabilities instead.
+const BRIDGE_PK = bridgePubkey()
 
 const POSTED_CAP = Number(process.env.POSTED_CAP || 100000)
 const DEL_SINCE_SECS = Number(process.env.DEL_SINCE_SECS || 172800) // 48h
@@ -1069,22 +1068,13 @@ function publishWrapToRelays(wrap, mkSocket) {
   })
 }
 
-async function returnLaneSend(toHex, text, meta, publish = publishWrapToRelays) {
-  if (!BRIDGE_SK) { err('return lane: no bridge key to seal with — skipping'); return 0 }
-  const now = Math.floor(Date.now() / 1000)
-  // NIP-59 backdating: randomise wrap and seal timestamps into the past so an observer cannot
-  // correlate a channel message with a delivery by timing alone.
-  const fuzzed = () => now - Math.floor(Math.random() * 172800)
+async function returnLaneSend(toHex, descriptor, meta, publish = publishWrapToRelays) {
+  if (!hasBridgeKey()) { err('return lane: no bridge key to seal with — skipping'); return 0 }
   try {
-    const rumor = { kind: 14, pubkey: BRIDGE_PK, created_at: now, tags: [['p', toHex]], content: text }
-    rumor.id = getEventHash(rumor)
-    const seal = finalizeEvent({ kind: 13, created_at: fuzzed(), tags: [],
-      content: nip44.encrypt(JSON.stringify(rumor), nip44.getConversationKey(BRIDGE_SK, toHex)) }, BRIDGE_SK)
-    const wsk = generateSecretKey()
-    const wrap = finalizeEvent({ kind: 1059, created_at: fuzzed(), tags: [['p', toHex]],
-      content: nip44.encrypt(JSON.stringify(seal), nip44.getConversationKey(wsk, toHex)) }, wsk)
     const relays = (PUB.relays || []).length
-    const accepted = await publish(wrap)
+    // A3 §2.5: the seal/wrap construction and the key both live in nostr_egress.mjs. `descriptor`
+    // is {template, slots} — there is no parameter here that could carry a composed sentence.
+    const { wrap, accepted, bytes } = await sealAndWrap({ template: descriptor.template, to: toHex, slots: descriptor.slots }, publish)
     // Journal stamped with the accept-count so the durable record is landed-reality, not intent: a
     // 0/N carry is written accepted:0, never a false "sent". The wrap's author is ephemeral and can
     // never trip the tripwire, so this record is a written-down intent — worth making a truthful one;
@@ -1093,7 +1083,7 @@ async function returnLaneSend(toHex, text, meta, publish = publishWrapToRelays) 
     if (accepted < 1)
       err(`RETURN 0/${relays} -> ${toHex.slice(0, 12)}…: seal reached NO relay — NOT marked sent, will re-carry (wrap ${wrap.id.slice(0, 12)}…)`)
     else
-      log(`RETURN ${accepted}/${relays} -> ${toHex.slice(0, 12)}…: sealed ${String(text).length}B (wrap ${wrap.id.slice(0, 12)}…)`)
+      log(`RETURN ${accepted}/${relays} -> ${toHex.slice(0, 12)}…: sealed ${bytes}B (wrap ${wrap.id.slice(0, 12)}…)`)
     return accepted
   } catch (e) { err(`return lane: seal/send failed: ${e.message}`); return 0 }
 }
@@ -1111,12 +1101,15 @@ function relayDrop(reason, id, deterministic = true) {
   err(`RELAY drop[${reason}]: wrap ${String(id).slice(0, 12)}… (pre-auth, unackable)`)
   if (deterministic) markRelaySeen(id)
 }
-function relayReject(sender, id, reason, wantCh) {
+function relayReject(sender, id, reason, wantCh, extra = {}) {
   // Post-auth reject: the sender IS proven, so the refusal is ACKED — a drop and a silence must not
   // look the same (§5). Marked seen: the decision is deterministic for this wrap id.
-  err(`RELAY reject: ${reason} — sender ${sender.slice(0, 12)}… -> '${wantCh}' (wrap ${String(id).slice(0, 12)}…)`)
+  err(`RELAY reject: ${reason}${extra.cap ? ` (${extra.cap}B)` : ''} — sender ${sender.slice(0, 12)}… -> '${wantCh}' (wrap ${String(id).slice(0, 12)}…)`)
   markRelaySeen(id)
-  returnLaneSend(sender, JSON.stringify({ ok: false, reason, channel: wantCh, ts: Math.floor(Date.now() / 1000) }), { lane: 'relay-ack' })
+  returnLaneSend(sender, {
+    template: 'relay_ack_err',
+    slots: { reason, channel: wantCh, ts: Math.floor(Date.now() / 1000), ...extra },
+  }, { lane: 'relay-ack' })
 }
 function resolveRelayDest(wantCh) {
   // Allowlist check against the resolved relay_channels (UUIDs at boot). DEFAULT EMPTY → nothing
@@ -1134,7 +1127,7 @@ async function postRelay(ev, sender, dest, wantCh, body) {
   try { npub = nip19.npubEncode(sender) } catch { npub = null }
   const npubShort = npub ? `${npub.slice(0, 10)}…${npub.slice(-5)}` : sender.slice(0, 12) + '…'
   const nowSec = Math.floor(Date.now() / 1000)
-  const ackOk = (buzzId) => returnLaneSend(sender, JSON.stringify({ ok: true, channel: dest, buzz_event_id: buzzId || null, ts: nowSec }), { lane: 'relay-ack' })
+  const ackOk = (buzzId) => returnLaneSend(sender, { template: 'relay_ack_ok', slots: { channel: dest, buzzEventId: buzzId || null, ts: nowSec } }, { lane: 'relay-ack' })
   if (FORWARD_MODE !== 'buzz') {
     log(`RELAY[dryrun] -> ${dest}: from ${sender.slice(0, 12)}… (${Buffer.byteLength(body)}B) :: ${JSON.stringify(body.slice(0, 80))}`)
     return
@@ -1166,7 +1159,7 @@ async function postRelay(ev, sender, dest, wantCh, body) {
   })
 }
 function handleRelayIngress(ev) {
-  if (!BRIDGE_SK || !PUB) return
+  if (!hasBridgeKey() || !PUB) return
   const nowMs = Date.now()
   if (relaySeen.has(ev.id)) return                                          // §6 dedup BEFORE decrypt
   const wrapBytes = Buffer.byteLength(JSON.stringify(ev))
@@ -1176,13 +1169,13 @@ function handleRelayIngress(ev) {
   relayDecWin.push(nowMs)
   // ---- expensive step: decryption of UNAUTHENTICATED input (the §7 DoS surface) ----
   let seal
-  try { seal = JSON.parse(nip44.decrypt(ev.content, nip44.getConversationKey(BRIDGE_SK, ev.pubkey))) }
+  try { seal = openSeal(ev) }
   catch { return relayDrop('decrypt', ev.id) }
   let ok = false
   try { ok = verifyEvent(seal) } catch { ok = false }
   if (!ok || seal.kind !== 13) return relayDrop('verify', ev.id)            // authorship proof (§2.4)
   let rumor
-  try { rumor = JSON.parse(nip44.decrypt(seal.content, nip44.getConversationKey(BRIDGE_SK, seal.pubkey))) }
+  try { rumor = openRumor(seal) }
   catch { return relayDrop('decrypt', ev.id) }
   if (!rumor || String(rumor.pubkey) !== String(seal.pubkey)) return relayDrop('mismatch', ev.id) // bind unsigned rumor
   // ---- the sender is now AUTHENTICATED: every drop below is ACKED ----
@@ -1199,7 +1192,7 @@ function handleRelayIngress(ev) {
   const body = String(rumor.content || '')
   const bytes = Buffer.byteLength(body)
   if (!bytes) return relayReject(sender, ev.id, 'empty body', wantCh)
-  if (bytes > PUB.maxContentBytes) return relayReject(sender, ev.id, `over ${PUB.maxContentBytes}B cap`, wantCh)
+  if (bytes > PUB.maxContentBytes) return relayReject(sender, ev.id, 'over cap', wantCh, { cap: PUB.maxContentBytes })
   if (!relayRateOk(sender, dest, nowMs)) return relayReject(sender, ev.id, 'rate cap', wantCh)
   addRelaySeen(ev.id)   // claim BEFORE the async send: a copy from another relay must not post again
   postRelay(ev, sender, dest, wantCh, body)
@@ -1240,7 +1233,7 @@ function agentAuthoredBy(buzzId) {
 // only ever moves bytes to an address. The one place a body could reach a prompt is the action
 // layer, where the wake is content-free and the body is read-plane data (design §5).
 async function scanReturnLane(msgs, opts = {}) {
-  if (!PUB.returnLane.length || !BRIDGE_SK) return
+  if (!PUB.returnLane.length || !hasBridgeKey()) return
   const gateActive = opts.authors !== undefined            // an explicit (even empty) gate is default-closed
   const gate = gateActive ? new Set(opts.authors || []) : null
   for (const m of msgs || []) {
@@ -1272,12 +1265,10 @@ async function scanReturnLane(msgs, opts = {}) {
       const repliedTo = parents.some(pid => agentAuthoredBy(pid) === r.npub_hex)
       if (!mentioned && !repliedTo) continue
       addRlSeen(key)                                       // in-memory now: no double-carry within this scan/overlap
-      const accepted = await returnLaneSend(r.npub_hex,
-        `📥 **${r.mention}** — you were ${repliedTo && !mentioned ? 'replied to' : 'mentioned'} in the community.\n\n> ` +
-        body.replace(/\r/g, '').split('\n').join('\n> ') +
-        `\n\n_carried out by waggle's return lane. Replying to this message reaches nobody; ` +
-        `post from your own key and the bridge brings it back in._`,
-        { src: m.id, why: repliedTo && !mentioned ? 'reply' : 'mention' }, opts.publish)
+      const accepted = await returnLaneSend(r.npub_hex, {
+        template: 'return_carry',
+        slots: { mention: r.mention, why: repliedTo && !mentioned ? 'reply' : 'mention', body },
+      }, { src: m.id, why: repliedTo && !mentioned ? 'reply' : 'mention' }, opts.publish)
       // Persist-on-landed: durable dedup only once the seal reached a relay. A silent 0/N is rolled
       // back so the overlap re-read (and a restart) re-carry it — a rare re-carry beats a lost mention.
       if (accepted >= 1) markRlSeen(key)
@@ -1589,14 +1580,14 @@ if (!process.env.WB_NO_BOOT) {
     log(`public read lane -> inbox ${PUB.inbox}: ${PUB.relays.length} relay(s), ${PUB.authors.length} watched author(s), ${PUB.events.length} watched note(s), pub-since=${PUB.since} (${PUB_SINCE_SECS}s), watermark=${pubWatermark || 'none'}`)
     log(`  gates: staging=${PUB.staging || 'HOLD (none)'} · backfill<=${PUB.backfillLimit} · maxContent=${PUB.maxContentBytes}B · rate ${PUB.replierPerMin}/replier/min ${PUB.channelPerMin}/chan/min ${PUB.lanePerHour}/lane/h · deletes ${PUB.deletesPerHour}/h (A7)`)
     if (PUB.grantors.length) log(`  admission: ${PUB.grantors.length} grantor key(s); NIP-DA kinds ${NIPDA.grant}/${NIPDA.revocation}/${NIPDA.index}`)
-    if (PUB.relayChannels.length && BRIDGE_SK) log(`  relay lane: ${PUB.relayChannels.length} allowlisted channel(s); decrypt budget ${PUB.relayDecryptBudget}/min, wrap cap ${PUB.relayMaxWrapBytes}B — a channel waggle has not joined fails as RELAY[buzz] ERR, never a silent §7 drop`)
-    else if (PUB.relayChannels.length && !BRIDGE_SK) err('WARN: relay_channels configured but no BRIDGE key to open sealed requests — relay lane INERT.')
+    if (PUB.relayChannels.length && hasBridgeKey()) log(`  relay lane: ${PUB.relayChannels.length} allowlisted channel(s); decrypt budget ${PUB.relayDecryptBudget}/min, wrap cap ${PUB.relayMaxWrapBytes}B — a channel waggle has not joined fails as RELAY[buzz] ERR, never a silent §7 drop`)
+    else if (PUB.relayChannels.length && !hasBridgeKey()) err('WARN: relay_channels configured but no BRIDGE key to open sealed requests — relay lane INERT.')
     PUB.relays.forEach(connectPublic)
     if (PUB.staging && PUB.approvers.length && FORWARD_MODE === 'buzz') {
       log(`approval console: watching staging for commands from ${PUB.approvers.length} approver(s)`)
       pollCommands(); setInterval(pollCommands, 15000)
     }
-    if (PUB.scanChannels.length && PUB.returnLane.length && BRIDGE_SK && FORWARD_MODE === 'buzz') {
+    if (PUB.scanChannels.length && PUB.returnLane.length && hasBridgeKey() && FORWARD_MODE === 'buzz') {
       log(`return-lane scan: ${PUB.scanChannels.length} channel(s) · ${PUB.returnLane.length} recipient(s) · signer gate ${PUB.scanAuthors.length} key(s)`)
       // Silence-is-not-calm: a configured scan with an empty gate routes NOTHING, so say so loudly
       // rather than let it look like "no mentions." Set scan_authors (or declare approvers/grantors).

--- a/src/egress.mjs
+++ b/src/egress.mjs
@@ -1,0 +1,343 @@
+// src/egress.mjs — the Buzz-egress chokepoint (#134 A3; docs/DESIGN_EGRESS_CHOKEPOINT.md).
+//
+// waggle is infrastructure. It carries, it never authors. Before this module, that property was
+// held by CONVENTION — by every author so far having chosen to write a template — and convention
+// is exactly what failed on 2026-07-31. Seven call sites each reached execFile('buzz', …) and the
+// CLI signed whatever string it was handed; the good paths and the bad path were the same call.
+//
+// The fix is not a check that callers must remember to run. It is a VOCABULARY WITH NO WORD FOR
+// THE FORBIDDEN THING: emit() takes a tagged union, never a string, so "send this sentence" is
+// not expressible. There is exactly one execFile('buzz', …) write in the tree and it is below.
+//
+// INV-A3-1  every emitted byte is a source literal, a typed slot value, or a carried_body that
+//           went through a neutralising renderer
+// INV-A3-3  no caller can reach the signer with a caller-composed string — by type shape
+// INV-A3-4  wrapJson is single-line by contract (§2.4), enforced at render time
+// INV-A3-5  every slot of every template declares one of the closed slot types
+import { execFile } from 'node:child_process'
+import { renderQuarantined, renderReleased } from './render.mjs'
+
+// --- The closed slot-type set (§2.2, INV-A3-5) -----------------------------------------------
+//
+// Closing the TYPE set is what makes this structural rather than conventional. A template
+// language with a {message} slot is the original hole with extra steps, so there is deliberately
+// no slot type that accepts free prose: `carried_body` accepts arbitrary bytes but always renders
+// through the hostile-content renderer and always lands attributed to an external author, and
+// `inline_token` accepts operator text but is stripped and capped and never leaves its code span.
+//
+// A future `detail: string` fails by construction here — as an UNKNOWN SLOT TYPE — with no
+// reviewer required to notice it. Adding a ninth type is a deliberate spec change, which is
+// exactly the friction wanted.
+const reject = (type, why) => { throw new Error(`egress: slot rejected (${type}): ${why}`) }
+
+const hexOfLength = (n, type) => (v) => {
+  const s = String(v == null ? '' : v).toLowerCase()
+  if (!new RegExp(`^[0-9a-f]{${n}}$`).test(s)) reject(type, `expected ${n} hex chars, got ${JSON.stringify(String(v).slice(0, 24))}`)
+  return s
+}
+
+// Short operator-supplied text, rendered INSIDE backticks and never permitted to leave them.
+// This type exists for exactly one reason: handleCommand's unrecognized-verb reply already
+// echoes the approver's own word back at them, and deleting that affordance would change
+// behaviour. It is the narrowest thing that preserves it — not a general-purpose string slot.
+const INLINE_TOKEN_MAX = 24
+const inlineToken = (v) => {
+  const s = String(v == null ? '' : v)
+    .replace(/[`\r\n]/g, '')       // cannot close its own code span, cannot reach a new line
+    .replace(/[@*_]/g, '')         // cannot ping anyone, cannot mint emphasis
+    .slice(0, INLINE_TOKEN_MAX)
+  return s
+}
+
+const SLOT_TYPES = {
+  id: hexOfLength(64, 'id'),
+  hex: hexOfLength(64, 'hex'),
+  // An npub is bech32, not hex — but every caller here holds either an npub string or a raw
+  // pubkey, so this accepts both shapes and nothing else. Anything with whitespace or markup in
+  // it is not an identity and is refused.
+  npub: (v) => {
+    const s = String(v == null ? '' : v)
+    if (!/^(npub1[0-9a-z]{20,90}|[0-9a-f]{64})$/i.test(s)) reject('npub', `not an npub or pubkey: ${JSON.stringify(s.slice(0, 24))}`)
+    return s
+  },
+  // A resolved channel handle or UUID. Never a caller-composed label.
+  channel: (v) => {
+    const s = String(v == null ? '' : v)
+    if (!/^[0-9a-fA-F-]{36}$|^[\w][\w .-]{0,63}$/.test(s)) reject('channel', `not a channel handle or UUID: ${JSON.stringify(s.slice(0, 32))}`)
+    return s
+  },
+  count: (v) => { const n = Number(v); if (!Number.isFinite(n)) reject('count', `not a number: ${JSON.stringify(v)}`); return String(n) },
+  ts: (v) => { const n = Number(v); if (!Number.isFinite(n)) reject('ts', `not a number: ${JSON.stringify(v)}`); return String(n) },
+  // `enum` is special-cased in renderSlots because its permitted set is per-slot, declared in the
+  // catalogue. Listed here so it is a member of the closed set like everything else.
+  enum: (v) => String(v),
+  inline_token: inlineToken,
+  // An EXTERNAL author's display name, from their public kind:0 — fully attacker-controlled, and
+  // rendered OUTSIDE any code span (in bold, on the attribution line). `inline_token` is the wrong
+  // type for it precisely because that type's contract is "never leaves the code span".
+  //
+  // The same stripping already happens at the fetch site, which is why this is not a live hole
+  // today. But it lives there by CONVENTION — a future caller sourcing a name from anywhere else
+  // gets no guard at all. Moving it into the type is the whole thesis of A3 applied to the one
+  // untrusted slot that renders as chrome rather than as content. The fetch-site strip stays as
+  // belt-and-braces.
+  display_name: (v) => String(v == null ? '' : v).replace(/[`@[\]()\n\r*_~]/g, '').trim().slice(0, 32),
+  // A Buzz @handle from OPERATOR CONFIG, rendered as a LIVE mention on purpose — waking the
+  // approver is the point of the quarantine header, and waking the recipient is the point of a
+  // sealed-envelope delivery. Distinct from display_name for exactly that reason: this one is
+  // trusted-by-provenance and keeps its @, so it must never be fed an external value.
+  handle: (v) => {
+    const s = String(v == null ? '' : v).trim()
+    if (!/^[\w][\w.-]{0,63}$/.test(s)) reject('handle', `not a bare handle: ${JSON.stringify(s.slice(0, 32))}`)
+    return s
+  },
+  // The ONLY slot that accepts arbitrary bytes. It never renders as waggle's own words: the
+  // renderer neutralises it and the surrounding template attributes it to its external author.
+  // What A3 blocks is authorship reconstruction, and attribution blocks that at any N.
+  carried_body: (v) => String(v == null ? '' : v),
+  // Site 1's sealed envelope JSON. INV-A3-4: single-line BY CONTRACT, not by accident of
+  // formatting. It is embedded in a fenced code block, and the fence's safety is load-bearing on
+  // the JSON containing no newline — a planted ``` cannot reach the start of a line and so cannot
+  // close the fence. A future JSON.stringify(ev, null, 2) is an entirely reasonable-looking
+  // readability change that would silently reopen a fence break, so the escaper refuses it here
+  // rather than trusting whoever edits the call site next.
+  wrapJson: (v) => {
+    const s = typeof v === 'string' ? v : JSON.stringify(v)
+    if (/[\r\n]/.test(s)) reject('wrapJson', 'contains a newline — INV-A3-4 requires single-line JSON (never pretty-printed)')
+    return s
+  },
+}
+
+export const SLOT_TYPE_NAMES = Object.freeze(Object.keys(SLOT_TYPES))
+
+// --- The catalogue (§2.1) --------------------------------------------------------------------
+//
+// Closed and compiled in. `slots` declares each slot's TYPE — that declaration is what the
+// catalogue test asserts against SLOT_TYPE_NAMES, so an unknown type cannot reach production.
+// `action` picks the argv shape; every one of them ends at the single execFile below.
+const CATALOGUE = {
+  // Site 1 — forward(): a sealed 1059 handed to a recipient's inbox. The prose is entirely in
+  // this template; the only variables are the recipient, the channel name, and the envelope.
+  sealed_envelope: {
+    action: 'send',
+    slots: { name: 'handle', channel: 'channel', wrapJson: 'wrapJson' },
+    optional: ['channel'],
+    render: ({ name, channel, wrapJson }) => {
+      const label = channel
+        ? `New Concord channel post on **${channel}** — its outer \`p\` tag is a random decoy, not a recipient. ` +
+          `Decrypt with the plane key you derive from the **${channel} community_root** ` +
+          `(publicChannel(root, channel_id, epoch).conv); do NOT re-seal. If your runtime holds no Concord grant for ` +
+          `this channel, you cannot open it yet — that's a provisioning gap, flag it and hold:`
+        : `New Armada DM — sealed, unwrap with your key:`
+      return `@${name}\n\n${label}\n\n\`\`\`json\n${wrapJson}\n\`\`\`\n`
+    },
+  },
+
+  // Site 2a — forwardPublic(), quarantined. The renderer is the guard; it is unchanged.
+  // `when`, `claim` and `why` were caller-composed strings before this. They are now a timestamp,
+  // an optional timestamp, and an enum — the three of them were the quiet half of §1.1's hole:
+  // benign today, and nothing but convention stopped the next edit concatenating into them.
+  quarantine_header: {
+    action: 'send',
+    slots: {
+      body: 'carried_body', approver: 'handle', name: 'display_name', npub: 'npub',
+      ts: 'ts', claimedTs: 'ts', why: 'enum', id: 'id',
+    },
+    optional: ['approver', 'name', 'claimedTs'],
+    enums: { why: ['mirrored feed', 'granted participant', 'standing follow', 'reply to our note', 'released from quarantine'] },
+    render: ({ body, approver, name, npub, ts, claimedTs, why, id }) => renderQuarantined({
+      body,
+      mention: approver ? `@${approver} ` : '',
+      name,
+      npub,
+      when: new Date(Number(ts) * 1000).toISOString(),
+      // The clamp notice is prose, so it belongs here and not in a caller's string. A5 clamps an
+      // attacker-controlled created_at; this is how the reader is told the claim was moved.
+      claim: claimedTs ? `  ·  ⚠︎ author-claimed \`${new Date(Number(claimedTs) * 1000).toISOString()}\` (clamped)` : '',
+      why,
+      id,
+    }),
+  },
+
+  // Sites 2b and 7 — forwardPublic() released, and postRelay(). A vouched identity's own words,
+  // attributed, with liveRefs deciding whether its @mentions survive (#94).
+  released_post: {
+    action: 'send',
+    slots: { body: 'carried_body', name: 'display_name', npubShort: 'inline_token', liveRefs: 'enum' },
+    optional: ['name'],
+    enums: { liveRefs: [true, false] },
+    render: (s) => renderReleased(s),
+  },
+
+  // Sites 3 and 5 — withdraw()'s follow-up post and its edit tier. Same bytes, two actions.
+  a7_tombstone: {
+    action: 'send',
+    slots: { author: 'npub', origId: 'id', delId: 'id' },
+    render: ({ author, origId, delId }) =>
+      `🗑 **Withdrawn by author** — NIP-09 deletion\n` +
+      `author \`${author}\` · original \`${origId}\` · delete \`${delId}\`\n` +
+      `_Content removed at the author's request._\n`,
+  },
+  a7_tombstone_edit: {
+    action: 'edit',
+    slots: { author: 'npub', origId: 'id', delId: 'id' },
+    render: (s) => CATALOGUE.a7_tombstone.render(s),
+  },
+
+  // Site 4 — withdraw()'s delete tier. No body at all: a fixed public reason, in the argv.
+  a7_delete: {
+    action: 'delete',
+    slots: {},
+    render: () => null,
+  },
+
+  // Site 6 — the approval console's confirmations. This is the template that closes the actual
+  // hole: replyInStaging used to take a `text: string`, and its unrecognized-verb caller passed
+  // runtime-variable operator input. Now the caller picks a VERB and the words live here.
+  console_ack: {
+    action: 'reply',
+    slots: { verb: 'enum', author: 'npub', echo: 'inline_token', granted: 'enum' },
+    optional: ['author', 'echo', 'granted'],
+    enums: {
+      verb: ['unrecognized', 'rejected', 'muted', 'no_original', 'bad_signature', 'rate_capped', 'released'],
+      granted: [true, false],
+    },
+    render: ({ verb, author, echo, granted }) => {
+      switch (verb) {
+        case 'unrecognized':
+          return `unrecognized command \`${echo}\` — try **approve** (or release), **follow**, **mute**, or **reject**.`
+        case 'rejected':
+          return `🚫 rejected — no action taken; the author remains quarantined.`
+        case 'muted':
+          return `🔇 muted \`${String(author).slice(0, 12)}…\` — their replies will no longer reach staging.`
+        case 'no_original':
+          return `⚠️ could not fetch the original from any relay — nothing released.`
+        case 'bad_signature':
+          return `⚠️ signature verification FAILED — refusing to release.`
+        case 'rate_capped':
+          return `⚠️ rate cap would be exceeded — try again later.`
+        case 'released':
+          return `✅ released to the community channel${granted ? ` · standing follow granted (their replies now skip the queue)` : ''}`
+        // No default: renderSlots has already refused any verb outside the enum, so an
+        // unreachable branch here would only hide a catalogue/enum mismatch.
+      }
+      reject('enum', `console_ack verb fell through: ${JSON.stringify(verb)}`)
+    },
+  },
+
+  // The `released` ack has one more shape: the note was already out. Kept as its own verb rather
+  // than a boolean on `released`, so the catalogue reads as the set of things waggle can say.
+  console_ack_already: {
+    action: 'reply',
+    slots: { granted: 'enum' },
+    optional: ['granted'],
+    enums: { granted: [true, false] },
+    render: ({ granted }) =>
+      `✅ already released earlier${granted ? ` · standing follow granted (their replies now skip the queue)` : ''}`,
+  },
+}
+
+export const TEMPLATE_NAMES = Object.freeze(Object.keys(CATALOGUE))
+export const templateSpec = (name) => CATALOGUE[name]
+
+// --- Rendering: every slot through its declared type ------------------------------------------
+function renderSlots(templateName, slots = {}) {
+  const spec = CATALOGUE[templateName]
+  if (!spec) reject('template', `unknown template ${JSON.stringify(templateName)}`)
+  const optional = new Set(spec.optional || [])
+  const out = {}
+  for (const [slot, type] of Object.entries(spec.slots)) {
+    const raw = slots[slot]
+    const absent = raw === undefined || raw === null || raw === ''
+    if (absent) {
+      if (!optional.has(slot)) reject(type, `template ${templateName} requires slot ${slot}`)
+      out[slot] = type === 'enum' ? undefined : ''
+      continue
+    }
+    if (type === 'enum') {
+      const permitted = (spec.enums || {})[slot]
+      if (!permitted || !permitted.includes(raw)) reject('enum', `${templateName}.${slot} not in {${(permitted || []).join('|')}}: ${JSON.stringify(raw)}`)
+      out[slot] = raw
+      continue
+    }
+    const escape = SLOT_TYPES[type]
+    if (!escape) reject('slot-type', `${templateName}.${slot} declares unknown slot type ${JSON.stringify(type)} (INV-A3-5)`)
+    out[slot] = escape(raw)
+  }
+  // A caller passing a slot the template does not declare is a caller trying to say something
+  // the catalogue has no word for. Refuse rather than silently ignore it.
+  for (const given of Object.keys(slots)) {
+    if (!(given in spec.slots)) reject('slot', `template ${templateName} has no slot ${JSON.stringify(given)}`)
+  }
+  return { spec, values: out }
+}
+
+// Exported so the catalogue test can drive rendering with hostile values without shelling out.
+export function renderTemplate(templateName, slots) {
+  const { spec, values } = renderSlots(templateName, slots)
+  return spec.render(values)
+}
+
+// --- The one signing call ---------------------------------------------------------------------
+//
+// Everything above is about what may be SAID. This is the only place anything is signed on the
+// Buzz transport. If a second execFile appears anywhere in src/, the ban test (§2.3) fails.
+let runBuzz = (args) => new Promise((resolve, rejectP) => {
+  execFile('buzz', args, (e, so, se) => {
+    if (e) { const wrapped = new Error(String(se || e.message).trim()); wrapped.cause = e; return rejectP(wrapped) }
+    resolve(String(so || ''))
+  })
+})
+
+// Test seam ONLY — lets the catalogue test assert on argv without a `buzz` binary present. Not a
+// bypass: it replaces the transport, never the catalogue or the escapers above.
+export function __setTransportForTests(fn) { const prev = runBuzz; runBuzz = fn; return () => { runBuzz = prev } }
+
+// --- Reads --------------------------------------------------------------------------------
+//
+// Read verbs author nothing and are out of A3's scope for what waggle can SAY — but they live
+// here anyway, because the enforcement axis is the IMPORT, not the verb (§2.3). If bridge.mjs
+// kept its own `child_process` import for three reads, the ban test would have to permit that
+// import and would then be blind to a write sneaking in beside it. One module owns the transport;
+// the ban stays absolute and therefore meaningful.
+const READS = {
+  channels_list: () => ['channels', 'list'],
+  messages_get: ({ channel, limit, since, before }) => {
+    const a = ['messages', 'get', '--channel', SLOT_TYPES.channel(channel), '--limit', SLOT_TYPES.count(limit)]
+    if (since !== undefined && since !== null) a.push('--since', SLOT_TYPES.ts(since))
+    if (before !== undefined && before !== null) a.push('--before', SLOT_TYPES.ts(before))
+    return a
+  },
+}
+
+export const READ_NAMES = Object.freeze(Object.keys(READS))
+
+// query(name, params) -> Promise<stdout>. A closed set, argv built from typed values.
+export function query(name, params = {}) {
+  const build = READS[name]
+  if (!build) reject('read', `unknown read verb ${JSON.stringify(name)}`)
+  return runBuzz(build(params))
+}
+
+function argvFor(spec, descriptor, content) {
+  switch (spec.action) {
+    case 'send':   return ['messages', 'send', '--channel', SLOT_TYPES.channel(descriptor.dest), '--content', content]
+    case 'reply':  return ['messages', 'send', '--channel', SLOT_TYPES.channel(descriptor.dest), '--reply-to', SLOT_TYPES.id(descriptor.parentId), '--content', content]
+    case 'edit':   return ['messages', 'edit', '--event', SLOT_TYPES.id(descriptor.targetId), '--content', content]
+    case 'delete': return ['messages', 'delete', '--event', SLOT_TYPES.id(descriptor.targetId), '--reason-code', 'nip09', '--public-reason', 'withdrawn by author (NIP-09)']
+    default:       return reject('action', `unknown action ${JSON.stringify(spec.action)}`)
+  }
+}
+
+// emit(descriptor) -> Promise<{ stdout }>
+//
+// `descriptor` is a tagged union: { template, dest?, parentId?, targetId?, slots }. There is no
+// field for a caller-composed string, which is the entire design (INV-A3-3).
+export async function emit(descriptor) {
+  if (!descriptor || typeof descriptor !== 'object') reject('descriptor', 'emit requires a descriptor object')
+  if (typeof descriptor === 'string') reject('descriptor', 'emit does not accept strings')
+  const { spec, values } = renderSlots(descriptor.template, descriptor.slots)
+  const content = spec.render(values)
+  const stdout = await runBuzz(argvFor(spec, descriptor, content))
+  return { stdout }
+}

--- a/src/nostr_egress.mjs
+++ b/src/nostr_egress.mjs
@@ -1,0 +1,170 @@
+// src/nostr_egress.mjs — the Nostr-transport chokepoint (#134 A3 §2.5).
+//
+// The sibling of egress.mjs, and the reason INV-A3-2 can be stated at all. There are TWO egress
+// transports, not one: the Buzz CLI signs kind:9 with BUZZ_PRIVATE_KEY, and this path signs
+// NIP-59 envelopes with the bridge's own key IN-PROCESS. A ban that only watched the CLI was
+// structurally blind to this half — it never spells `buzz` at all.
+//
+// Same shape as the Buzz chokepoint, second transport: one signing verb over a CLOSED set of
+// envelope kinds (kind:13 seal, kind:1059 wrap) and a closed catalogue of bodies. No caller may
+// hand it a free string either.
+//
+// This module also OWNS THE KEY. Signing is not the only thing a private key does — the relay
+// lane unseals inbound wraps with it too — and a ban on `finalizeEvent` alone would leave
+// BRIDGE_SK spread across the file with nothing to stop the next signer appearing beside a
+// decrypt. So the key is derived here, never exported, and callers get capabilities instead:
+// `bridgePubkey()`, `hasBridgeKey()`, `openSealed()`, `sealAndWrap()`.
+//
+// INV-A3-2  exactly one function per transport invokes a signer. This is the Nostr one.
+import { finalizeEvent, generateSecretKey, getEventHash, getPublicKey } from 'nostr-tools/pure'
+import * as nip19 from 'nostr-tools/nip19'
+import * as nip44 from 'nostr-tools/nip44'
+
+// --- The key, held here and nowhere else ------------------------------------------------------
+const BRIDGE_SK = (() => {
+  const raw = process.env.BUZZ_PRIVATE_KEY
+  if (!raw) return null
+  try { return raw.startsWith('nsec1') ? nip19.decode(raw).data : Uint8Array.from(Buffer.from(raw, 'hex')) } catch { return null }
+})()
+const BRIDGE_PK = BRIDGE_SK ? getPublicKey(BRIDGE_SK) : null
+
+// The PUBLIC key is safe to hand out and is needed all over bridge.mjs for REQ filters and
+// self-comparison. The secret never leaves this module.
+export const bridgePubkey = () => BRIDGE_PK
+export const hasBridgeKey = () => !!BRIDGE_SK
+
+// --- The catalogue of things waggle may say on this transport ---------------------------------
+//
+// Its bodies are machine JSON and one carried mention today, which is why §2.5 rates this lower
+// urgency than the Buzz half — but "lower urgency" is not "optional": nothing structural stopped
+// a future caller putting a sentence in an ack, and a second signer path is exactly how the Buzz
+// side got into this state.
+const reject = (why) => { throw new Error(`nostr-egress: ${why}`) }
+
+const hex64 = (v, what) => {
+  const s = String(v == null ? '' : v).toLowerCase()
+  if (!/^[0-9a-f]{64}$/.test(s)) reject(`${what} is not a 64-hex id: ${JSON.stringify(String(v).slice(0, 24))}`)
+  return s
+}
+const num = (v, what) => { const n = Number(v); if (!Number.isFinite(n)) reject(`${what} is not a number`); return n }
+const handle = (v) => {
+  const s = String(v == null ? '' : v).trim()
+  if (!/^[\w][\w.-]{0,63}$/.test(s)) reject(`not a bare handle: ${JSON.stringify(s.slice(0, 32))}`)
+  return s
+}
+// The community's own words, carried out to a guest. Untrusted in the same sense as the Buzz
+// side's carried_body: quoted, never rendered as waggle's own voice.
+const carried = (v) => String(v == null ? '' : v)
+
+const CATALOGUE = {
+  // Relay-lane acks. Typed JSON, never prose — a caller picks ok/err and supplies fields.
+  relay_ack_ok: {
+    build: ({ channel, buzzEventId, ts }) => JSON.stringify({
+      ok: true,
+      channel: String(channel),
+      buzz_event_id: buzzEventId ? hex64(buzzEventId, 'buzzEventId') : null,
+      ts: num(ts, 'ts'),
+    }),
+  },
+  relay_ack_err: {
+    // `reason` is a closed set, not a message. An ack that could carry an arbitrary reason string
+    // is a free-text path wearing a JSON hat — and one of these already WAS composed at the call
+    // site (`over ${PUB.maxContentBytes}B cap`, interpolating config into the wire).
+    //
+    // The rendered strings below are byte-identical to what the lane sent before #134: A3 changes
+    // what waggle CAN say, never what crosses. A granted participant's client parsing `reason`
+    // sees exactly what it saw yesterday.
+    reasons: {
+      'channel not allowlisted': () => 'channel not allowlisted',
+      'not admitted': () => 'not admitted',
+      'empty body': () => 'empty body',
+      'rate cap': () => 'rate cap',
+      'over cap': ({ cap }) => `over ${num(cap, 'cap')}B cap`,
+    },
+    build: ({ reason, channel, ts, cap }, spec) => {
+      const render = spec.reasons[reason]
+      if (!render) reject(`ack reason not in {${Object.keys(spec.reasons).join('|')}}: ${JSON.stringify(reason)}`)
+      return JSON.stringify({
+        ok: false,
+        reason: render({ cap }),
+        channel: channel == null ? null : String(channel),
+        ts: num(ts, 'ts'),
+      })
+    },
+  },
+  // The return lane's actual product: a community message carried out to a guest the community
+  // relay will not serve. The prose is here; the caller supplies who, why, and the body.
+  return_carry: {
+    whys: ['mention', 'reply'],
+    build: ({ mention, why, body }, spec) => {
+      if (!spec.whys.includes(why)) reject(`carry reason not in {${spec.whys.join('|')}}: ${JSON.stringify(why)}`)
+      return `📥 **${handle(mention)}** — you were ${why === 'reply' ? 'replied to' : 'mentioned'} in the community.\n\n> ` +
+        carried(body).replace(/\r/g, '').split('\n').join('\n> ') +
+        `\n\n_carried out by waggle's return lane. Replying to this message reaches nobody; ` +
+        `post from your own key and the bridge brings it back in._`
+    },
+  },
+}
+
+export const NOSTR_TEMPLATE_NAMES = Object.freeze(Object.keys(CATALOGUE))
+
+// Exported so the catalogue test can drive body construction without signing anything.
+export function buildBody(template, slots = {}) {
+  const spec = CATALOGUE[template]
+  if (!spec) reject(`unknown template ${JSON.stringify(template)}`)
+  return spec.build(slots, spec)
+}
+
+// --- Reading the bridge's own sealed inbox ----------------------------------------------------
+//
+// Not egress, but it is the other thing the key does, and it lives here so that BRIDGE_SK has
+// exactly one home. Each throws rather than returning a sentinel; the caller never sees the key.
+//
+// DELIBERATELY TWO CALLS, not one. The caller must verify the seal's signature BETWEEN them —
+// that is the authorship proof (§2.4), and it is what keeps the second (expensive) decrypt off
+// unauthenticated input on the §7 DoS surface. A single open-it-all helper would quietly decrypt
+// the inner rumor before anything had proven the seal was authentic, and the ordering would be
+// lost in a refactor with nothing to catch it. Keep them separate.
+export function openSeal(ev) {
+  if (!BRIDGE_SK) reject('no bridge key to open sealed mail')
+  return JSON.parse(nip44.decrypt(ev.content, nip44.getConversationKey(BRIDGE_SK, ev.pubkey)))
+}
+export function openRumor(seal) {
+  if (!BRIDGE_SK) reject('no bridge key to open sealed mail')
+  return JSON.parse(nip44.decrypt(seal.content, nip44.getConversationKey(BRIDGE_SK, seal.pubkey)))
+}
+
+// --- The one signing call on this transport ---------------------------------------------------
+//
+// sealAndWrap({ template, to, slots }, publish) -> { wrap, accepted, bytes }
+//
+// `to` is the recipient pubkey; the body comes from the catalogue and nowhere else. The seal is
+// signed by the BRIDGE key (a NIP-17 seal names its real sender, so it must be); the wrap around
+// it is signed by a THROWAWAY, which is why this traffic never appears on the wire as the poster
+// key — and why the wrap id can never trip the tripwire.
+export async function sealAndWrap({ template, to, slots }, publish) {
+  if (!BRIDGE_SK) reject('no bridge key to seal with')
+  if (typeof template !== 'string') reject('sealAndWrap requires a catalogue template name, not a string body')
+  const toHex = hex64(to, 'recipient')
+  const text = buildBody(template, slots)
+
+  const now = Math.floor(Date.now() / 1000)
+  // NIP-59 backdating: randomise wrap and seal timestamps into the past so an observer cannot
+  // correlate a channel message with a delivery by timing alone.
+  const fuzzed = () => now - Math.floor(Math.random() * 172800)
+
+  const rumor = { kind: 14, pubkey: BRIDGE_PK, created_at: now, tags: [['p', toHex]], content: text }
+  rumor.id = getEventHash(rumor)
+  const seal = finalizeEvent({
+    kind: 13, created_at: fuzzed(), tags: [],
+    content: nip44.encrypt(JSON.stringify(rumor), nip44.getConversationKey(BRIDGE_SK, toHex)),
+  }, BRIDGE_SK)
+  const wsk = generateSecretKey()
+  const wrap = finalizeEvent({
+    kind: 1059, created_at: fuzzed(), tags: [['p', toHex]],
+    content: nip44.encrypt(JSON.stringify(seal), nip44.getConversationKey(wsk, toHex)),
+  }, wsk)
+
+  const accepted = await publish(wrap)
+  return { wrap, accepted, bytes: text.length }
+}

--- a/tests/egress_ban.mjs
+++ b/tests/egress_ban.mjs
@@ -51,26 +51,26 @@ for (const f of files) {
 }
 
 // ---------------------------------------------------------------------------------------------
-console.log('\n-- Nostr transport: no NEW signer site may appear (INV-A3-2, ratcheted) --')
+console.log('\n-- Nostr transport: only nostr_egress.mjs may sign or hold the key (INV-A3-2) --')
 //
-// INV-A3-2 wants exactly one function per transport to invoke a signer. That is TRUE for Buzz as
-// of #134 and NOT YET TRUE for Nostr: the sibling chokepoint (§2.5) has not been built, so
-// `finalizeEvent` still lives in bridge.mjs. Asserting "only nostr.mjs may sign" today would be a
-// test that passes for the wrong reason.
-//
-// So this is a RATCHET rather than the final gate: the exact current signer sites are pinned, and
-// any new one fails. That keeps the Nostr path from drifting toward prose while the Buzz path is
-// being fixed — which §2.3 names as the whole point of covering both transports from day one —
-// and it converts to the strict single-module ban when §2.5 lands.
-const SIGNER_SITES_EXPECTED = {
-  'bridge.mjs': 2,   // returnLaneSend(): the kind:13 seal and the kind:1059 wrap
-}
+// INV-A3-2 wants exactly one function per transport to invoke a signer. Both halves now hold:
+// egress.mjs owns the Buzz CLI, nostr_egress.mjs owns the in-process NIP-59 signing AND the
+// bridge key itself. The key matters as much as the signer here — signing is not the only thing
+// a private key does (the relay lane unseals with it), and a ban on `finalizeEvent` alone would
+// leave BRIDGE_SK spread across the file with nothing stopping the next signer appearing beside
+// a decrypt.
 for (const f of files) {
   const text = readFileSync(join(SRC, f), 'utf8')
   // Count CALLS, not the import line: `finalizeEvent(` with a paren.
   const calls = (text.match(/finalizeEvent\s*\(/g) || []).length
-  const expected = SIGNER_SITES_EXPECTED[f] || 0
-  ok(`${f}: ${calls} finalizeEvent call site(s), pinned at ${expected}`, calls === expected)
+  const holdsKey = /BRIDGE_SK/.test(text)
+  if (f === 'nostr_egress.mjs') {
+    ok(`${f}: holds the signer (expected)`, calls > 0)
+    ok(`${f}: holds the bridge key (expected)`, holdsKey)
+  } else {
+    ok(`${f}: no finalizeEvent call site`, calls === 0)
+    ok(`${f}: never references BRIDGE_SK`, !holdsKey)
+  }
 }
 {
   const planted = 'const e = finalizeEvent({ kind: 1 }, sk)'

--- a/tests/egress_ban.mjs
+++ b/tests/egress_ban.mjs
@@ -1,0 +1,82 @@
+// tests/egress_ban.mjs — the enforcement gate (#134 A3 §2.3).
+//
+// A chokepoint nobody is forced to use is a style guide. This suite is what forces it.
+//
+// BAN THE CAPABILITY, NOT THE SPELLING. An earlier proposal was to grep for `execFile('buzz'`.
+// That is the wrong axis: it is evaded by aliasing the function, by a variable verb, by
+// spawn('sh', ['-c', …]) — and it is structurally blind to the Nostr transport, which never
+// spells `buzz` at all. So the ban is on the IMPORTS and SIGNER SYMBOLS.
+//
+// Honest residual, stated rather than papered over: `require('child_' + 'process')` still slips a
+// static check, and anyone with commit access can route around a lint rule. What an import ban
+// reliably stops is the ACCIDENT — the next contributor reaching for the convenient thing — which
+// is the actual threat model here. It is not airtight and nothing below claims it is.
+import { readFileSync, readdirSync, writeFileSync, unlinkSync } from 'node:fs'
+import { join, dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const SRC = resolve(dirname(fileURLToPath(import.meta.url)), '..', 'src')
+const files = readdirSync(SRC).filter(f => f.endsWith('.mjs'))
+
+let fails = 0
+const ok = (name, cond) => { console.log(`${cond ? 'ok  ' : 'FAIL'} — ${name}`); if (!cond) fails++ }
+
+// The scanner, factored out so the negative control can drive it over a planted file.
+const importsChildProcess = (text) => /(^|[^\w])(import\s[^\n]*['"]node:child_process['"]|require\(\s*['"](node:)?child_process['"]\s*\))/m.test(text)
+
+console.log('-- Buzz transport: only egress.mjs may import child_process --')
+
+for (const f of files) {
+  const text = readFileSync(join(SRC, f), 'utf8')
+  const has = importsChildProcess(text)
+  if (f === 'egress.mjs') ok(`${f}: holds the transport (expected)`, has)
+  else ok(`${f}: does not import child_process`, !has)
+}
+
+// NEGATIVE CONTROL. The loop above passes trivially if the scanner is broken — a regex that never
+// matches and a codebase that never violates are indistinguishable. Plant a violation and require
+// the scanner to catch it.
+{
+  const planted = join(SRC, '__ban_control__.mjs')
+  try {
+    writeFileSync(planted, "import { execFile } from 'node:child_process'\nexport const x = execFile\n")
+    const caught = importsChildProcess(readFileSync(planted, 'utf8'))
+    ok('NEGATIVE CONTROL — a planted child_process import IS detected', caught)
+    // And the shape the design calls out as the reason not to grep for `execFile('buzz'`:
+    ok('NEGATIVE CONTROL — the ban is on the import, so an aliased spawn would still be caught',
+      importsChildProcess("const { spawn: go } = require('child_process')"))
+  } finally {
+    try { unlinkSync(planted) } catch { /* already gone */ }
+  }
+}
+
+// ---------------------------------------------------------------------------------------------
+console.log('\n-- Nostr transport: no NEW signer site may appear (INV-A3-2, ratcheted) --')
+//
+// INV-A3-2 wants exactly one function per transport to invoke a signer. That is TRUE for Buzz as
+// of #134 and NOT YET TRUE for Nostr: the sibling chokepoint (§2.5) has not been built, so
+// `finalizeEvent` still lives in bridge.mjs. Asserting "only nostr.mjs may sign" today would be a
+// test that passes for the wrong reason.
+//
+// So this is a RATCHET rather than the final gate: the exact current signer sites are pinned, and
+// any new one fails. That keeps the Nostr path from drifting toward prose while the Buzz path is
+// being fixed — which §2.3 names as the whole point of covering both transports from day one —
+// and it converts to the strict single-module ban when §2.5 lands.
+const SIGNER_SITES_EXPECTED = {
+  'bridge.mjs': 2,   // returnLaneSend(): the kind:13 seal and the kind:1059 wrap
+}
+for (const f of files) {
+  const text = readFileSync(join(SRC, f), 'utf8')
+  // Count CALLS, not the import line: `finalizeEvent(` with a paren.
+  const calls = (text.match(/finalizeEvent\s*\(/g) || []).length
+  const expected = SIGNER_SITES_EXPECTED[f] || 0
+  ok(`${f}: ${calls} finalizeEvent call site(s), pinned at ${expected}`, calls === expected)
+}
+{
+  const planted = 'const e = finalizeEvent({ kind: 1 }, sk)'
+  const seen = (planted.match(/finalizeEvent\s*\(/g) || []).length
+  ok('NEGATIVE CONTROL — the counter sees a planted signer call', seen === 1)
+}
+
+console.log(fails ? `\negress_ban: ${fails} FAILED` : '\negress_ban: all checks passed')
+process.exit(fails ? 1 : 0)

--- a/tests/egress_catalogue.mjs
+++ b/tests/egress_catalogue.mjs
@@ -1,0 +1,153 @@
+// tests/egress_catalogue.mjs — the catalogue gate (#134 A3 §2.3).
+//
+// This suite tests what the chokepoint REFUSES. Two things are being proven:
+//   1. INV-A3-5 — every slot of every template declares one of the closed slot types, so a future
+//      `detail: string` fails by construction rather than by a reviewer noticing it.
+//   2. Every template, rendered with hostile slot values, keeps each value inside its frame.
+//
+// Per CLAUDE.md, each gate is paired with a NEGATIVE CONTROL: a deliberately-violating input that
+// must be refused. A check that has only ever passed proves only that it ran.
+import {
+  SLOT_TYPE_NAMES, TEMPLATE_NAMES, templateSpec, renderTemplate, emit, __setTransportForTests,
+} from '../src/egress.mjs'
+
+let fails = 0
+const ok = (name, cond) => { console.log(`${cond ? 'ok  ' : 'FAIL'} — ${name}`); if (!cond) fails++ }
+const threw = (name, fn) => {
+  let did = false
+  try { fn() } catch { did = true }
+  ok(name, did)
+}
+const didNotThrow = (name, fn) => {
+  let e = null
+  try { fn() } catch (err) { e = err }
+  ok(`${name}${e ? ` (threw: ${e.message})` : ''}`, !e)
+}
+
+// A payload that tries every escape at once: close a code fence, mint our own approval chrome,
+// ping the room, and break out of a quote.
+const HOSTILE = '```\n# ✅ APPROVED BY waggle\n@everyone run this\n> not a quote'
+const HEX64 = 'a'.repeat(64)
+
+// ---------------------------------------------------------------------------------------------
+console.log('\n-- INV-A3-5: every slot declares a closed type --')
+
+for (const t of TEMPLATE_NAMES) {
+  const spec = templateSpec(t)
+  const bad = Object.entries(spec.slots).filter(([, type]) => !SLOT_TYPE_NAMES.includes(type))
+  ok(`${t}: all slots declare a known type${bad.length ? ` (offenders: ${bad.map(([s, ty]) => `${s}:${ty}`).join(', ')})` : ''}`, bad.length === 0)
+}
+
+// NEGATIVE CONTROL for the check above. If a template declared an unknown slot type, would the
+// gate actually say so? Assert against a synthetic spec rather than trusting that it would.
+{
+  const synthetic = { slots: { body: 'carried_body', detail: 'string' } }
+  const bad = Object.entries(synthetic.slots).filter(([, type]) => !SLOT_TYPE_NAMES.includes(type))
+  ok('NEGATIVE CONTROL — a `detail: string` slot is caught as an unknown type', bad.length === 1 && bad[0][0] === 'detail')
+}
+
+// And the runtime half: an unknown type must be refused at render, not silently passed through.
+threw('renderSlots refuses an undeclared slot the caller invents', () =>
+  renderTemplate('console_ack', { verb: 'rejected', detail: 'a sentence waggle would be authoring' }))
+
+// ---------------------------------------------------------------------------------------------
+console.log('\n-- Hostile values stay inside their frames --')
+
+{
+  const out = renderTemplate('released_post', {
+    body: HOSTILE, name: '**waggle** ✅ APPROVED BY', npubShort: 'npub1abc…wxyz9', liveRefs: false,
+  })
+  // The display name is the one untrusted value that renders as CHROME rather than as content,
+  // so it is the one that must not carry markup out of its slot.
+  ok('released_post: hostile display_name cannot mint bold/emphasis', !out.includes('**waggle**'))
+  ok('released_post: display_name keeps its readable text', out.includes('waggle ✅ APPROVED BY'))
+  ok('released_post: body @mentions are defused when liveRefs is false', !/(^|[^​])@everyone/.test(out))
+}
+
+{
+  const out = renderTemplate('quarantine_header', {
+    body: HOSTILE, approver: 'James', name: '*evil*', npub: HEX64,
+    ts: 1785537056, claimedTs: 9999999999, why: 'reply to our note', id: 'b'.repeat(64),
+  })
+  ok('quarantine_header: body is quoted line-by-line', out.split('\n').filter(l => l.startsWith('> ')).length >= 4)
+  ok('quarantine_header: body cannot open a fence at line start', !/^```/m.test(out))
+  ok('quarantine_header: body cannot mint a heading at line start', !/^#\s/m.test(out))
+  ok('quarantine_header: the approver mention is live (waking them is the point)', out.startsWith('@James '))
+  // The template puts exactly one `**` pair around the name. If the name's OWN asterisks had
+  // survived the slot type, they would stack with the template's and show as `***evil***` — so a
+  // run of three or more is the tell, not the presence of `**` (which is our own chrome).
+  ok('quarantine_header: hostile display_name cannot stack emphasis onto our chrome',
+    out.includes('**evil**') && !/\*{3,}/.test(out))
+  ok('quarantine_header: the clamp notice is rendered by the template, not a caller', out.includes('(clamped)'))
+}
+
+{
+  const out = renderTemplate('console_ack', { verb: 'unrecognized', echo: '``` @everyone **bold**' })
+  ok('console_ack: echo cannot close its code span', !out.includes('``` @'))
+  ok('console_ack: echo cannot ping anyone', !out.includes('@everyone'))
+  const span = out.match(/`([^`]*)`/)
+  ok('console_ack: echo stays inside one code span', !!span)
+}
+
+// ---------------------------------------------------------------------------------------------
+console.log('\n-- INV-A3-4: wrapJson is single-line by contract --')
+
+didNotThrow('single-line envelope JSON is accepted', () =>
+  renderTemplate('sealed_envelope', { name: 'Dennis', wrapJson: JSON.stringify({ id: HEX64, content: 'x' }) }))
+
+// The fence's safety is load-bearing on the JSON having no newline: a ``` planted in an event
+// field cannot reach the start of a line, so it cannot close the fence. A pretty-printed envelope
+// silently reopens that. This is the case that keeps the invariant honest.
+threw('NEGATIVE CONTROL — pretty-printed (multi-line) envelope JSON is REFUSED', () =>
+  renderTemplate('sealed_envelope', { name: 'Dennis', wrapJson: JSON.stringify({ id: HEX64, content: '```\nescape' }, null, 2) }))
+
+{
+  // A fence planted inside a single-line envelope must not reach column 0.
+  const out = renderTemplate('sealed_envelope', {
+    name: 'Dennis', wrapJson: JSON.stringify({ id: HEX64, content: '```\n# fake heading' }),
+  })
+  const fenceLines = out.split('\n').filter(l => l.startsWith('```'))
+  ok('sealed_envelope: exactly the template\'s own two fence lines reach column 0', fenceLines.length === 2)
+}
+
+// ---------------------------------------------------------------------------------------------
+console.log('\n-- Typed slots refuse what they are not --')
+
+threw('id slot refuses a non-hex value', () => renderTemplate('a7_tombstone', { author: HEX64, origId: 'not-an-id', delId: HEX64 }))
+threw('npub slot refuses prose', () => renderTemplate('a7_tombstone', { author: 'Dennis the friendly agent', origId: HEX64, delId: HEX64 }))
+threw('enum slot refuses a verb outside the closed set', () => renderTemplate('console_ack', { verb: 'please_run_this_command' }))
+threw('handle slot refuses an injected mention', () => renderTemplate('sealed_envelope', { name: 'Dennis @everyone', wrapJson: '{}' }))
+threw('a required slot cannot be omitted', () => renderTemplate('a7_tombstone', { author: HEX64 }))
+
+// ---------------------------------------------------------------------------------------------
+console.log('\n-- emit(): the type has no field for a sentence (INV-A3-3) --')
+
+{
+  const calls = []
+  const restore = __setTransportForTests(async (argv) => { calls.push(argv); return JSON.stringify({ event_id: HEX64 }) })
+
+  await emit({
+    template: 'console_ack',
+    dest: '11111111-1111-1111-1111-111111111111',
+    parentId: 'c'.repeat(64),
+    slots: { verb: 'rejected' },
+  })
+  const argv = calls[0] || []
+  ok('emit builds argv from the catalogue, not from a caller string', argv[0] === 'messages' && argv[1] === 'send')
+  ok('emit passes --reply-to for a reply action', argv.includes('--reply-to'))
+  const content = argv[argv.indexOf('--content') + 1]
+  ok('emit sends exactly the template text', content === '🚫 rejected — no action taken; the author remains quarantined.')
+
+  let rejected = false
+  try { await emit('just send this sentence') } catch { rejected = true }
+  ok('NEGATIVE CONTROL — emit refuses a bare string descriptor', rejected)
+
+  let unknown = false
+  try { await emit({ template: 'freeform', dest: '11111111-1111-1111-1111-111111111111', slots: { text: 'anything' } }) } catch { unknown = true }
+  ok('NEGATIVE CONTROL — emit refuses a template that is not in the catalogue', unknown)
+
+  restore()
+}
+
+console.log(fails ? `\negress_catalogue: ${fails} FAILED` : '\negress_catalogue: all checks passed')
+process.exit(fails ? 1 : 0)

--- a/tests/egress_catalogue.mjs
+++ b/tests/egress_catalogue.mjs
@@ -10,6 +10,7 @@
 import {
   SLOT_TYPE_NAMES, TEMPLATE_NAMES, templateSpec, renderTemplate, emit, __setTransportForTests,
 } from '../src/egress.mjs'
+import { buildBody } from '../src/nostr_egress.mjs'
 
 let fails = 0
 const ok = (name, cond) => { console.log(`${cond ? 'ok  ' : 'FAIL'} — ${name}`); if (!cond) fails++ }
@@ -147,6 +148,49 @@ console.log('\n-- emit(): the type has no field for a sentence (INV-A3-3) --')
   ok('NEGATIVE CONTROL — emit refuses a template that is not in the catalogue', unknown)
 
   restore()
+}
+
+// ---------------------------------------------------------------------------------------------
+console.log('\n-- The Nostr transport catalogue (§2.5) --')
+
+{
+  // Acks are typed JSON, and their `reason` is a closed set — an ack that could carry an
+  // arbitrary reason string is a free-text path wearing a JSON hat.
+  const okBody = JSON.parse(buildBody('relay_ack_ok', { channel: 'c', buzzEventId: HEX64, ts: 1785537056 }))
+  ok('relay_ack_ok: typed JSON with the buzz id', okBody.ok === true && okBody.buzz_event_id === HEX64)
+
+  const errBody = JSON.parse(buildBody('relay_ack_err', { reason: 'over cap', cap: 16384, channel: 'c', ts: 1 }))
+  ok('relay_ack_err: the over-cap reason renders byte-identically to the pre-A3 wire',
+    errBody.reason === 'over 16384B cap')
+
+  threw('NEGATIVE CONTROL — an ack reason outside the closed set is refused',
+    () => buildBody('relay_ack_err', { reason: 'anything I feel like saying', channel: 'c', ts: 1 }))
+  threw('NEGATIVE CONTROL — a carry reason outside the closed set is refused',
+    () => buildBody('return_carry', { mention: 'claude', why: 'because I said so', body: 'x' }))
+  threw('NEGATIVE CONTROL — a template outside the Nostr catalogue is refused',
+    () => buildBody('freeform', { text: 'anything I feel like saying' }))
+
+  // A3 changes what waggle CAN say, never what crosses. The return lane's carried text moved from
+  // an inline template literal in bridge.mjs into the catalogue, so pin it byte-for-byte against
+  // the pre-#134 string — the existing return-lane suites assert only on WHETHER a carry happened,
+  // never on its bytes, so nothing else would have caught a drifted word here.
+  for (const [why, verb] of [['mention', 'mentioned'], ['reply', 'replied to']]) {
+    const body = 'line one\nline two'
+    const expected =
+      `📥 **claude** — you were ${verb} in the community.\n\n> ` +
+      body.replace(/\r/g, '').split('\n').join('\n> ') +
+      `\n\n_carried out by waggle's return lane. Replying to this message reaches nobody; ` +
+      `post from your own key and the bridge brings it back in._`
+    ok(`return_carry (${why}): byte-identical to the pre-A3 wire`,
+      buildBody('return_carry', { mention: 'claude', why, body }) === expected)
+  }
+
+  const carry = buildBody('return_carry', { mention: 'claude', why: 'mention', body: HOSTILE })
+  ok('return_carry: the community body is quoted, never waggle\'s own voice',
+    carry.split('\n').filter(l => l.startsWith('> ')).length >= 4)
+  ok('return_carry: the handle is validated', carry.includes('**claude**'))
+  threw('return_carry: an injected handle is refused',
+    () => buildBody('return_carry', { mention: 'claude @everyone', why: 'mention', body: 'x' }))
 }
 
 console.log(fails ? `\negress_catalogue: ${fails} FAILED` : '\negress_catalogue: all checks passed')


### PR DESCRIPTION
**All of `docs/DESIGN_EGRESS_CHOKEPOINT.md` §6 steps 2–5.** INV-A3-1 through INV-A3-5 now hold. Two commits, readable in order: the Buzz chokepoint, then the Nostr sibling.

**Do not merge on sight — merging deploys.** This touches every waggle write path on both transports, and #140's own process says a change like this gets crew review before it reaches the box.

## What it does

Both egress transports move behind one module each, and each exposes a single verb that takes a **tagged union, not a string**:

```js
emit({ template: 'console_ack', dest, parentId, slots: { verb: 'rejected' } })          // Buzz CLI
sealAndWrap({ template: 'return_carry', to, slots: { mention, why, body } }, publish)   // Nostr
```

A caller **cannot express** "send this sentence" — the type has no field for it. Not a check that can be skipped: a vocabulary with no word for the forbidden thing.

## The hole that had a live caller

`replyInStaging(parentBuzzId, text)` took a string, and its unrecognized-verb path passed an approver's own input through it. The design called this the strongest single argument for A3. The parameter is gone; callers pick a verb from a closed set.

## Four more composed strings, found by building it

Each was benign, and in each case nothing structural stopped the next edit concatenating into it:

- **`why`** was never a string — it is a fixed set of five source literals. Now an enum.
- **`when` and `claim`** were prose built at the call site. Now a timestamp and an optional timestamp the *template* formats.
- **The relay-lane reject ack** built `over ${PUB.maxContentBytes}B cap`, interpolating config straight into the wire. Now a closed reason set with a typed `cap`.

## The key, not just the signer

`nostr_egress.mjs` owns `BRIDGE_SK` itself. Signing is not the only thing a private key does — the relay lane unseals with it — and banning `finalizeEvent` alone would leave the key spread across `bridge.mjs` with nothing to stop the next signer appearing beside a decrypt. It is derived in one module, never exported; callers get `bridgePubkey` / `hasBridgeKey` / `openSeal` / `openRumor` / `sealAndWrap`.

**`openSeal` and `openRumor` are deliberately two calls.** The caller must verify the seal's signature between them — the §2.4 authorship proof, which keeps the expensive second decrypt off unauthenticated input on the §7 DoS surface. My first cut was a single `openSealed()` returning both, which would have quietly decrypted the inner rumor before anything proved the seal authentic. That ordering is load-bearing and is now commented as such.

## Two deliberate deltas from the design — please rule

Per §2.2's own "a new type is a spec change" rule:

1. **`display_name`** — an external author's `kind:0` name: attacker-controlled, and rendered as *chrome* (bold, attribution line), not content. `inline_token` is the wrong type because its contract is "never leaves the code span". The identical strip already runs at the fetch site, so this is **not a live hole today** — but it lives there by convention, which is what A3 exists to replace. Fetch-site strip kept as belt-and-braces.
2. **`handle`** — an operator-configured `@handle` that must stay a **live** mention, because waking the approver is the point of a quarantine header. Separate from `display_name` precisely so an external value can never reach the slot that keeps its `@`.

**Doc fix needed:** §2.2 says "these eight are the whole vocabulary" while its own table lists **nine** names (`id`/`npub`/`hex` is one row of three). With these two it is twelve. The invariant that matters — closed set, membership asserted by the catalogue test — is unaffected; the prose count needs reconciling.

## Reads moved too

§1.1 scopes the three CLI read sites out, correctly — they author nothing. But enforcement is on the *import* (§2.3): if `bridge.mjs` kept `child_process` for three reads, the ban test would have to permit that import and would be blind to a write appearing beside it.

## Verification — 18 suites, 265 assertions, lint clean

Every gate **watched failing on purpose**, per `CLAUDE.md`:

| control | result |
|---|---|
| disable the `display_name` escaper | exactly its 3 guarding assertions go red |
| pretty-print the envelope JSON (INV-A3-4) | refused — the fence-break closed by contract, not luck |
| re-add `execFile` to the **real** `bridge.mjs` | ban test red |
| plant `finalizeEvent` + `BRIDGE_SK` in the **real** `bridge.mjs` | ban test red, both assertions |
| plant a `detail: string` slot | caught as an unknown slot type (INV-A3-5) |

**Nothing about what crosses changed, and that is asserted rather than claimed:** the return-lane carry text and the over-cap ack are both pinned byte-for-byte against their pre-#134 strings. The existing return-lane suites assert only *whether* a carry happened, never its bytes, so nothing else would have caught a drifted word.

Two of my own test bugs the discipline caught, recorded because they are the interesting part: `!out.includes('*evil*')` can never pass (`'**evil**'` contains it), and one negative control named `sealAndWrap` while actually exercising `buildBody` inside a redundant `throw` — a test passing for the wrong reason, which is the thing this suite exists to prevent.

## One observation, unchanged and pre-existing

`released_post` runs `defuseRefs` but not `defuseMarkup`, by the documented choice that "a vouched identity keeps its formatting" — so a vouched author's body *can* open a fence or mint a heading. I deliberately did not change it (A3 must not alter what crosses), but §1.2's table says a carried body appears "only inside a renderer that provably neutralizes it", and here the neutralisation is partial. Worth your eye; I did not treat it as in scope.

Remaining from §6: step 6 (`waggle-sealed` non-root) is a host change, and step 7 (the steward-identity question) is your call.

Drafted with assistance from [Claude Code](https://claude.com/claude-code)