### PR TITLE
deploy-runner: don't restart production for a commit that ships no code (#162)

### DIFF
--- a/deploy/deploy-runner.sh
+++ b/deploy/deploy-runner.sh
@@ -127,6 +127,35 @@ if [ -n "$DRY_RUN" ]; then
   exit 0
 fi
 
+# --- no-op gate: did anything we actually SHIP change? (#162) ----------------------------
+# The SHA comparison above answers "is there a new commit", not "is there new CODE". Docs,
+# CI config and deploy/ are not in the ship list, so a docs-only merge would otherwise rsync
+# byte-identical content, run npm ci, and RESTART THE LANE — dropping every relay
+# subscription and re-running backfill to change nothing. Most merges on this repo are docs.
+#
+# Skipping the restart is only safe if the tree really is already correct for the new commit,
+# so this does not merely assume it: the SHA is recorded and verify-deployed.sh is still run.
+# A drift alarms exactly as it would after a full deploy.
+#
+# Falls through to a full deploy whenever the question cannot be answered — no DEPLOYED_SHA
+# (first run), or a recorded SHA the hub does not have (force-push, rebase, restored tree).
+# Being unable to check is not a reason to skip work.
+if [ "$DEPLOYED_SHA" != "none" ] && git -C "$HUB" cat-file -e "${DEPLOYED_SHA}^{commit}" 2>/dev/null; then
+  # shellcheck disable=SC2086  # SHIP is an intentional word list
+  CHANGED=$(git -C "$HUB" diff --name-only "$DEPLOYED_SHA" "$TARGET_SHA" -- $SHIP 2>/dev/null || echo '?')
+  if [ -z "$CHANGED" ]; then
+    log "no shipped files changed between $(git -C "$HUB" rev-parse --short "$DEPLOYED_SHA") and $SHORT — recording without restarting"
+    printf '%s\n' "$TARGET_SHA" > "$TREE/DEPLOYED_SHA.tmp" && mv "$TREE/DEPLOYED_SHA.tmp" "$TREE/DEPLOYED_SHA"
+    if sh "$HUB/deploy/verify-deployed.sh" "$LANE" "$TREE" "$TARGET_SHA"; then
+      log "no-op deploy OK — $TREE already matches $SHORT, verified, lane untouched"
+      exit 0
+    else
+      alarm "no-op deploy: tree does NOT match $SHORT despite no shipped file changing — investigate now"
+      exit 1
+    fi
+  fi
+fi
+
 # --- deploy: check out the exact sha in the hub, ship code-only into the tree ------------
 git -C "$HUB" checkout --quiet --detach "$TARGET_SHA" \
   || { alarm "could not check out $SHORT in hub"; exit 2; }

--- a/tests/deploy_runner.mjs
+++ b/tests/deploy_runner.mjs
@@ -159,6 +159,72 @@ try {
   } catch (e) { dc = e.status ?? 1; dOut = (e.stdout || '') + (e.stderr || '') }
   check(dc === 0, 'WB_TREE unset + DRY_RUN -> exit 0 (no set -e trip on the override guard)')
   check(/DRY_RUN/.test(dOut) && /waggle-read/.test(dOut), 'unset WB_TREE -> tree defaults to /opt/waggle-read')
+
+  // (8) the no-op gate (#162): a commit that changes NO shipped file must not restart the lane.
+  //
+  // The runner deploys `main` HEAD, and most merges here are docs. Without this gate each one
+  // rsyncs byte-identical content, runs npm ci and bounces the bridge — dropping every relay
+  // subscription to change nothing. The cases below run on the SAME tree in sequence, because
+  // the gate is about the transition from one deployed SHA to the next.
+  const tick = (tree, ref, marker, extraEnv = {}) => {
+    let c = 0, o = ''
+    try {
+      o = execFileSync('sh', ['-c', `sh "${SCRIPT}" read 2>&1`], {
+        cwd: REPO, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'],
+        env: { ...process.env, WB_HUB: hub, WB_TREE: tree, WB_REF: ref, WB_NO_FETCH: '1',
+               STUB_CI_STATE: 'success', WB_CI_STATE_CMD: 'echo "$STUB_CI_STATE" #',
+               WB_NPM_CMD: ':', WB_RESTART_CMD: `touch "${marker}" #`, ...extraEnv },
+      })
+    } catch (e) { c = e.status ?? 1; o = (e.stdout || '') + (e.stderr || '') }
+    return { code: c, out: o }
+  }
+
+  // Two commits on top of TARGET in the hub: one touching only an unshipped path, one touching
+  // a shipped one. Made on a detached HEAD so the hub's own checkout state is irrelevant.
+  const inHub = (cmd) => execSync(`git -C "${hub}" ${cmd}`, { encoding: 'utf8' }).trim()
+  inHub(`-c advice.detachedHead=false checkout --quiet --detach ${TARGET}`)
+  writeFileSync(join(hub, 'README.md'), readFileSync(join(hub, 'README.md'), 'utf8') + '\n<!-- docs-only -->\n')
+  inHub('add README.md')
+  inHub('-c user.email=t@t -c user.name=t commit --quiet -m "docs only"')
+  const DOCS_SHA = inHub('rev-parse HEAD')
+  writeFileSync(join(hub, 'src', 'log.mjs'), readFileSync(join(hub, 'src', 'log.mjs'), 'utf8') + '\n// shipped change\n')
+  inHub('add src/log.mjs')
+  inHub('-c user.email=t@t -c user.name=t commit --quiet -m "code change"')
+  const CODE_SHA = inHub('rev-parse HEAD')
+
+  const nt = join(work, 'tree-noop')
+  mkdirSync(nt, { recursive: true })
+  const nm = join(nt, '.restarted')
+
+  const base = tick(nt, TARGET, nm)
+  check(base.code === 0 && existsSync(nm), 'no-op gate: baseline deploy restarts, as before')
+
+  rmSync(nm, { force: true })
+  const docsTick = tick(nt, DOCS_SHA, nm)
+  check(docsTick.code === 0, 'docs-only commit -> exit 0')
+  check(!existsSync(nm), 'docs-only commit -> lane NOT restarted')
+  check(/no shipped files changed/.test(docsTick.out), 'docs-only -> says why it skipped, never silently')
+  check(readFileSync(join(nt, 'DEPLOYED_SHA'), 'utf8').trim() === DOCS_SHA,
+    'docs-only -> SHA still recorded, so the next tick is not re-evaluated')
+  check(/verified/.test(docsTick.out), 'docs-only -> tree still VERIFIED, not merely assumed')
+
+  // NEGATIVE CONTROL. The checks above pass just as happily if the gate skipped everything
+  // unconditionally — a runner that never restarts and one that restarts only when needed are
+  // indistinguishable until a real code change is put through it.
+  rmSync(nm, { force: true })
+  const codeTick = tick(nt, CODE_SHA, nm)
+  check(codeTick.code === 0, 'NEGATIVE CONTROL — shipped-file change -> exit 0')
+  check(existsSync(nm), 'NEGATIVE CONTROL — shipped-file change DOES restart the lane')
+  check(!/no shipped files changed/.test(codeTick.out), 'NEGATIVE CONTROL — did not take the no-op path')
+  check(/\/\/ shipped change/.test(readFileSync(join(nt, 'src', 'log.mjs'), 'utf8')),
+    'NEGATIVE CONTROL — the new code actually reached the tree')
+
+  // Being unable to answer the question is not a reason to skip work: a recorded SHA the hub
+  // does not have (force-push, rebase, a restored tree) must fall through to a full deploy.
+  rmSync(nm, { force: true })
+  writeFileSync(join(nt, 'DEPLOYED_SHA'), 'f'.repeat(40) + '\n')
+  const orphan = tick(nt, CODE_SHA, nm)
+  check(orphan.code === 0 && existsSync(nm), 'unknown recorded SHA -> falls through to a full deploy')
 } finally {
   rmSync(work, { recursive: true, force: true })
 }


### PR DESCRIPTION
Closes #162.

The runner's only "is there work to do" test was a SHA comparison — which answers *is there a new commit*, not *is there new code*. `docs/`, `CLAUDE.md`, `README.md`, `.github/` and `deploy/` are not in the ship list, so a docs-only merge rsynced byte-identical content, ran `npm ci`, and **restarted the lane**: every relay subscription dropped and backfill re-run, to change nothing.

That is not a rare case here. Most merges on this repo are docs, and since the runner was bootstrapped this morning every one of them bounces the bridge.

## The gate

Between the CI-green check and the deploy, ask git whether any *shipped* path differs:

```sh
git -C "$HUB" diff --name-only "$DEPLOYED_SHA" "$TARGET_SHA" -- $SHIP
```

Empty ⇒ record the new SHA and return without touching the lane.

**Skipping is only safe if the tree really is already correct for the new commit, so this doesn't assume it** — `verify-deployed.sh` still runs, and a mismatch alarms exactly as it would after a full deploy. The skip is logged with its reason; it is never a silent no-op.

**It fails toward doing the work.** No recorded SHA (first run), or a recorded SHA the hub doesn't have (force-push, rebase, a restored tree) ⇒ full deploy. Being unable to check is not a reason to skip.

## Testing

Four cases added to `tests/deploy_runner.mjs`, run in sequence on one tree because the gate is about the *transition* between deployed SHAs:

- docs-only commit → exit 0, **lane not restarted**, reason logged, SHA still recorded, tree still verified
- **negative control** — a shipped-file change still restarts, still takes the full path, and the new code is asserted to have actually reached the tree
- an unknown recorded SHA falls through to a full deploy

The negative control is the one that matters: *a runner that never restarts and one that restarts only when needed are indistinguishable* until a real code change goes through it. I also disabled the gate on purpose and watched the docs-only checks turn red, then restored it.

## One field note, already on the issue

The runner deploys **`main` HEAD, not each commit**, so merges landing inside one 3-minute window coalesce into a single deploy. Observed today: `a043a3a` → `f2ad79b` covered both #163 (code) and #164 (docs) in one tick. So the restart cost was always per-*tick*, not per-*merge*, and batching merges already mitigated some of it. This removes the rest.

That also means today's deploy was **not** a clean observation of the docs-only case — a restart was genuinely required for #163. The honest confirmation is the test above, plus watching a future docs-only merge leave `ActiveEnterTimestamp` unmoved.

Drafted with assistance from [Claude Code](https://claude.com/claude-code)