### PR TITLE
fix(egress): handle sanitises instead of rejecting, and config is checked at boot (#134)

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ against what git says, because a stale build is invisible while every status sur
 `npm test` runs 19 suites against the **real** exported functions with synthetic events — no
 sockets, no production state:
 
-boot · durable dedup store · relay fan-out · quarantine gating · deletion propagation · sealed-lane rate caps · grant
+boot · egress catalogue · egress ban · durable dedup store · relay fan-out · quarantine gating · deletion propagation · sealed-lane rate caps · grant
 admission · message rendering · deployed-build verification · return lane · return-lane scan ·
 return-lane no-miss · relay ingress · tripwire union · tripwire detection drill · deploy runner · console Host check
 

--- a/src/bridge.mjs
+++ b/src/bridge.mjs
@@ -37,7 +37,7 @@ import WebSocket from 'ws'
 // (A3 §2.5). Verification is a public-key operation and belongs wherever input is judged.
 import { verifyEvent } from 'nostr-tools/pure'
 import * as nip19 from 'nostr-tools/nip19'
-import { emit, query } from './egress.mjs'
+import { emit, query, checkConfigRenderable } from './egress.mjs'
 import { bridgePubkey, hasBridgeKey, openSeal, openRumor, sealAndWrap } from './nostr_egress.mjs'
 import { createHash } from 'node:crypto'
 import { readFileSync, writeFileSync, appendFileSync, existsSync, mkdirSync } from 'node:fs'
@@ -1563,6 +1563,24 @@ if (!process.env.WB_NO_BOOT) {
   loadPostedMap()
   loadRlSeen()
   loadRelaySeen()
+  // Every config-sourced typed slot is rendered ONCE here, before a single event is accepted. A
+  // value that cannot render would otherwise throw inside a delivery path — and both delivery
+  // paths markSeen before emit resolves, so that throw drops the message permanently for one ERR
+  // line. Failing at boot turns an invisible, per-message, unrecoverable loss into a loud refusal
+  // to start, which is the trade this repo always makes.
+  {
+    // TARGETS is a list of pubkey STRINGS (keys of RECIPIENTS), not records — reading `.name` off
+    // it yields undefined, and an undefined name fails `handle`, so a first draft of this check
+    // refused to boot on a perfectly good config. The boot suite caught it. Worth the comment:
+    // a fail-closed startup gate that is itself wrong turns a dropped message into a total
+    // outage, which is strictly worse than the bug it guards against.
+    const problems = checkConfigRenderable({
+      recipientNames: Object.values(RECIPIENTS).map(r => r.name),
+      approverMention: PUB && PUB.approverMention,
+    })
+    for (const p of problems) err(`FATAL: config value ${p.what} = ${JSON.stringify(p.value)} cannot be rendered — ${p.error}`)
+    if (problems.length) { err('FATAL: refusing to start — a value that cannot render would silently drop every message on that path.'); process.exit(1) }
+  }
   log(`waggle — mode=${FORWARD_MODE}, ${TARGETS.length} recipients, ${RELAYS.length} relays, ${PLANE_AUTHORS.length} channel plane(s), dm-since=${SINCE} (${SINCE_SECS}s), chan-since=${CHANNEL_SINCE} (${CHANNEL_SINCE_SECS}s)`)
   if (!SEALED_LANES) {
     log('sealed lanes: DISABLED (SEALED_LANES=off) — DM + Concord channel routing OFF; running PUBLIC read lane only')

--- a/src/egress.mjs
+++ b/src/egress.mjs
@@ -86,9 +86,32 @@ const SLOT_TYPES = {
   // approver is the point of the quarantine header, and waking the recipient is the point of a
   // sealed-envelope delivery. Distinct from display_name for exactly that reason: this one is
   // trusted-by-provenance and keeps its @, so it must never be fed an external value.
+  //
+  // SANITISES, IT DOES NOT REJECT — and the difference is a production incident. An earlier form
+  // required /^[\w][\w.-]{0,63}$/, which refuses any name containing a SPACE. Buzz display names
+  // routinely have one ("My Dude" is a crew member named in #134), and `approver_mention` is
+  // documented in config.example.json as "<Buzz @name…>". A rejection here is not a caught error:
+  // both call sites mark the event seen BEFORE emit resolves (bridge.mjs:558 sealed, :781 public),
+  // so a throw logs one line and the message is gone — dropped from durable dedup, unrecoverable
+  // across restart. On the public lane a spaced approver_mention would have failed EVERY
+  // quarantined arrival.
+  //
+  // The prior code at both sites was a bare `@${name}` that accepted anything, so rejecting is a
+  // regression, not a tightening. What A3 actually needs from this slot is that a config value
+  // cannot break out of the template — not that it match an identifier grammar. So: strip what
+  // could escape (backtick, newline, markup, a second @), cap the length, keep everything else
+  // including spaces. A value that sanitises to nothing IS broken config and is still refused —
+  // loudly at boot now, via checkConfigRenderable() below, rather than per-message hours later.
   handle: (v) => {
-    const s = String(v == null ? '' : v).trim()
-    if (!/^[\w][\w.-]{0,63}$/.test(s)) reject('handle', `not a bare handle: ${JSON.stringify(s.slice(0, 32))}`)
+    const s = String(v == null ? '' : v)
+      .replace(/[`\r\n]/g, '')        // cannot open a code span, cannot reach a new line
+      // `_` is deliberately NOT stripped: the prior regex allowed it via \w, so `agent_1` is a
+      // legitimate handle and removing it would corrupt a real name to fix nothing. (display_name
+      // does strip it — that slot is attacker-controlled, this one is operator config.)
+      .replace(/[@[\]()*~]/g, '')     // no second mention, no link, no emphasis
+      .trim()
+      .slice(0, 64)
+    if (!s) reject('handle', `empty after sanitising: ${JSON.stringify(String(v).slice(0, 32))}`)
     return s
   },
   // The ONLY slot that accepts arbitrary bytes. It never renders as waggle's own words: the
@@ -270,6 +293,30 @@ function renderSlots(templateName, slots = {}) {
     if (!(given in spec.slots)) reject('slot', `template ${templateName} has no slot ${JSON.stringify(given)}`)
   }
   return { spec, values: out }
+}
+
+// --- Boot-time config check (the general fix behind the `handle` incident) --------------------
+//
+// The `handle` regression was one instance of a class: a config value that fails its slot type
+// throws INSIDE a delivery path, and both delivery paths mark the event seen before emit resolves.
+// The message is then gone, and the operator learns about it from one ERR line, per message,
+// hours after the deploy.
+//
+// So the escapers are run against config ONCE at boot, where a failure is loud and costs nothing:
+// a bad value refuses to start rather than silently eating traffic. This repo's posture is
+// default-closed and LOUD, and "being unable to check is not the same as being fine" — a bridge
+// that cannot render its own configured names should say so before it starts accepting events.
+//
+// Returns a list of {what, value, error}; empty means every config-sourced typed slot renders.
+export function checkConfigRenderable({ recipientNames = [], approverMention = null } = {}) {
+  const problems = []
+  const probe = (what, value, type) => {
+    try { SLOT_TYPES[type](value) } catch (e) { problems.push({ what, value: String(value).slice(0, 40), error: e.message }) }
+  }
+  for (const [i, n] of recipientNames.entries()) probe(`recipients[${i}].name`, n, 'handle')
+  // Absent is fine — the slot is optional and the caller passes undefined.
+  if (approverMention) probe('public.approver_mention', approverMention, 'handle')
+  return problems
 }
 
 // Exported so the catalogue test can drive rendering with hostile values without shelling out.

--- a/src/nostr_egress.mjs
+++ b/src/nostr_egress.mjs
@@ -47,9 +47,23 @@ const hex64 = (v, what) => {
   return s
 }
 const num = (v, what) => { const n = Number(v); if (!Number.isFinite(n)) reject(`${what} is not a number`); return n }
+// Sanitises, does not reject — same reasoning as egress.mjs's `handle`, and the same incident.
+// `return_carry.mention` is fed `r.mention` from return-lane config (bridge.mjs:1270), so a
+// recipient configured with a spaced Buzz name would throw mid-carry. Milder than the Buzz side
+// (rlSeen is rolled back, so a restart re-carries) but it still aborts the carry loop, taking
+// every LATER recipient in that scan down with it.
+//
+// Kept as its own copy rather than imported from egress.mjs on purpose: this module owns the
+// Nostr transport and must not depend on the Buzz one. That duplication is why the bug existed in
+// two places at once — so if a third appears, the escapers should move to a shared module that
+// neither transport owns.
 const handle = (v) => {
-  const s = String(v == null ? '' : v).trim()
-  if (!/^[\w][\w.-]{0,63}$/.test(s)) reject(`not a bare handle: ${JSON.stringify(s.slice(0, 32))}`)
+  const s = String(v == null ? '' : v)
+    .replace(/[`\r\n]/g, '')
+    .replace(/[@[\]()*~]/g, '')   // `_` kept — legitimate in a handle, see egress.mjs
+    .trim()
+    .slice(0, 64)
+  if (!s) reject(`handle empty after sanitising: ${JSON.stringify(String(v).slice(0, 32))}`)
   return s
 }
 // The community's own words, carried out to a guest. Untrusted in the same sense as the Buzz

--- a/tests/egress_catalogue.mjs
+++ b/tests/egress_catalogue.mjs
@@ -9,6 +9,7 @@
 // must be refused. A check that has only ever passed proves only that it ran.
 import {
   SLOT_TYPE_NAMES, TEMPLATE_NAMES, templateSpec, renderTemplate, emit, __setTransportForTests,
+  checkConfigRenderable,
 } from '../src/egress.mjs'
 import { buildBody } from '../src/nostr_egress.mjs'
 
@@ -117,8 +118,46 @@ console.log('\n-- Typed slots refuse what they are not --')
 threw('id slot refuses a non-hex value', () => renderTemplate('a7_tombstone', { author: HEX64, origId: 'not-an-id', delId: HEX64 }))
 threw('npub slot refuses prose', () => renderTemplate('a7_tombstone', { author: 'Dennis the friendly agent', origId: HEX64, delId: HEX64 }))
 threw('enum slot refuses a verb outside the closed set', () => renderTemplate('console_ack', { verb: 'please_run_this_command' }))
-threw('handle slot refuses an injected mention', () => renderTemplate('sealed_envelope', { name: 'Dennis @everyone', wrapJson: '{}' }))
 threw('a required slot cannot be omitted', () => renderTemplate('a7_tombstone', { author: HEX64 }))
+
+// --- handle: sanitises, and must NOT reject a legitimate name -------------------------------
+//
+// `handle` asserts the PROPERTY (no injected live mention survives) rather than the MECHANISM (it
+// throws). Asserting the throw is what let the spaced-name regression through: "rejects anything
+// unusual" passed every test, and a legitimate "My Dude" was just as unusual as an injected
+// @everyone. Both halves are needed — refusing everything and refusing nothing pass a
+// one-directional test identically.
+{
+  // Every render below goes through `safe`: a slot that throws must surface as a clean FAIL line,
+  // not as an uncaught exception that aborts the suite mid-run. A crash is technically a red CI,
+  // but it hides which assertions never got to run.
+  const safe = (fn) => { try { return fn() } catch { return null } }
+
+  const injected = safe(() => renderTemplate('sealed_envelope', { name: 'Dennis @everyone', wrapJson: '{}' }))
+  ok('handle defuses an injected mention', injected !== null && !injected.includes('@everyone'))
+  ok('handle keeps the legitimate part of the name', injected !== null && injected.includes('Dennis'))
+
+  // The regression this suite could not see. Every fixture used 'A'/'B'/'Dennis' — no space
+  // anywhere — so a validator that refused spaces was green while it silently dropped every
+  // sealed DM to a recipient whose Buzz name has one.
+  for (const name of ['My Dude', 'Jean-Luc', 'agent_1', 'Ann O.']) {
+    let out = null
+    try { out = renderTemplate('sealed_envelope', { name, wrapJson: '{"a":1}' }) } catch (e) { out = null }
+    ok(`handle accepts a legitimate Buzz name ${JSON.stringify(name)}`, out !== null && out.startsWith(`@${name}`))
+  }
+  // A name that is nothing BUT markup is broken config and is still refused — loudly, and at boot.
+  threw('handle still refuses a name that sanitises to nothing', () => renderTemplate('sealed_envelope', { name: '***', wrapJson: '{}' }))
+}
+
+// --- the boot check that turns a per-message drop into a refusal to start ----------------------
+{
+  ok('config check passes a clean config',
+    checkConfigRenderable({ recipientNames: ['My Dude', 'Neil'], approverMention: 'Jim the approver' }).length === 0)
+  const bad = checkConfigRenderable({ recipientNames: ['ok', '***'], approverMention: null })
+  ok('config check names the offending entry', bad.length === 1 && bad[0].what === 'recipients[1].name')
+  ok('config check tolerates an absent approver_mention',
+    checkConfigRenderable({ recipientNames: ['ok'] }).length === 0)
+}
 
 // ---------------------------------------------------------------------------------------------
 console.log('\n-- emit(): the type has no field for a sentence (INV-A3-3) --')
@@ -189,8 +228,17 @@ console.log('\n-- The Nostr transport catalogue (§2.5) --')
   ok('return_carry: the community body is quoted, never waggle\'s own voice',
     carry.split('\n').filter(l => l.startsWith('> ')).length >= 4)
   ok('return_carry: the handle is validated', carry.includes('**claude**'))
-  threw('return_carry: an injected handle is refused',
-    () => buildBody('return_carry', { mention: 'claude @everyone', why: 'mention', body: 'x' }))
+  // Same property-not-mechanism rule as the Buzz side, and the same regression: `r.mention` is
+  // return-lane config (bridge.mjs:1270), so a spaced name threw mid-carry and took every LATER
+  // recipient in that scan down with it.
+  // Same `safe` discipline as the Buzz side: a throwing handle must read as a FAIL, not a crash.
+  const safeCarry = (mention) => {
+    try { return buildBody('return_carry', { mention, why: 'mention', body: 'x' }) } catch { return null }
+  }
+  const injectedCarry = safeCarry('claude @everyone')
+  ok('return_carry: an injected handle is defused', injectedCarry !== null && !injectedCarry.includes('@everyone'))
+  const spacedCarry = safeCarry('My Dude')
+  ok('return_carry: a legitimate spaced name still carries', spacedCarry !== null && spacedCarry.includes('**My Dude**'))
 }
 
 console.log(fails ? `\negress_catalogue: ${fails} FAILED` : '\negress_catalogue: all checks passed')


### PR DESCRIPTION
Fixes the blocking finding from my review of #168 ([comment](https://github.com/JAFairweather/waggle/pull/168#issuecomment-5153126947)).

**#168 merged at 20:00:43Z while I was building this, so the defect is on `main` now** — and per #164 that means it is deploying. I originally targeted this at the feature branch; retargeted to `main`.

## The defect

`handle` was `/^[\w][\w.-]{0,63}$/` — **no spaces** — and it is fed operator-config values that routinely have them. Three sites, two modules:

```
sealed_envelope.name       <- rec.name             bridge.mjs:534
quarantine_header.approver <- PUB.approverMention   bridge.mjs:735
return_carry.mention       <- r.mention             bridge.mjs:1270
```

**A rejection here is not a caught error.** Both Buzz sites `markSeen` *before* `emit` resolves (`:558`, `:781`), so the throw logs one line and the message is **gone** — dropped from durable dedup, unrecoverable across restart. On the public lane a spaced `approver_mention` fails **every quarantined arrival**. The return-lane copy is milder (`rlSeen` rolls back) but aborts the carry loop, taking every *later* recipient in that scan with it.

The prior code at all three sites was a bare `` `@${name}` `` accepting anything, so rejecting is a **regression, not a tightening**.

**Whether it is biting right now depends on the live `config.json`.** The check is:

```sh
jq -r '.recipients[].name' /opt/waggle-sealed/config.json
jq -r '.public.approver_mention' /opt/waggle-read/config.json
```

Any value with a space means that lane is dropping messages now.

## The fix

**Sanitise, don't reject.** What A3 needs from this slot is that a config value cannot break *out* of the template — not that it match an identifier grammar. Strip backtick, newline, a second `@`, link/emphasis markup; keep everything else including spaces; cap at 64.

`_` is deliberately **kept**: the old regex allowed it via `\w`, so stripping it would corrupt `agent_1` to fix nothing. (`display_name` still strips it — that slot is attacker-controlled; this one is operator config.)

**The validator existed in two copies, so the bug existed twice.** Both fixed, with the reason for the duplication now written down — `nostr_egress.mjs` must not depend on the Buzz transport — along with what to do if a third appears.

**`checkConfigRenderable()` at boot** is the general fix behind the instance: run the escapers over config once at startup and refuse to start on a value that cannot render, turning an invisible per-message loss into a loud refusal.

Worth flagging: **my first draft of that boot check read `.name` off `TARGETS`, which is a list of pubkey strings, so it refused to boot on a good config.** The boot suite caught it. It is noted in a comment, because a fail-closed startup gate that is itself wrong turns a dropped message into a total outage — strictly worse than the bug it guards against.

## Tests: property, not mechanism

The existing fixture asserted `handle` **throws** on `'Dennis @everyone'`. That framing is exactly what let this through — *"refuses anything unusual"* was green, and a legitimate `"My Dude"` was as unusual as an injected `@everyone`. They now assert the property that matters: **no injected live mention survives**, *and* legitimate names still render.

**Negative control** — restore the old rejecting `handle`:

```
FAIL — handle defuses an injected mention
FAIL — handle keeps the legitimate part of the name
FAIL — handle accepts a legitimate Buzz name "My Dude"
FAIL — handle accepts a legitimate Buzz name "Ann O."
FAIL — config check passes a clean config
```

`Jean-Luc` and `agent_1` keep passing under the old regex, so the control is **precise rather than blanket**. Assertions are wrapped so a throwing slot reads as a clean `FAIL` rather than crashing the suite mid-run — the first version of the control did crash, which hid which assertions never ran.

`npm run lint` clean · `npm test` **19/19, 275 checks**, rebased on current `main` (`3f1c717`).

## Also

`README.md`'s roster listed **17** suites while claiming **19**.

## Not addressed

- The `markSeen`-before-`emit` ordering is **pre-existing** and wider than this fix; boot validation removes the trigger, not the sharp edge. Worth its own issue.
- I reviewed `nostr_egress.mjs`'s handle path and catalogue, not its sealing, at depth.
- Nothing run against a live box.

---

Drafted with assistance from [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pj7AyMK4XPsib7tdR8P8JB)_