### PR TITLE
tripwire: a run that observed nothing must not report OK

### DIFF
--- a/tests/tripwire_detection.mjs
+++ b/tests/tripwire_detection.mjs
@@ -81,6 +81,45 @@ try {
 
   // A substituted run must never be mistakable for a live one in a log.
   check('a drill run announces that it is a drill', /DRILL/.test(pos.out))
+
+  // --- the size floor: a run that OBSERVED NOTHING has cleared nothing ---
+  //
+  // This is the case that was reporting green in production. With an empty observation set,
+  // "every on-relay post was emitted by our process" is vacuously true — every one of zero
+  // events was accounted for — so exit 0 reports our eyesight, not the world.
+  console.log('\nsize floor (0 observed must not be OK)')
+  const noEvents = resolve(dir, 'none.jsonl')
+  writeFileSync(noEvents, '')
+
+  const empty = run(full, noEvents)
+  check('0 observed + a non-empty journal -> INCONCLUSIVE, not OK', empty.code === 3, `exit ${empty.code}`)
+  check('it refuses to print OK', !/^OK/m.test(empty.out))
+  check('it says nothing was checked', /0 on-relay event\(s\) observed/.test(empty.out))
+  check('it names the read path as the suspect, not a quiet key',
+    /read path is not seeing/.test(empty.out))
+  check('it states plainly that this is not an all-clear', /NOT an all-clear/.test(empty.out))
+
+  // Both halves of the floor: an empty journal too is a quiet period, still not an all-clear.
+  const emptyJournal = resolve(dir, 'empty-journal.log')
+  writeFileSync(emptyJournal, '')
+  const quiet = run(emptyJournal, noEvents)
+  check('0 observed + an empty journal -> still INCONCLUSIVE', quiet.code === 3, `exit ${quiet.code}`)
+  check('it distinguishes a quiet period from a blind one', /may simply be a quiet period/.test(quiet.out))
+
+  // NEGATIVE CONTROL for the floor itself. A tool that returned INCONCLUSIVE unconditionally
+  // would pass every check above. The clean run at line ~79 is the counterpart — it observed
+  // two events and exited 0 — so assert the floor did not swallow it.
+  check('NEGATIVE CONTROL — a run that DID observe events still reports OK (exit 0)',
+    neg.code === 0 && /^OK/m.test(neg.out), `exit ${neg.code}`)
+  check('NEGATIVE CONTROL — the OK states how many events it actually checked',
+    /all 2 on-relay post\(s\)/.test(neg.out))
+
+  // --- alerting: an alarm with nowhere to go must say so ---
+  console.log('\nalarm delivery')
+  check('an unconfigured alarm path is reported on a CLEAN run, before an incident',
+    /no alarm delivery path configured/.test(neg.out))
+  check('a firing alarm with no delivery path says nobody was told',
+    /ALARM NOT DELIVERED/.test(pos.out))
 } finally {
   rmSync(dir, { recursive: true, force: true })
 }

--- a/tests/tripwire_union.mjs
+++ b/tests/tripwire_union.mjs
@@ -31,9 +31,14 @@ const check = (name, cond, detail = '') => {
 // spawnSync, not execFileSync: the per-journal accounting is written to STDERR, and execFileSync
 // hands back only stdout on success — so a passing run looked like it had produced no summary at
 // all. Both streams are evidence here.
-function run(journals) {
+// `events` substitutes the wire (--events-from), as the detection drill does. Without it this
+// suite hit the real relays with a 1-minute window, observed nothing, and asserted OK on an empty
+// observation set — the very shape the size floor now refuses. It was also, incidentally, a
+// network-dependent unit test.
+function run(journals, events) {
   const args = ['--since-min', '1']
   for (const j of journals) args.push('--journal', j)
+  if (events) args.push('--events-from', events)
   const r = spawnSync('node', [TOOL, ...args],
     { env: { ...process.env, POSTER, ALARM_NSEC: '', ALARM_TO: '' }, encoding: 'utf8' })
   return { code: r.status, out: (r.stdout || '') + (r.stderr || '') }
@@ -49,21 +54,27 @@ try {
   writeFileSync(readJ, JSON.stringify({ id: id('a'), kind: 9, lane: 'public' }) + '\n')
   writeFileSync(sealedJ, JSON.stringify({ id: id('b'), kind: 9, lane: 'sealed' }) + '\n')
 
+  // One event on the wire, present in the read lane's journal. An OK now means something was
+  // actually checked and accounted for, rather than that nothing was seen.
+  const eventsFile = resolve(dir, 'events.jsonl')
+  writeFileSync(eventsFile, JSON.stringify({ id: id('a'), kind: 9, created_at: Math.floor(Date.now() / 1000), tags: [], content: 'ours' }) + '\n')
+
   console.log('tripwire union (#87)')
 
-  const both = run([readJ, sealedJ])
+  const both = run([readJ, sealedJ], eventsFile)
   check('unions every lane it is given', /2 journaled across 2\/2 lane\(s\)/.test(both.out),
     both.out.split('\n').find(l => l.includes('journaled')) || 'no summary line')
   check('a complete union can report OK', both.code === 0, `exit ${both.code}`)
+  check('...and the OK is over a non-empty observation set', /all 1 on-relay post\(s\)/.test(both.out))
 
   // The property that matters: a missing lane journal must NOT become an all-clear.
-  const half = run([readJ, resolve(dir, 'absent', 'send-journal.log')])
+  const half = run([readJ, resolve(dir, 'absent', 'send-journal.log')], eventsFile)
   check('a half-synced union does not exit clean', half.code === 3, `exit ${half.code}`)
   check('it says INCONCLUSIVE, not OK', /INCONCLUSIVE/.test(half.out) && !/^OK/m.test(half.out))
   check('it names the missing journal', /absent/.test(half.out))
 
   // Comma-separated form is accepted, since that is how a systemd unit will pass it.
-  const csv = run([`${readJ},${sealedJ}`])
+  const csv = run([`${readJ},${sealedJ}`], eventsFile)
   check('accepts comma-separated journals', /2\/2 lane\(s\)/.test(csv.out))
 } finally {
   rmSync(dir, { recursive: true, force: true })

--- a/tools/tripwire.mjs
+++ b/tools/tripwire.mjs
@@ -116,8 +116,17 @@ function fetchPosterEvents() {
   }))).then(() => [...seen.values()])
 }
 
+// Is there anywhere for an alarm to GO? Detection that fires into the void is not detection, and
+// the absence of a delivery path is exactly the kind of thing discovered during an incident rather
+// than before one. Reported on every run, clean or not — a 30-minute timer saying so is cheap
+// compared to finding out when it matters.
+const alarmConfigured = () => !!(process.env.ALARM_NSEC && process.env.ALARM_TO)
+
 async function alarmDM(text) {
-  if (!process.env.ALARM_NSEC || !process.env.ALARM_TO) return
+  if (!alarmConfigured()) {
+    console.error('tripwire: ⚠ ALARM NOT DELIVERED — ALARM_NSEC/ALARM_TO are unset, so this alarm exists only in this log and data/tripwire-alarms.log. Nobody has been told.')
+    return
+  }
   try {
     const ask = process.env.ALARM_NSEC.startsWith('nsec1') ? nip19.decode(process.env.ALARM_NSEC).data : Uint8Array.from(Buffer.from(process.env.ALARM_NSEC, 'hex'))
     const to = process.env.ALARM_TO.startsWith('npub1') ? nip19.decode(process.env.ALARM_TO).data : process.env.ALARM_TO.toLowerCase()
@@ -127,9 +136,30 @@ async function alarmDM(text) {
     const seal = finalizeEvent({ kind: 13, created_at: now(), tags: [], content: nip44.encrypt(JSON.stringify(rumor), nip44.getConversationKey(ask, to)) }, ask)
     const wsk = generateSecretKey()
     const wrap = finalizeEvent({ kind: 1059, created_at: now(), tags: [['p', to]], content: nip44.encrypt(JSON.stringify(seal), nip44.getConversationKey(wsk, to)) }, wsk)
-    await Promise.all(loadRelays().map(url => new Promise(r => { let ws; try { ws = new WebSocket(url) } catch { return r() } const t = setTimeout(() => { try { ws.close() } catch { /* */ } r() }, 6000); ws.on('open', () => ws.send(JSON.stringify(['EVENT', wrap]))); ws.on('message', () => { clearTimeout(t); ws.close(); r() }); ws.on('error', () => { clearTimeout(t); r() }) })))
-    console.error('tripwire: alarm DM sent')
-  } catch (e) { console.error(`tripwire: alarm DM failed: ${e.message}`) }
+    // Count what was ACCEPTED, not what was attempted. The previous version resolved on the first
+    // frame of any kind — including an `["OK", id, false, "..."]` rejection — and on timeouts and
+    // socket errors too, then printed "alarm DM sent" unconditionally. That is the same
+    // relay-OK-is-not-proof trap the rest of this project is built around, in the one place where
+    // believing a false success is worst: the alarm.
+    const relays = loadRelays()
+    const results = await Promise.all(relays.map(url => new Promise(r => {
+      let ws
+      try { ws = new WebSocket(url) } catch { return r(false) }
+      const done = (v) => { clearTimeout(t); try { ws.close() } catch { /* */ } r(v) }
+      const t = setTimeout(() => done(false), 6000)
+      ws.on('open', () => ws.send(JSON.stringify(['EVENT', wrap])))
+      ws.on('message', (d) => {
+        let m
+        try { m = JSON.parse(d.toString()) } catch { return done(false) }
+        if (m[0] === 'OK' && m[1] === wrap.id) return done(m[2] === true)
+        // NOTICE or anything else: keep waiting for the OK until the timeout.
+      })
+      ws.on('error', () => done(false))
+    })))
+    const accepted = results.filter(Boolean).length
+    if (accepted > 0) console.error(`tripwire: alarm DM delivered ${accepted}/${relays.length} relay(s)`)
+    else console.error(`tripwire: ⚠ ALARM NOT DELIVERED — 0/${relays.length} relay(s) accepted the alarm DM. The alarm exists only in this log and data/tripwire-alarms.log.`)
+  } catch (e) { console.error(`tripwire: ⚠ ALARM NOT DELIVERED — alarm DM failed: ${e.message}`) }
 }
 
 // --- run ---
@@ -154,6 +184,11 @@ const iso = (s) => new Date(s * 1000).toISOString()
 
 console.error(`tripwire: poster ${posterHex.slice(0, 12)}… · window ${sinceMin}m · ${events.length} on-relay event(s) · ${journal.size} journaled across ${JOURNALS.length - missing.length}/${JOURNALS.length} lane(s) · ${anomalies.length} unaccounted`)
 
+// Said on EVERY run, not only when something fires. An operator who learns during an incident
+// that the alarm had nowhere to go has learned it too late, and a detector whose alarm is
+// undeliverable is a detector in name only.
+if (!alarmConfigured()) console.error('tripwire: ⚠ no alarm delivery path configured (ALARM_NSEC/ALARM_TO unset) — if this run had found something, nobody would have been told.')
+
 if (!anomalies.length) {
   // A half-synced union cannot produce an all-clear. With a lane's journal absent, "nothing
   // unaccounted" only means nothing was found in the part we could see, and reporting that as OK
@@ -162,7 +197,26 @@ if (!anomalies.length) {
     console.log(`INCONCLUSIVE — no anomalies found, but ${missing.length} of ${JOURNALS.length} lane journal(s) were missing:\n  ${missing.join('\n  ')}\nFix the sync before trusting this result. This is NOT an all-clear.`)
     process.exit(3)
   }
-  console.log('OK — every on-relay post by the poster key was emitted by our process.')
+  // SIZE FLOOR. A check that observed NOTHING has cleared nothing. "Every on-relay post was
+  // emitted by our process" is vacuously true over an empty set — every one of zero events was
+  // accounted for — so an all-clear here reports the strength of our eyesight, not the state of
+  // the world. It is the same shape as the scan of an empty file that once reported everything
+  // clean, and `CLAUDE.md` names it: put a size floor on fetched input.
+  //
+  // The journal count is the diagnostic that makes this actionable rather than merely cautious.
+  // Zero observed while the journal records sends in the same window does not mean the poster was
+  // quiet — it means the read path cannot see the surface the key is actually used on, and every
+  // OK it has ever printed was that blindness, not an assurance.
+  if (!events.length) {
+    console.log(
+      `INCONCLUSIVE — 0 on-relay event(s) observed in the last ${sinceMin}m, so nothing was checked.` +
+      (journal.size
+        ? `\nThe journal recorded ${journal.size} send(s) in the same period. Zero observed against a non-empty journal means the read path is not seeing the surface the poster key is used on — not that the key was idle.`
+        : `\nThe journal is also empty for this window, so this may simply be a quiet period — but a run that saw nothing still proves nothing about the read path.`) +
+      `\nThis is NOT an all-clear.`)
+    process.exit(3)
+  }
+  console.log(`OK — all ${events.length} on-relay post(s) by the poster key were emitted by our process.`)
   process.exit(0)
 }
 


### PR DESCRIPTION
Two hardening fixes to the detection gate, both the same family: **a check that cannot see must say so rather than return green.**

## 1. Size floor

With an empty observation set, *"every on-relay post by the poster key was emitted by our process"* is **vacuously true** — every one of zero events was accounted for. So `exit 0` was reporting the strength of our eyesight, not the state of the world.

`CLAUDE.md` already names this shape — *"put a size floor on fetched input"*, next to the scan of an empty file that once reported everything clean — and the tool already applies it elsewhere: a missing lane journal is `INCONCLUSIVE` for exactly this reason. Zero observed now exits 3 the same way.

The journal count is what makes it actionable rather than merely cautious:

- **zero observed, non-empty journal** → the read path is not seeing the surface the key is used on. Not a quiet key.
- **zero observed, empty journal** → possibly a genuine quiet period, and it says so. Still not an all-clear.

## 2. Alarm delivery

Three ways an alarm could go nowhere while looking fine:

- **Unset `ALARM_NSEC`/`ALARM_TO` returned silently**, so a firing alarm existed only in a log file. It now says nobody was told — and an unconfigured delivery path is reported on **every** run, including clean ones, because discovering it during an incident is discovering it too late.
- **`alarm DM sent` printed after the relay sends merely settled.** Each socket resolved on its first frame of any kind — an `["OK", id, false, …]` rejection included — and on timeouts and errors too. It now matches the `OK` frame to the wrap id, counts genuine acceptances, and reports `N/M`. That is the relay-OK-is-not-proof rule this project is built on, applied in the one place where believing a false success is worst.
- **`0/N` accepted now says NOT DELIVERED** instead of claiming a send.

## Testing

Nine cases added to the detection drill, with the negative control that matters: **a tool returning `INCONCLUSIVE` unconditionally would pass every size-floor check**, so the run that *did* observe events is asserted to still exit 0 and to state how many it checked. The floor was also removed on purpose and watched turning seven checks red.

**The floor immediately caught a vacuous pass in the suite itself.** `tripwire_union` asserted *"a complete union can report OK"* while driving the tool against the **real relays** with a one-minute window — so it observed nothing and got exit 0 for the same reason. It now substitutes the wire with `--events-from` and puts one journaled event on it, so the OK is over something actually examined. That also makes it network-free, which a unit test should have been anyway.

Worth recording: I pushed the first commit before reading the suite result and the branch was briefly red. The union failure is what caught it.

Drafted with assistance from [Claude Code](https://claude.com/claude-code)