### PR TITLE
docs: CLAUDE.md — a second pair of eyes before merge, and assert both directions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,6 +89,18 @@ not in the source you edited.
   merge your own work unless asked, and never merge anything you would not want running in
   production that minute. If something must land without shipping, that is what pinning `WB_REF`
   to a tag is for.
+- **A substantive PR is read by someone who did not write it, before it is merged.** Not a style
+  preference — the merge button ships to production (above), so the author-reads-own-work path has
+  no second pair of eyes anywhere in it. Earned 2026-08-01: #168 was careful work that passed
+  review-by-CI with 18 green suites, and shipped a defect that permanently dropped every sealed
+  message to one recipient. The review that found it was posted 25 minutes after the merge. **CI
+  green is not a review** — every fixture in that suite used a name with no space in it, and the
+  bug was a name with a space. *Substantive* means: touches a delivery path, a gate, a key, or the
+  deploy runner. Docs and tests are exempt.
+- **Land the fix before the next thing.** Six merges went out in under an hour that day, three of
+  them shipping code and restarting production, and the incident was found in the middle of it.
+  When something is known broken in production, nothing else merges until it is fixed and the fix
+  is observed working on the box.
 - **Issues-first.** Every item becomes a GitHub issue before code.
 - **Check open PRs before starting an issue.** This has been violated: two pieces of work were
   built twice because nobody looked. `gh pr list --state open` costs nothing.
@@ -113,6 +125,13 @@ that merely ran.** The suite was green through all of them.
 - **Run the negative control.** A check that has only ever passed proves nothing. Make it fail on
   purpose once and watch it say so. An alarm that always fires and one that never fires fail
   identically.
+- **Assert the property, not the mechanism — and assert both directions.** A test that only checks
+  a guard *rejects* something cannot tell "refuses the dangerous thing" from "refuses everything".
+  2026-08-01: a slot validator was asserted to throw on `Dennis @everyone`; it also threw on
+  `My Dude`, a real recipient, and silently dropped every message to them. Green suite, live
+  outage. Pair every refusal assertion with one that a legitimate value still gets through, and
+  make the fixtures resemble production — every name in that suite was `A`, `B` or `Dennis`, so
+  nothing with a space was ever rendered.
 - **A command that prints nothing has told you nothing.** A send once failed silently because a
   path no longer existed; the exit status looked ordinary.
 - **Syntax valid ≠ works.** `node --check` has passed on code whose identifiers did not exist.


### PR DESCRIPTION
Two rules earned on 2026-08-01, written down where the next session will read them. **Docs-only** — ships no code, so per #162/#169 it does not restart the lane. **Yours to merge, not mine** — a PR proposing a review rule is a poor place for me to skip review.

## 1. A substantive PR is read by someone who did not write it

The merge button ships to production. So an author merging their own work has **zero other eyes anywhere in the path** — not at review, not at deploy, not at any gate in between.

What earned it: #168 was careful, well-tested work with 18 green suites. It shipped a defect that permanently dropped every sealed message to one recipient. **The review that found it was posted 25 minutes after the merge.** The order was the whole problem — the analysis was right, it just arrived after the thing it was analysing had deployed.

And the reason CI could not stand in for that review: **every fixture in that suite used a name with no space in it, and the bug was a name with a space.** A suite cannot fail on an input nobody thought to write down.

Scoped to *substantive* — delivery path, gate, key, deploy runner. Docs and tests stay frictionless, or the rule gets routed around within a week.

## 2. Land the fix before the next thing

Six merges in under an hour, three shipping code and restarting production, with the incident discovered in the middle of that. Nothing was individually reckless; the pace was.

## 3. Assert the property, not the mechanism — in both directions

The transferable one, added to Verification discipline:

> A test that only checks a guard *rejects* something cannot tell "refuses the dangerous thing" from "refuses everything."

The validator was asserted to throw on `Dennis @everyone`. It also threw on `My Dude` — a real recipient — and the suite could not tell those apart, because it only ever asked whether the guard said no. Pair every refusal assertion with one that a legitimate value still gets through, and make fixtures resemble production.

This sits directly under the existing negative-control rule, which is its sibling: that one says make it fail on purpose, this one says make it *pass* on purpose too.

## Note on authorship

I wrote all three rules and I caused a fair share of what they describe — I merged four PRs in 40 minutes, including two nobody but me had read. So treat this as a proposal about how you run your project, not a finding. If the review rule is too heavy for a project with one human and an agent crew, the version worth keeping is probably rule 3 alone, since it is the one that would have caught the bug rather than merely slowed the merge.

`npm run lint` clean · `npm test` 19/19 · no code files touched.

---

Drafted with assistance from [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pj7AyMK4XPsib7tdR8P8JB)_