### PR TITLE
fix: record undelivered messages durably instead of losing them to a log line (#171)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,14 +145,14 @@ that merely ran.** The suite was green through all of them.
 
 ## Tests
 
-`npm test` — 19 suites, against the real exported functions with synthetic events. No sockets,
+`npm test` — 20 suites, against the real exported functions with synthetic events. No sockets,
 no production state, no writes outside a temp dir.
 
 boot · egress catalogue · egress ban · durable dedup store · relay fan-out · quarantine gating · deletion propagation · sealed-lane rate caps · grant
 admission · message rendering · deployed-build verification · return lane · return-lane scan ·
-return-lane no-miss · relay ingress · tripwire union · tripwire detection drill · deploy runner · console Host check
+return-lane no-miss · relay ingress · tripwire union · tripwire detection drill · deploy runner · console Host check · undelivered record
 
-CI runs them on push and PR. **If a run reports fewer than 19, the branch is on a stale base.**
+CI runs them on push and PR. **If a run reports fewer than 20, the branch is on a stale base.**
 The count of record is the `test` script in `package.json`; a prose count that disagrees with it
 is the prose being wrong.
 

--- a/README.md
+++ b/README.md
@@ -104,12 +104,12 @@ against what git says, because a stale build is invisible while every status sur
 
 ## Tests
 
-`npm test` runs 19 suites against the **real** exported functions with synthetic events — no
+`npm test` runs 20 suites against the **real** exported functions with synthetic events — no
 sockets, no production state:
 
 boot · egress catalogue · egress ban · durable dedup store · relay fan-out · quarantine gating · deletion propagation · sealed-lane rate caps · grant
 admission · message rendering · deployed-build verification · return lane · return-lane scan ·
-return-lane no-miss · relay ingress · tripwire union · tripwire detection drill · deploy runner · console Host check
+return-lane no-miss · relay ingress · tripwire union · tripwire detection drill · deploy runner · console Host check · undelivered record
 
 The rendering suite is the one to read if you are reviewing. It tests what the bridge **refuses**,
 not only what it does: a hostile note tries to ping the approver, mint an `APPROVED BY` heading,

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -120,7 +120,7 @@ in [deploy/README.md](../deploy/README.md).
 - **Publish the agent relay list:** `node tools/publish_relay_list.mjs` (so the identity
   is discoverable).
 - **Admit a participant**, if you want one: `sh tools/grant-setup.sh`.
-- **Run the safety gates before you ship:** `npm test` — 19 suites driving the real
+- **Run the safety gates before you ship:** `npm test` — 20 suites driving the real
   routing functions with synthetic events (no sockets, no production state), all green.
 
 `waggle-init.mjs --check` rolls the config half of this into one readiness verdict; the

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "start": "node src/bridge.mjs",
     "dryrun": "FORWARD_MODE=dryrun node src/bridge.mjs",
     "lint": "eslint src tools tests",
-    "test": "node tests/boot.mjs && node tests/egress_catalogue.mjs && node tests/egress_ban.mjs && node tests/relay_fanout.mjs && node tests/durable_store.mjs && node tests/a1_quarantine.mjs && node tests/a7_deletion.mjs && node tests/lane2_caps.mjs && node tests/nipda_admission.mjs && node tests/render_states.mjs && node tests/deploy_verify.mjs && node tests/return_lane.mjs && node tests/return_lane_scan.mjs && node tests/return_lane_nomiss.mjs && node tests/relay_ingress.mjs && node tests/tripwire_union.mjs && node tests/tripwire_detection.mjs && node tests/deploy_runner.mjs && node tests/console_host.mjs",
+    "test": "node tests/boot.mjs && node tests/egress_catalogue.mjs && node tests/egress_ban.mjs && node tests/relay_fanout.mjs && node tests/durable_store.mjs && node tests/a1_quarantine.mjs && node tests/a7_deletion.mjs && node tests/lane2_caps.mjs && node tests/nipda_admission.mjs && node tests/render_states.mjs && node tests/deploy_verify.mjs && node tests/return_lane.mjs && node tests/return_lane_scan.mjs && node tests/return_lane_nomiss.mjs && node tests/relay_ingress.mjs && node tests/tripwire_union.mjs && node tests/tripwire_detection.mjs && node tests/deploy_runner.mjs && node tests/console_host.mjs && node tests/undelivered.mjs",
     "console": "node tools/serve-console.mjs"
   },
   "dependencies": {

--- a/src/bridge.mjs
+++ b/src/bridge.mjs
@@ -141,6 +141,19 @@ let pubWatermark = loadPubWatermark()
 // kind:5 lookback is intentionally LONGER than the kind:1 watermark: deletes are rare,
 // idempotent under dedup, and a delete issued while the lane was down must not be missed.
 const POSTED_MAP_PATH = process.env.POSTED_MAP_PATH || resolve(ROOT, 'data', 'posted-map.log')
+// #171 — the durable record of what did NOT get delivered.
+//
+// Both Buzz lanes commit the event id to durable dedup BEFORE the async send, deliberately:
+// "we favor never double-post (the §8 firehose line) over never drop" (routePublic). That
+// tradeoff is a real position and this does not reverse it — reversing it is a policy call for
+// the maintainer, not a bug fix (see #171).
+//
+// What it DOES fix is that the losing side of that trade was invisible. A failed send produced
+// one ERR line in a journal that rotates, and the message was gone with no record that it had
+// ever existed. On 2026-08-01 that made a config-validation regression indistinguishable from
+// silence until someone went looking. An append-only list of undelivered messages costs nothing,
+// changes no delivery behaviour, and turns "gone" into "recoverable, and countable".
+const UNDELIVERED_PATH = process.env.UNDELIVERED_PATH || resolve(ROOT, 'data', 'undelivered.log')
 // Tripwire send-journal: every event id THIS process publishes as the poster identity,
 // appended synchronously. An out-of-process watcher (tools/tripwire.mjs) diffs the poster's
 // on-relay events against this journal — any post signed by our key that is NOT here means
@@ -327,6 +340,27 @@ const seenStore = durableSet({ path: SEEN_PATH, cap: SEEN_CAP, label: 'dedup', n
 const seen = seenStore.mem
 const loadSeen = () => seenStore.load()
 const markSeen = (id) => seenStore.commit(id)
+
+// #171 — record a message that was accepted for delivery and then failed to land. The id is
+// already durably seen by the time this runs, so nothing will retry it: this file IS the message,
+// as far as any later recovery is concerned. Keep it machine-readable and append-only, for the
+// same reason the send-journal is: something else has to be able to read it without parsing prose.
+//
+// Deliberately never throws. A failure to record a failure must not take down the lane, and a
+// disk-full box should still deliver what it can — but it must SAY so, or the silence this exists
+// to end just moves one level up.
+function recordUndelivered({ lane, dest, recipient, id, author, reason }) {
+  const line = JSON.stringify({
+    ts: Math.floor(Date.now() / 1000), lane, dest, recipient: recipient || null,
+    id, author: author || null, reason: String(reason || '').slice(0, 300),
+  })
+  try {
+    mkdirSync(dirname(UNDELIVERED_PATH), { recursive: true })
+    appendFileSync(UNDELIVERED_PATH, line + '\n')
+  } catch (e) {
+    err(`UNDELIVERED: could not record the loss of ${String(id).slice(0, 12)}… — ${e.message}`)
+  }
+}
 
 // Relay-lane dedup — a SEPARATE file. Committed on any DETERMINISTIC outcome (posted, a reject, or
 // a decrypt/verify failure that will never become valid) so a relay re-serving that wrap is cheap;
@@ -535,7 +569,13 @@ function forward(rec, ev, src) {
   }).then(({ stdout }) => {
     log(`FORWARD[buzz] ok -> ${rec.name} inbox: ${src && src.channel ? `${src.channel} ` : 'DM '}1059 ${ev.id.slice(0, 12)}…`)
     journalSend(parseBuzzEventId(stdout), { kind: 9, dest: rec.inbox, lane: 'sealed' })
-  }).catch(e => err(`FORWARD[buzz] ERR -> ${rec.name}: ${e.message}`))
+  }).catch(e => {
+    err(`FORWARD[buzz] ERR -> ${rec.name}: ${e.message}`)
+    // The event was marked seen before this send (route()), and the mark is per EVENT, not per
+    // recipient — so on a plane fan-out the others received it and this one silently did not.
+    // That asymmetry is what made the 2026-08-01 loss read as "that agent isn't responding".
+    recordUndelivered({ lane: 'sealed', dest: rec.inbox, recipient: rec.name, id: ev.id, author: ev.pubkey, reason: e.message })
+  })
 }
 
 function route(ev) {
@@ -758,7 +798,10 @@ async function forwardPublic(ev, why, dest, quarantine) {
     if (!buzzId) err(`A7 warn[no-id]: could not capture buzz event id for ${ev.id.slice(0, 12)}… — withdrawal will use follow-up tier`)
     recordPosted({ id: ev.id, author: ev.pubkey, buzz: buzzId, dest, q: !!quarantine, ts: nowSec, agent })
     journalSend(buzzId, { kind: 9, dest, lane: 'public' })
-  }).catch(e => err(`PUBLIC[buzz] ERR -> ${dest}: ${e.message}`))
+  }).catch(e => {
+    err(`PUBLIC[buzz] ERR -> ${dest}: ${e.message}`)
+    recordUndelivered({ lane: 'public', dest, recipient: null, id: ev.id, author: ev.pubkey, reason: e.message })
+  })
 }
 
 function routePublic(ev) {
@@ -1555,7 +1598,7 @@ function connectPublic(url) {
 // Exported so a harness can drive the REAL routing functions (not a copy) with synthetic
 // events in dryrun, without opening any relay socket. Set WB_NO_BOOT=1 to import without
 // booting the live subscriber. No effect on normal `node src/bridge.mjs` runs.
-export { durableSet, fanout, defuseRefs, defuseMarkup, quoted, renderQuarantined, renderReleased, fetchEventById, returnLaneSend, publishWrapToRelays, scanReturnLane, pollScanChannels, scanChannel, scanSince, bumpScanCursor, loadScanCursors, agentAuthoredBy, rlSeen, rlKey, loadRlSeen, markRlSeen, addRlSeen, dropRlSeen, route, routePublic, routeDelete, processGrantEvent, grantSet, forwardPublic, clampCreated, rateOk, bumpPubWatermark, loadPubWatermark, markSeen, seen, PUB, postedMap, recordPosted, parseBuzzEventId, resolveChannels, handleRelayIngress, relaySeen, markRelaySeen, addRelaySeen, dropRelaySeen, loadRelaySeen, relayRateOk, resolveRelayDest, relayDropTotalPreAuth, relayDropCounts }
+export { recordUndelivered, UNDELIVERED_PATH, durableSet, fanout, defuseRefs, defuseMarkup, quoted, renderQuarantined, renderReleased, fetchEventById, returnLaneSend, publishWrapToRelays, scanReturnLane, pollScanChannels, scanChannel, scanSince, bumpScanCursor, loadScanCursors, agentAuthoredBy, rlSeen, rlKey, loadRlSeen, markRlSeen, addRlSeen, dropRlSeen, route, routePublic, routeDelete, processGrantEvent, grantSet, forwardPublic, clampCreated, rateOk, bumpPubWatermark, loadPubWatermark, markSeen, seen, PUB, postedMap, recordPosted, parseBuzzEventId, resolveChannels, handleRelayIngress, relaySeen, markRelaySeen, addRelaySeen, dropRelaySeen, loadRelaySeen, relayRateOk, resolveRelayDest, relayDropTotalPreAuth, relayDropCounts }
 
 // --- boot -------------------------------------------------------------------
 if (!process.env.WB_NO_BOOT) {
@@ -1563,6 +1606,15 @@ if (!process.env.WB_NO_BOOT) {
   loadPostedMap()
   loadRlSeen()
   loadRelaySeen()
+  // #171 — say it on every boot. A record of lost messages that nobody reads is the same silence
+  // it exists to end, one level further out. Non-fatal: these are past losses, not a reason to
+  // refuse to start now.
+  try {
+    if (existsSync(UNDELIVERED_PATH)) {
+      const n = readFileSync(UNDELIVERED_PATH, 'utf8').split('\n').filter(Boolean).length
+      if (n) err(`⚠ ${n} previously undelivered message(s) recorded in ${UNDELIVERED_PATH} — these were accepted, marked seen, and never landed. Nothing will retry them.`)
+    }
+  } catch { /* a boot log must never be the thing that stops a boot */ }
   // Every config-sourced typed slot is rendered ONCE here, before a single event is accepted. A
   // value that cannot render would otherwise throw inside a delivery path — and both delivery
   // paths markSeen before emit resolves, so that throw drops the message permanently for one ERR

--- a/tests/undelivered.mjs
+++ b/tests/undelivered.mjs
@@ -1,0 +1,113 @@
+// undelivered.mjs — a send that FAILS must leave a durable record (#171).
+//
+// Why this test exists: both Buzz lanes commit the event id to durable dedup BEFORE the async
+// send — deliberately, because the project favours "never double-post" (the §8 firehose line)
+// over "never drop". That trade is a real position and this suite does not argue with it. What it
+// asserts is the part that was missing: when the losing side of the trade happens, the loss is
+// WRITTEN DOWN. Before #171 a failed send produced one ERR line in a rotating journal, and the
+// message was gone with nothing to count, audit, or replay.
+//
+// It also closes a gap the whole suite had: NO test drove a failing transport. Every one either
+// set WB_STUB_SEND or replaced the transport with something that resolves — which is precisely why
+// a slot escaper that threw inside a delivery path stayed green through 19 suites while production
+// dropped messages.
+//
+// Drives the real recordUndelivered plus the real egress transport seam. No sockets, temp dir only.
+
+import { mkdtempSync, rmSync, readFileSync, existsSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+const dir = mkdtempSync(join(tmpdir(), 'wb-undelivered-'))
+process.env.UNDELIVERED_PATH = join(dir, 'undelivered.log')
+process.env.WB_NO_BOOT = '1'
+process.env.FORWARD_MODE = 'dryrun'
+
+let fails = 0
+const ok = (name, cond, detail = '') => {
+  if (cond) return console.log(`  ok   ${name}`)
+  fails++
+  console.log(`  FAIL ${name}${detail ? ` — ${detail}` : ''}`)
+}
+
+console.log('undelivered record (#171)')
+
+try {
+  const { recordUndelivered } = await import('../src/bridge.mjs')
+  const { emit, __setTransportForTests } = await import('../src/egress.mjs')
+
+  const readLog = () => existsSync(process.env.UNDELIVERED_PATH)
+    ? readFileSync(process.env.UNDELIVERED_PATH, 'utf8').split('\n').filter(Boolean).map(l => JSON.parse(l))
+    : []
+
+  // --- the record itself ------------------------------------------------------------------
+  ok('no file exists before anything fails', readLog().length === 0)
+
+  recordUndelivered({
+    lane: 'sealed', dest: 'inbox-uuid', recipient: 'My Dude',
+    id: 'a'.repeat(64), author: 'b'.repeat(64), reason: 'egress: slot rejected (handle)',
+  })
+
+  const rows = readLog()
+  ok('a failed delivery is written down', rows.length === 1)
+  ok('it is machine-readable, not prose', rows[0] && typeof rows[0] === 'object')
+  ok('it names the recipient who did not get it', rows[0]?.recipient === 'My Dude',
+    'the whole point: a plane fan-out delivers to the others and silently not to this one')
+  ok('it names the lane', rows[0]?.lane === 'sealed')
+  ok('it keeps the event id, so the message is recoverable from a relay', rows[0]?.id === 'a'.repeat(64))
+  ok('it keeps the author', rows[0]?.author === 'b'.repeat(64))
+  ok('it keeps why it failed', /slot rejected/.test(rows[0]?.reason || ''))
+  ok('it is timestamped', Number.isFinite(rows[0]?.ts) && rows[0].ts > 0)
+
+  // Append-only: a second loss must not overwrite the first.
+  recordUndelivered({ lane: 'public', dest: 'staging', id: 'c'.repeat(64), reason: 'boom' })
+  const two = readLog()
+  ok('append-only — a second loss does not erase the first', two.length === 2 && two[0].id === 'a'.repeat(64))
+  ok('a recipient-less lane records null rather than omitting the field', two[1].recipient === null)
+
+  // A long reason is truncated, so one pathological error cannot flood the file the way an
+  // untruncated stack trace would.
+  recordUndelivered({ lane: 'public', dest: 'x', id: 'd'.repeat(64), reason: 'z'.repeat(5000) })
+  ok('a huge reason is capped', readLog()[2].reason.length <= 300)
+
+  // --- recording must never become the new failure ------------------------------------------
+  let threw = false
+  try {
+    recordUndelivered({ lane: 'sealed', dest: '/', id: 'e'.repeat(64), reason: 'x' })
+  } catch { threw = true }
+  ok('recording never throws into the delivery path', !threw,
+    'a failure to record a failure must not take down the lane')
+
+  // --- the gap this suite closes: a transport that actually FAILS ---------------------------
+  //
+  // Every other suite stubs success. This one makes emit() reject and asserts the caller sees a
+  // real rejection it can record — the shape no existing test exercised.
+  const restore = __setTransportForTests(() => Promise.reject(new Error('relay refused: simulated')))
+  let caught = null
+  try {
+    await emit({ template: 'a7_tombstone', dest: 'chan', slots: { author: 'f'.repeat(64), origId: 'a'.repeat(64), delId: 'b'.repeat(64) } })
+  } catch (e) { caught = e }
+  restore()
+  ok('a failing transport rejects rather than resolving quietly', caught !== null)
+  ok('the rejection carries the reason the recorder needs', /relay refused/.test(caught?.message || ''))
+
+  // NEGATIVE CONTROL. Everything above passes if recordUndelivered wrote unconditionally, and it
+  // passes if the transport always rejected. Assert the other direction of each: a SUCCEEDING
+  // transport resolves and adds no row.
+  const before = readLog().length
+  const restore2 = __setTransportForTests(() => Promise.resolve('{"event_id":"' + 'a'.repeat(64) + '"}'))
+  let resolved = false
+  try {
+    await emit({ template: 'a7_tombstone', dest: 'chan', slots: { author: 'f'.repeat(64), origId: 'a'.repeat(64), delId: 'b'.repeat(64) } })
+    resolved = true
+  } catch { resolved = false }
+  restore2()
+  ok('NEGATIVE CONTROL — a working transport still resolves', resolved,
+    'if this fails the seam is broken and every "it failed" assertion above is meaningless')
+  ok('NEGATIVE CONTROL — a successful send records no loss', readLog().length === before)
+} finally {
+  rmSync(dir, { recursive: true, force: true })
+}
+
+console.log(fails ? `\nundelivered: ${fails} check(s) failed` : '\nall checks passed')
+process.exit(fails ? 1 : 0)


### PR DESCRIPTION
Partial fix for #171 — and deliberately the part that changes **no policy**.

## Why partial: reading the code changed the issue

I went in to implement #171's "roll back on failure" and found this at `routePublic`:

> **A2/A3: commit-before-dispatch.** markSeen persists the id synchronously BEFORE the async send, so a kill -9 mid-send can never re-post it — **we favor "never double-post" (the §8 firehose line) over "never drop"**.

That is not an oversight. It is a stated decision, tied to the one line the spec says never to cross — *an agent becoming a posting firehose* — which is also the ToS argument in §7. **Rolling back on failure reverses it.** That is your call, not something to slip inside a fix labelled "bug". So I didn't. #171 is updated with the finding and the tradeoff spelled out.

## What's left is purely additive

Remove that option and the remaining problem is that **the losing side of the trade was invisible**. A failed send produced one `ERR` line in a rotating journal, and the message was gone with nothing to count, audit, or replay.

`data/undelivered.log` now records every failed delivery on both Buzz lanes:

```json
{"ts":1754087168,"lane":"sealed","dest":"<inbox>","recipient":"My Dude",
 "id":"<64-hex>","author":"<64-hex>","reason":"egress: slot rejected (handle)"}
```

- **Append-only**, reason capped at 300 chars so one pathological error can't flood it.
- **Never throws** into the delivery path — a failure to record a failure must not take down the lane.
- **Reported at boot**, because a record nobody reads is the same silence one level out.
- `data/` is already gitignored, so it never enters git.

**The event id is the point.** The original is still on the relays, so a *recorded* loss is recoverable; an unrecorded one isn't.

**The `recipient` field is what would have made 2026-08-01 legible.** `markSeen` is per *event*, not per recipient — so a plane fan-out delivered to three and silently not to the fourth. That reads as "that agent isn't responding," not as a bridge fault. This is the field that distinguishes those.

## The gap this closes in the suite itself

**No existing test drove a failing transport.** Every one either set `WB_STUB_SEND` or replaced the transport with something that resolves. That is precisely how a slot escaper that threw inside a delivery path stayed green through 19 suites while production dropped messages — the failure path had no coverage at all.

`tests/undelivered.mjs` (suite 20) drives a genuinely rejecting transport, and asserts **both directions**: a failing transport rejects and gets recorded, a working one resolves and records nothing.

**Negative control:** making `recordUndelivered` a no-op turns **9 checks red**; restored, green.

*(First run of that control produced zero failures and I nearly reported it as passing — the suite had died at import because `config.json` was absent, so nothing ran. Re-run with config present. A control that produces no output has told you nothing.)*

`npm run lint` clean · `npm test` **20/20**.

## Still open on #171

The ordering itself. Options, with the constraint above now explicit:

- **Roll back on failure** — reverses the documented never-double-post preference. Needs your ruling.
- **Per-recipient dedup keys** (composite, like the return lane's `rlKey`) — the only thing that actually fixes *partial* fan-out loss, but it re-keys the durable store, so it needs a dual-read migration or it re-delivers the whole 48h window on deploy. Real hazard, worth its own PR.
- **This PR** — makes the loss visible and recoverable without touching either.

Not merging this myself, per the rule in #177.

---

Drafted with assistance from [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pj7AyMK4XPsib7tdR8P8JB)_