### PR TITLE
test: make the two enforcement gates actually cover what they claim (#175, #172)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,7 +148,7 @@ that merely ran.** The suite was green through all of them.
 `npm test` — 22 suites, against the real exported functions with synthetic events. No sockets,
 no production state, no writes outside a temp dir.
 
-suite roster · boot · egress catalogue · egress ban · durable dedup store · relay fan-out · quarantine gating · deletion propagation · sealed-lane rate caps · grant
+boot · suite roster · egress catalogue · egress ban · durable dedup store · relay fan-out · quarantine gating · deletion propagation · sealed-lane rate caps · grant
 admission · message rendering · deployed-build verification · return lane · return-lane scan ·
 return-lane no-miss · return-lane pending · relay ingress · tripwire union · tripwire detection drill · deploy runner · console Host check · undelivered record
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,14 +145,14 @@ that merely ran.** The suite was green through all of them.
 
 ## Tests
 
-`npm test` — 21 suites, against the real exported functions with synthetic events. No sockets,
+`npm test` — 22 suites, against the real exported functions with synthetic events. No sockets,
 no production state, no writes outside a temp dir.
 
-boot · egress catalogue · egress ban · durable dedup store · relay fan-out · quarantine gating · deletion propagation · sealed-lane rate caps · grant
+suite roster · boot · egress catalogue · egress ban · durable dedup store · relay fan-out · quarantine gating · deletion propagation · sealed-lane rate caps · grant
 admission · message rendering · deployed-build verification · return lane · return-lane scan ·
 return-lane no-miss · return-lane pending · relay ingress · tripwire union · tripwire detection drill · deploy runner · console Host check · undelivered record
 
-CI runs them on push and PR. **If a run reports fewer than 21, the branch is on a stale base.**
+CI runs them on push and PR. **If a run reports fewer than 22, the branch is on a stale base.**
 The count of record is the `test` script in `package.json`; a prose count that disagrees with it
 is the prose being wrong.
 

--- a/README.md
+++ b/README.md
@@ -107,9 +107,9 @@ against what git says, because a stale build is invisible while every status sur
 `npm test` runs 22 suites against the **real** exported functions with synthetic events — no
 sockets, no production state:
 
-boot · egress catalogue · egress ban · durable dedup store · relay fan-out · quarantine gating · deletion propagation · sealed-lane rate caps · grant
+boot · suite roster · egress catalogue · egress ban · durable dedup store · relay fan-out · quarantine gating · deletion propagation · sealed-lane rate caps · grant
 admission · message rendering · deployed-build verification · return lane · return-lane scan ·
-return-lane no-miss · relay ingress · tripwire union · tripwire detection drill · deploy runner · console Host check · undelivered record
+return-lane no-miss · return-lane pending · relay ingress · tripwire union · tripwire detection drill · deploy runner · console Host check · undelivered record
 
 The rendering suite is the one to read if you are reviewing. It tests what the bridge **refuses**,
 not only what it does: a hostile note tries to ping the approver, mint an `APPROVED BY` heading,

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ against what git says, because a stale build is invisible while every status sur
 
 ## Tests
 
-`npm test` runs 21 suites against the **real** exported functions with synthetic events — no
+`npm test` runs 22 suites against the **real** exported functions with synthetic events — no
 sockets, no production state:
 
 boot · egress catalogue · egress ban · durable dedup store · relay fan-out · quarantine gating · deletion propagation · sealed-lane rate caps · grant

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -120,7 +120,7 @@ in [deploy/README.md](../deploy/README.md).
 - **Publish the agent relay list:** `node tools/publish_relay_list.mjs` (so the identity
   is discoverable).
 - **Admit a participant**, if you want one: `sh tools/grant-setup.sh`.
-- **Run the safety gates before you ship:** `npm test` — 21 suites driving the real
+- **Run the safety gates before you ship:** `npm test` — 22 suites driving the real
   routing functions with synthetic events (no sockets, no production state), all green.
 
 `waggle-init.mjs --check` rolls the config half of this into one readiness verdict; the

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "start": "node src/bridge.mjs",
     "dryrun": "FORWARD_MODE=dryrun node src/bridge.mjs",
     "lint": "eslint src tools tests",
-    "test": "node tests/boot.mjs && node tests/egress_catalogue.mjs && node tests/egress_ban.mjs && node tests/relay_fanout.mjs && node tests/durable_store.mjs && node tests/a1_quarantine.mjs && node tests/a7_deletion.mjs && node tests/lane2_caps.mjs && node tests/nipda_admission.mjs && node tests/render_states.mjs && node tests/deploy_verify.mjs && node tests/return_lane.mjs && node tests/return_lane_scan.mjs && node tests/return_lane_nomiss.mjs && node tests/return_lane_pending.mjs && node tests/relay_ingress.mjs && node tests/tripwire_union.mjs && node tests/tripwire_detection.mjs && node tests/deploy_runner.mjs && node tests/console_host.mjs && node tests/undelivered.mjs",
+    "test": "node tests/suite_count.mjs && node tests/boot.mjs && node tests/egress_catalogue.mjs && node tests/egress_ban.mjs && node tests/relay_fanout.mjs && node tests/durable_store.mjs && node tests/a1_quarantine.mjs && node tests/a7_deletion.mjs && node tests/lane2_caps.mjs && node tests/nipda_admission.mjs && node tests/render_states.mjs && node tests/deploy_verify.mjs && node tests/return_lane.mjs && node tests/return_lane_scan.mjs && node tests/return_lane_nomiss.mjs && node tests/return_lane_pending.mjs && node tests/relay_ingress.mjs && node tests/tripwire_union.mjs && node tests/tripwire_detection.mjs && node tests/deploy_runner.mjs && node tests/console_host.mjs && node tests/undelivered.mjs",
     "console": "node tools/serve-console.mjs"
   },
   "dependencies": {

--- a/tests/egress_ban.mjs
+++ b/tests/egress_ban.mjs
@@ -11,15 +11,39 @@
 // static check, and anyone with commit access can route around a lint rule. What an import ban
 // reliably stops is the ACCIDENT — the next contributor reaching for the convenient thing — which
 // is the actual threat model here. It is not airtight and nothing below claims it is.
-import { readFileSync, readdirSync, writeFileSync, unlinkSync } from 'node:fs'
+import { readFileSync, readdirSync, writeFileSync, unlinkSync, mkdirSync, rmSync } from 'node:fs'
 import { join, dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 const SRC = resolve(dirname(fileURLToPath(import.meta.url)), '..', 'src')
-const files = readdirSync(SRC).filter(f => f.endsWith('.mjs'))
+
+// RECURSIVE (#175). The first version read one directory level, so a future src/lanes/foo.mjs
+// could import child_process or call finalizeEvent and this ban would pass. Not hypothetical: the
+// repo already moved this way once, when #154/#161 split bridge.mjs into leaf modules. A forcing
+// function with a scope hole is one refactor away from forcing nothing — and it stays green the
+// whole time, which is the failure this repo keeps re-learning.
+const files = readdirSync(SRC, { recursive: true }).map(String).filter(f => f.endsWith('.mjs'))
+
+// SCOPE — decided, not inherited from a glob (#175). This ban covers `src/`: the BRIDGE PROCESS,
+// whose authorship is what A3 constrains. `tools/` is deliberately NOT covered. Those are
+// operator-invoked CLIs, run deliberately by a human, and several legitimately do the banned
+// things by design: tripwire.mjs signs alarm DMs with a SEPARATE alarm key, grant.mjs drives a
+// remote signer, approve.mjs reposts through the delivery path. Banning them would forbid the
+// thing they exist to do.
+//
+// The boundary is WHO INITIATES, not the directory name: if a tool ever becomes something the
+// bridge process invokes rather than something an operator runs, it belongs in src/ and under
+// this ban.
 
 let fails = 0
 const ok = (name, cond) => { console.log(`${cond ? 'ok  ' : 'FAIL'} — ${name}`); if (!cond) fails++ }
+
+// SIZE FLOOR — same reasoning as #174's. Every per-file assertion below is vacuously true over an
+// empty list: a scan that finds nothing passes every ban. So prove the scan found what it is
+// supposed to be policing before trusting a word it says.
+ok(`the scan found source modules to police (${files.length})`, files.length >= 5)
+ok('the scan includes the two chokepoints it exists to protect',
+  files.includes('egress.mjs') && files.includes('nostr_egress.mjs'))
 
 // The scanner, factored out so the negative control can drive it over a planted file.
 const importsChildProcess = (text) => /(^|[^\w])(import\s[^\n]*['"]node:child_process['"]|require\(\s*['"](node:)?child_process['"]\s*\))/m.test(text)
@@ -47,6 +71,29 @@ for (const f of files) {
       importsChildProcess("const { spawn: go } = require('child_process')"))
   } finally {
     try { unlinkSync(planted) } catch { /* already gone */ }
+  }
+}
+
+// NEGATIVE CONTROL for the SCAN'S REACH, not just its regex (#175). The control above plants a
+// violation in the directory the scanner was already reading, so it passed even when the scan was
+// one level deep. This one plants it in a SUBDIRECTORY — the shape a future src/lanes/ refactor
+// would produce — and requires the file list itself to contain it.
+//
+// Before the recursive change this check failed, which is the whole point of writing it: it is the
+// difference between "the regex works" and "the regex is pointed at everything it must cover".
+{
+  const subdir = join(SRC, '__ban_control_dir__')
+  const planted = join(subdir, 'nested.mjs')
+  try {
+    mkdirSync(subdir, { recursive: true })
+    writeFileSync(planted, "import { execFile } from 'node:child_process'\nexport const x = execFile\n")
+    const rescan = readdirSync(SRC, { recursive: true }).map(String).filter(f => f.endsWith('.mjs'))
+    const found = rescan.find(f => f.endsWith('nested.mjs'))
+    ok('NEGATIVE CONTROL — the scan reaches into subdirectories', !!found)
+    ok('NEGATIVE CONTROL — and a violation planted there IS detected',
+      !!found && importsChildProcess(readFileSync(join(SRC, found), 'utf8')))
+  } finally {
+    try { rmSync(subdir, { recursive: true, force: true }) } catch { /* already gone */ }
   }
 }
 

--- a/tests/suite_count.mjs
+++ b/tests/suite_count.mjs
@@ -1,0 +1,89 @@
+// suite_count.mjs — the suite count in prose must match package.json (#172).
+//
+// Why this exists: the number is load-bearing. CLAUDE.md says "if a run reports fewer than N, the
+// branch is on a stale base" — a stale-base detector whose calibration was maintained by hand, and
+// therefore wrong most of the time. It drifted 13 → 16 → 17 → 19 → 20 in two days, hand-synced
+// across three files each round, and on one of those rounds README's roster listed 17 items beside
+// a claim of 19. A detector calibrated by hand is a detector that sits quiet through exactly the
+// situation it exists to catch.
+//
+// package.json's `test` script is the count of record. Everything else is a claim about it, and
+// claims are what this suite checks.
+//
+// Two properties beyond the obvious, both learned the hard way:
+//   - the scan is MULTILINE. A line-based grep missed a stale count in ci.yml because "The four"
+//     and "suites" sat on different lines; it was found by reading, not by the check.
+//   - the ROSTER length is asserted too, not just the number. README once carried a correct count
+//     beside a list of the wrong length, which a count-only check passes.
+
+import { readFileSync, readdirSync } from 'node:fs'
+import { dirname, resolve, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+let fails = 0
+const ok = (name, cond, detail = '') => {
+  if (cond) return console.log(`  ok   ${name}`)
+  fails++
+  console.log(`  FAIL ${name}${detail ? ` — ${detail}` : ''}`)
+}
+
+console.log('suite count (#172)')
+
+// --- the count of record ---------------------------------------------------------------------
+const pkg = JSON.parse(readFileSync(join(ROOT, 'package.json'), 'utf8'))
+const invoked = (pkg.scripts.test.match(/tests\/[\w-]+\.mjs/g) || [])
+const onDisk = readdirSync(join(ROOT, 'tests')).filter(f => f.endsWith('.mjs'))
+const N = invoked.length
+
+// Ground truth has to agree with itself first, or the number it certifies means nothing.
+ok(`package.json invokes ${N} suite(s)`, N > 0)
+ok('every invoked suite exists on disk', invoked.every(p => onDisk.includes(p.replace('tests/', ''))),
+  invoked.filter(p => !onDisk.includes(p.replace('tests/', ''))).join(', ') || '')
+ok('every suite on disk is invoked — an orphan file is a test nobody runs',
+  onDisk.every(f => invoked.includes(`tests/${f}`)),
+  onDisk.filter(f => !invoked.includes(`tests/${f}`)).join(', ') || '')
+ok('no suite is invoked twice', new Set(invoked).size === invoked.length)
+
+// --- the claims ---------------------------------------------------------------------------
+// MULTILINE on purpose (see header). `\s` spans newlines, so a count split across a wrap is still
+// caught — which a line-based grep is structurally unable to do.
+const NUMBER_WORDS = 'one|two|three|four|five|six|seven|eight|nine|ten|eleven|twelve|thirteen|fourteen|fifteen|sixteen|seventeen|eighteen|nineteen|twenty'
+const claimRe = new RegExp(`(\\d+|${NUMBER_WORDS})[\\s#*_-]+suites?\\b`, 'gi')
+const WORD_TO_N = { one: 1, two: 2, three: 3, four: 4, five: 5, six: 6, seven: 7, eight: 8, nine: 9, ten: 10, eleven: 11, twelve: 12, thirteen: 13, fourteen: 14, fifteen: 15, sixteen: 16, seventeen: 17, eighteen: 18, nineteen: 19, twenty: 20 }
+const asNumber = (s) => /^\d+$/.test(s) ? Number(s) : WORD_TO_N[s.toLowerCase()]
+
+// Every file that could carry a claim, not only the ones that carry one today — a stale count in a
+// file nobody thought to list is the exact failure this suite exists to prevent.
+const CANDIDATES = ['CLAUDE.md', 'README.md', 'docs/GETTING_STARTED.md', '.github/workflows/ci.yml', 'SECURITY.md']
+
+for (const rel of CANDIDATES) {
+  let text
+  try { text = readFileSync(join(ROOT, rel), 'utf8') } catch { continue }
+  const claims = [...text.matchAll(claimRe)].map(m => asNumber(m[1])).filter(Number.isFinite)
+  if (!claims.length) continue // a file that states no count cannot state a wrong one
+  const wrong = claims.filter(c => c !== N)
+  ok(`${rel}: every stated suite count is ${N}`, wrong.length === 0,
+    wrong.length ? `found ${wrong.join(', ')} — package.json says ${N}` : '')
+}
+
+// The stale-base threshold in CLAUDE.md is the reason the number matters at all.
+{
+  const claude = readFileSync(join(ROOT, 'CLAUDE.md'), 'utf8')
+  const m = claude.match(/fewer than\s+(\d+|[a-z]+)/i)
+  ok('CLAUDE.md stale-base threshold matches the real count', m && asNumber(m[1]) === N,
+    m ? `threshold says ${m[1]}, package.json says ${N}` : 'no threshold line found')
+}
+
+// --- the roster, not just the number ----------------------------------------------------------
+// README once claimed 19 beside a list of 17. A count-only check passes that.
+for (const rel of ['CLAUDE.md', 'README.md']) {
+  const text = readFileSync(join(ROOT, rel), 'utf8')
+  const roster = text.match(/boot ·[\s\S]*?(?=\n\n)/)
+  if (!roster) { ok(`${rel}: roster found`, false, 'no "boot · …" roster block'); continue }
+  const items = roster[0].split('·').map(s => s.trim()).filter(Boolean)
+  ok(`${rel}: roster lists ${N} suites`, items.length === N, `roster has ${items.length}`)
+}
+
+console.log(fails ? `\nsuite_count: ${fails} check(s) failed` : '\nall checks passed')
+process.exit(fails ? 1 : 0)


### PR DESCRIPTION
Closes #175 and #172. Both gates were green while blind to a class they were supposed to police — tests only, no `src/` changes.

## #175 — the A3 ban test read one directory level

`readdirSync(SRC)` doesn't descend. A future `src/lanes/foo.mjs` could import `child_process`, call `finalizeEvent`, or touch `BRIDGE_SK`, and the ban would pass. **Not hypothetical** — #154/#161 already split `bridge.mjs` into leaf modules, so more structure under `src/` is the direction of travel.

Now recursive, with a **negative control that plants the violation in a subdirectory**. The existing control planted it in the directory the scanner already read, so it passed even while the scan was one level deep — it tested the regex, not the reach. Reverting the scan to non-recursive makes exactly the two new checks red:

```
FAIL — NEGATIVE CONTROL — the scan reaches into subdirectories
FAIL — NEGATIVE CONTROL — and a violation planted there IS detected
```

**Scope is now a decision, not an artifact of the glob.** `src/` is the bridge process and is covered. `tools/` is *not*, and the reason is written into the file: those are operator-invoked CLIs that legitimately do the banned things by design — `tripwire.mjs` signs alarm DMs with a **separate** alarm key, `grant.mjs` drives a remote signer, `approve.mjs` reposts through the delivery path. Banning them would forbid the thing they exist to do. The boundary is **who initiates**, not the directory name: a tool the bridge process invokes belongs in `src/` and under the ban.

**Plus a size floor on the scan itself.** Every per-file ban is vacuously true over an empty file list — a scan that finds nothing passes every ban. Same shape as #174's floor, one level up.

## #172 — the suite count

**13 → 16 → 17 → 19 → 20 in two days**, hand-synced across three files each round, and once README carried a correct count beside a roster of the wrong length. `CLAUDE.md` makes that number load-bearing — *"if a run reports fewer than N, the branch is on a stale base"* — so a hand-maintained number is a detector that sits quiet through exactly the case it exists to catch.

`tests/suite_count.mjs` derives the count from `package.json` and checks:

- every invoked suite exists on disk
- **every file on disk is invoked** — an orphan is a test nobody runs
- no suite invoked twice
- every stated count in every candidate doc (`CLAUDE.md`, `README.md`, `GETTING_STARTED.md`, `ci.yml`, `SECURITY.md`)
- the stale-base threshold line specifically
- **the roster length** — because a count-only check passes the README failure

**The scan is multiline on purpose.** A line-based grep missed a stale count in `ci.yml` because "The four" and "suites" sat on different lines; it was found by reading, not by the check.

**Four negative controls, each watched failing:**

| control | result |
|---|---|
| desync a stated count | ✅ red |
| desync the stale-base threshold alone | ✅ red |
| correct count, short roster (the README failure) | ✅ red |
| count split across a line wrap (the `ci.yml` failure) | ✅ red |

Restored, all green. `npm run lint` clean · `npm test` **20/20**.

## Merge note

This and **#178** both add a suite as number 20 and both touch the doc counts, so whichever lands second needs a rebase and a bump to 21. The new assert makes that mechanical rather than a thing to remember — it'll fail loudly if the rebase forgets it, which is the whole point.

Not merging this myself, per #177.

---

Drafted with assistance from [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pj7AyMK4XPsib7tdR8P8JB)_