### PR TITLE
test(ban): scan src/ recursively and make tools/ a written decision (#175)

### DIFF
--- a/tests/egress_ban.mjs
+++ b/tests/egress_ban.mjs
@@ -11,12 +11,34 @@
 // static check, and anyone with commit access can route around a lint rule. What an import ban
 // reliably stops is the ACCIDENT — the next contributor reaching for the convenient thing — which
 // is the actual threat model here. It is not airtight and nothing below claims it is.
-import { readFileSync, readdirSync, writeFileSync, unlinkSync } from 'node:fs'
-import { join, dirname, resolve } from 'node:path'
+import { readFileSync, readdirSync, writeFileSync, unlinkSync, mkdirSync, rmSync } from 'node:fs'
+import { join, dirname, resolve, relative } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
-const SRC = resolve(dirname(fileURLToPath(import.meta.url)), '..', 'src')
-const files = readdirSync(SRC).filter(f => f.endsWith('.mjs'))
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const SRC = join(ROOT, 'src')
+const TOOLS = join(ROOT, 'tools')
+
+// RECURSIVE, deliberately (#175). `readdirSync` without it does not descend, so a future
+// src/lanes/foo.mjs could import child_process or call finalizeEvent and this gate would pass —
+// green the whole time, which is the specific failure this repo keeps naming. The tree has
+// already moved this way once (#154 split bridge.mjs into leaf modules), so nesting is a matter
+// of when, not whether.
+const mjsUnder = (root) => {
+  const out = []
+  const walk = (dir) => {
+    for (const ent of readdirSync(dir, { withFileTypes: true })) {
+      const full = join(dir, ent.name)
+      if (ent.isDirectory()) { if (ent.name !== 'node_modules') walk(full) }
+      else if (ent.name.endsWith('.mjs')) out.push(full)
+    }
+  }
+  walk(root)
+  return out
+}
+
+const srcFiles = mjsUnder(SRC)
+const files = srcFiles.map(f => relative(SRC, f))
 
 let fails = 0
 const ok = (name, cond) => { console.log(`${cond ? 'ok  ' : 'FAIL'} — ${name}`); if (!cond) fails++ }
@@ -24,7 +46,7 @@ const ok = (name, cond) => { console.log(`${cond ? 'ok  ' : 'FAIL'} — ${name}`
 // The scanner, factored out so the negative control can drive it over a planted file.
 const importsChildProcess = (text) => /(^|[^\w])(import\s[^\n]*['"]node:child_process['"]|require\(\s*['"](node:)?child_process['"]\s*\))/m.test(text)
 
-console.log('-- Buzz transport: only egress.mjs may import child_process --')
+console.log(`-- Buzz transport: only egress.mjs may import child_process (${files.length} file(s) under src/, recursive) --`)
 
 for (const f of files) {
   const text = readFileSync(join(SRC, f), 'utf8')
@@ -76,6 +98,69 @@ for (const f of files) {
   const planted = 'const e = finalizeEvent({ kind: 1 }, sk)'
   const seen = (planted.match(/finalizeEvent\s*\(/g) || []).length
   ok('NEGATIVE CONTROL — the counter sees a planted signer call', seen === 1)
+}
+
+// ---------------------------------------------------------------------------------------------
+console.log('\n-- tools/: scope is a DECISION, not an artifact of the glob (#175) --')
+//
+// A3's scope is what the BRIDGE PROCESS may author. `tools/` is operator-invoked CLIs — a human
+// runs them deliberately, and several legitimately sign: tripwire alarms under a separate
+// zero-authority key, grant.mjs through a bunker, publish_relay_list under a member's own key.
+// Excluding them is right. But until now it was right *by accident*: the scan globbed `src/` and
+// nobody had written down that `tools/` was out. An undocumented scope boundary on an enforcement
+// gate is one refactor from silently covering nothing.
+//
+// So tools/ IS scanned, against an explicit roster. Each entry is a decision with a reason. A NEW
+// tool that signs, or an existing one that starts to, fails this suite until someone adds it here
+// — which is the point: the exclusion becomes a deliberate act, not a side effect.
+//
+// The one hard rule tools/ does NOT get to opt out of: none of them may touch BRIDGE_SK. The
+// bridge's own key belongs to src/nostr_egress.mjs alone, whatever the caller's privileges.
+const TOOL_SIGNERS = {
+  'grant.mjs':              'issues NIP-DA 440/441 under the GRANTOR key (bunker or local), never the bridge key',
+  'participant-init.mjs':   'mints and publishes a participant identity under that participant\'s own key',
+  'publish_relay_list.mjs': 'publishes a NIP-65 kind:10002 under the member\'s own key',
+  'retract.mjs':            'publishes a NIP-09 deletion for a note the invoking key authored',
+  'tripwire.mjs':           'signs the alarm DM under a SEPARATE zero-authority key — rule 1 of the tripwire',
+  'waggle-init.mjs':        'operator setup CLI; shells out to the buzz binary to check readiness',
+}
+
+for (const full of mjsUnder(TOOLS)) {
+  const name = relative(TOOLS, full)
+  const text = readFileSync(full, 'utf8')
+  const signs = (text.match(/finalizeEvent\s*\(/g) || []).length > 0 || importsChildProcess(text)
+  const declared = Object.prototype.hasOwnProperty.call(TOOL_SIGNERS, name)
+  if (signs) {
+    ok(`tools/${name}: signs or shells out, and is on the roster with a reason`, declared)
+  } else if (declared) {
+    ok(`tools/${name}: on the roster but no longer signs — roster is stale, remove it`, false)
+  }
+  // The rule no tool may opt out of.
+  ok(`tools/${name}: never touches BRIDGE_SK`, !/BRIDGE_SK/.test(text))
+}
+
+// NEGATIVE CONTROL — a new signing tool that nobody added to the roster must fail.
+{
+  const planted = join(TOOLS, '__ban_control_tool__.mjs')
+  try {
+    writeFileSync(planted, "import { finalizeEvent } from 'nostr-tools/pure'\nexport const x = () => finalizeEvent({ kind: 1 }, sk)\n")
+    const text = readFileSync(planted, 'utf8')
+    const signs = (text.match(/finalizeEvent\s*\(/g) || []).length > 0
+    const declared = Object.prototype.hasOwnProperty.call(TOOL_SIGNERS, '__ban_control_tool__.mjs')
+    ok('NEGATIVE CONTROL — an unrostered signing tool is caught', signs && !declared)
+  } finally { try { unlinkSync(planted) } catch { /* */ } }
+}
+
+// NEGATIVE CONTROL — the recursive walk actually descends.
+{
+  const nested = join(SRC, '__ban_control_dir__')
+  try {
+    mkdirSync(nested, { recursive: true })
+    writeFileSync(join(nested, 'sneaky.mjs'), "import { execFile } from 'node:child_process'\nexport const x = execFile\n")
+    const found = mjsUnder(SRC).some(f => f.endsWith('sneaky.mjs'))
+    const caught = found && importsChildProcess(readFileSync(join(nested, 'sneaky.mjs'), 'utf8'))
+    ok('NEGATIVE CONTROL — a violation in a NESTED src/ directory is reached and caught', caught)
+  } finally { try { rmSync(nested, { recursive: true, force: true }) } catch { /* */ } }
 }
 
 console.log(fails ? `\negress_ban: ${fails} FAILED` : '\negress_ban: all checks passed')


### PR DESCRIPTION
Closes #175.

Two blind spots in the suite that makes A3 structural rather than advisory.

**Recursive.** `readdirSync` without it doesn't descend, so a future `src/lanes/foo.mjs` could import `child_process`, call `finalizeEvent` or touch `BRIDGE_SK` and the gate would pass — staying green the whole time. The tree has already moved that way once (#154 split `bridge.mjs` into leaf modules), so nesting is a matter of when, not whether.

**`tools/` was excluded by accident.** Excluding it is *right* — A3's scope is what the bridge **process** may author, and `tools/` is operator-invoked CLIs, several of which legitimately sign. But that exclusion was an artifact of the glob rather than a decision anyone wrote down.

It is now scanned against an explicit roster — one entry per signing tool, each with the reason it's permitted:

| tool | why it may sign |
|---|---|
| `grant.mjs` | NIP-DA 440/441 under the **grantor** key, never the bridge's |
| `participant-init.mjs` | mints/publishes under that **participant's own** key |
| `publish_relay_list.mjs` | NIP-65 `kind:10002` under the **member's own** key |
| `retract.mjs` | NIP-09 deletion for a note the invoking key authored |
| `tripwire.mjs` | alarm DM under a **separate zero-authority** key — rule 1 |
| `waggle-init.mjs` | operator setup CLI; shells out to the `buzz` binary |

A new signing tool, or an existing one that starts signing, now **fails until someone adds it here**. The exclusion becomes a deliberate act instead of a side effect.

**One rule no tool may opt out of:** none may touch `BRIDGE_SK`. The bridge's own key belongs to `src/nostr_egress.mjs` alone, whatever the caller's privileges. That's asserted for every file under `tools/`, rostered or not.

## Negative controls

A scanner that reaches nothing and a codebase with no violations are indistinguishable, so both are proven:

- a planted `child_process` import in a **nested** `src/` directory must be reached and caught
- an unrostered signing tool must fail the roster check

Drafted with assistance from [Claude Code](https://claude.com/claude-code)