### PR TITLE
tripwire: separate a blind check from a quiet one (#176)

### DIFF
--- a/tests/tripwire_detection.mjs
+++ b/tests/tripwire_detection.mjs
@@ -27,6 +27,7 @@ const POSTER = 'npub1s36nypljc6h88tey0kshf688eyd8myu636ctfs4e3d2w54nhsmnqfhaent'
 // operator is meant to trust; a test must not leave fake alarms in it.
 let ALARMS
 
+const quiet0 = (out) => !/^QUIET/m.test(out)
 let failures = 0
 const check = (name, cond, detail = '') => {
   if (cond) return console.log(`  ok   ${name}`)
@@ -97,14 +98,22 @@ try {
   check('it says nothing was checked', /0 on-relay event\(s\) observed/.test(empty.out))
   check('it names the read path as the suspect, not a quiet key',
     /read path is not seeing/.test(empty.out))
+  // The two cases must not collapse back together: blind still nags, quiet does not.
+  check('blind (journal non-empty) and quiet (journal empty) get DIFFERENT exit codes',
+    empty.code === 3 && quiet0(empty.out), 'both must not be 3')
   check('it states plainly that this is not an all-clear', /NOT an all-clear/.test(empty.out))
 
   // Both halves of the floor: an empty journal too is a quiet period, still not an all-clear.
   const emptyJournal = resolve(dir, 'empty-journal.log')
   writeFileSync(emptyJournal, '')
   const quiet = run(emptyJournal, noEvents)
-  check('0 observed + an empty journal -> still INCONCLUSIVE', quiet.code === 3, `exit ${quiet.code}`)
-  check('it distinguishes a quiet period from a blind one', /may simply be a quiet period/.test(quiet.out))
+  // #176: an idle hour must NOT fail the unit, or the detector cries wolf every tick and gets
+  // muted — the same end state as having no detector. But exit 0 here must never read like the
+  // OK it sits next to: no evidence of wrongdoing is not evidence of no wrongdoing.
+  check('0 observed + an EMPTY journal -> QUIET, exit 0 (no alert fatigue)', quiet.code === 0, `exit ${quiet.code}`)
+  check('the quiet line does not claim an all-clear', /not an all-clear/.test(quiet.out))
+  check('the quiet line says nothing was checked or claimed', /nothing is claimed/.test(quiet.out))
+  check('QUIET is visibly distinct from OK', /^QUIET/m.test(quiet.out) && !/^OK/m.test(quiet.out))
 
   // NEGATIVE CONTROL for the floor itself. A tool that returned INCONCLUSIVE unconditionally
   // would pass every check above. The clean run at line ~79 is the counterpart — it observed

--- a/tools/tripwire.mjs
+++ b/tools/tripwire.mjs
@@ -208,13 +208,32 @@ if (!anomalies.length) {
   // quiet — it means the read path cannot see the surface the key is actually used on, and every
   // OK it has ever printed was that blindness, not an assurance.
   if (!events.length) {
+    // BLIND vs QUIET — the same observation, two very different meanings, and #176 is right that
+    // collapsing them costs the alarm its credibility. An INCONCLUSIVE on every idle hour is a
+    // detector crying wolf, and this repo already knows where that ends: it gets muted, which is
+    // the same end state as having no detector at all.
+    //
+    // The journal is what separates them, and the tool already computed it — it was in the
+    // message text and not in the exit code.
+    if (journal.size) {
+      // Sends recorded, nothing seen on the wire: the read path is not looking at the surface the
+      // poster key is used on. Not a quiet key — a blind check. This is the one that must nag.
+      console.log(
+        `INCONCLUSIVE — 0 on-relay event(s) observed in the last ${sinceMin}m, so nothing was checked, ` +
+        `while the journal recorded ${journal.size} send(s) in the same period.\n` +
+        `Zero observed against a non-empty journal means the read path is not seeing the surface the ` +
+        `poster key is used on. This is NOT an all-clear.`)
+      process.exit(3)
+    }
+    // Nothing sent, nothing seen: consistent with a genuinely idle window. Exit 0 so an idle
+    // bridge does not fail its unit every tick — but say plainly that nothing was CLEARED. The
+    // distinction the wording has to carry: "no evidence of wrongdoing" is not "evidence of no
+    // wrongdoing", and this line must never read like the OK below it.
     console.log(
-      `INCONCLUSIVE — 0 on-relay event(s) observed in the last ${sinceMin}m, so nothing was checked.` +
-      (journal.size
-        ? `\nThe journal recorded ${journal.size} send(s) in the same period. Zero observed against a non-empty journal means the read path is not seeing the surface the poster key is used on — not that the key was idle.`
-        : `\nThe journal is also empty for this window, so this may simply be a quiet period — but a run that saw nothing still proves nothing about the read path.`) +
-      `\nThis is NOT an all-clear.`)
-    process.exit(3)
+      `QUIET — 0 on-relay event(s) observed and 0 journaled in the last ${sinceMin}m. ` +
+      `Consistent with an idle poster key.\nNothing was checked and nothing is claimed: this is ` +
+      `not an all-clear, it is an absence of activity to clear.`)
+    process.exit(0)
   }
   console.log(`OK — all ${events.length} on-relay post(s) by the poster key were emitted by our process.`)
   process.exit(0)


### PR DESCRIPTION
Closes #176. Follow-up to #174, whose reasoning stands — this is about its operational edge.

The floor was right, and the edge is real: with `--since-min` on a timer, a genuinely idle hour failed the unit **on every tick**. This repo already knows where that ends — *a detector that cries wolf gets muted, which is the same end state as having no detector at all.* That's the failure the floor exists to prevent, arriving from the other direction.

**The tool already computed the distinction** — it was in the message text and not in the exit code:

| observed | journal, same window | meaning | now |
|---|---|---|---|
| 0 | **non-empty** | **blind** — sends recorded, none seen on the wire, so the read path isn't looking at the surface the key is used on | **exit 3**, and it should nag |
| 0 | empty | consistent with an idle key | **exit 0 `QUIET`** |

**The wording on the quiet path is doing the work**, and is deliberately not the `OK` line it sits beside:

> `QUIET — 0 on-relay event(s) observed and 0 journaled … Nothing was checked and nothing is claimed: this is not an all-clear, it is an absence of activity to clear.`

No evidence of wrongdoing is not evidence of no wrongdoing, and an exit 0 that reads like the all-clear would give back exactly what #174 bought.

Tests assert the two cases get **different exit codes**, that `QUIET` is visibly distinct from `OK`, and that the quiet line refuses to claim an all-clear.

**Worth noting for the box:** its journal is *not* empty — it records hundreds of sends per window — so production takes the **blind** path and keeps reporting `INCONCLUSIVE`. That is correct and unchanged: the read path genuinely cannot see the gated relay yet. This PR only stops a genuinely idle bridge from crying wolf.

Drafted with assistance from [Claude Code](https://claude.com/claude-code)