### PR TITLE
test: assert the suite roster instead of hand-syncing it (#172)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,14 +145,14 @@ that merely ran.** The suite was green through all of them.
 
 ## Tests
 
-`npm test` — 19 suites, against the real exported functions with synthetic events. No sockets,
+`npm test` — 20 suites, against the real exported functions with synthetic events. No sockets,
 no production state, no writes outside a temp dir.
 
-boot · egress catalogue · egress ban · durable dedup store · relay fan-out · quarantine gating · deletion propagation · sealed-lane rate caps · grant
+suite roster · boot · egress catalogue · egress ban · durable dedup store · relay fan-out · quarantine gating · deletion propagation · sealed-lane rate caps · grant
 admission · message rendering · deployed-build verification · return lane · return-lane scan ·
 return-lane no-miss · relay ingress · tripwire union · tripwire detection drill · deploy runner · console Host check
 
-CI runs them on push and PR. **If a run reports fewer than 19, the branch is on a stale base.**
+CI runs them on push and PR. **If a run reports fewer than 20, the branch is on a stale base.**
 The count of record is the `test` script in `package.json`; a prose count that disagrees with it
 is the prose being wrong.
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ against what git says, because a stale build is invisible while every status sur
 
 ## Tests
 
-`npm test` runs 19 suites against the **real** exported functions with synthetic events — no
+`npm test` runs 20 suites against the **real** exported functions with synthetic events — no
 sockets, no production state:
 
 boot · egress catalogue · egress ban · durable dedup store · relay fan-out · quarantine gating · deletion propagation · sealed-lane rate caps · grant

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -120,7 +120,7 @@ in [deploy/README.md](../deploy/README.md).
 - **Publish the agent relay list:** `node tools/publish_relay_list.mjs` (so the identity
   is discoverable).
 - **Admit a participant**, if you want one: `sh tools/grant-setup.sh`.
-- **Run the safety gates before you ship:** `npm test` — 19 suites driving the real
+- **Run the safety gates before you ship:** `npm test` — 20 suites driving the real
   routing functions with synthetic events (no sockets, no production state), all green.
 
 `waggle-init.mjs --check` rolls the config half of this into one readiness verdict; the

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "start": "node src/bridge.mjs",
     "dryrun": "FORWARD_MODE=dryrun node src/bridge.mjs",
     "lint": "eslint src tools tests",
-    "test": "node tests/boot.mjs && node tests/egress_catalogue.mjs && node tests/egress_ban.mjs && node tests/relay_fanout.mjs && node tests/durable_store.mjs && node tests/a1_quarantine.mjs && node tests/a7_deletion.mjs && node tests/lane2_caps.mjs && node tests/nipda_admission.mjs && node tests/render_states.mjs && node tests/deploy_verify.mjs && node tests/return_lane.mjs && node tests/return_lane_scan.mjs && node tests/return_lane_nomiss.mjs && node tests/relay_ingress.mjs && node tests/tripwire_union.mjs && node tests/tripwire_detection.mjs && node tests/deploy_runner.mjs && node tests/console_host.mjs",
+    "test": "node tests/suite_count.mjs && node tests/boot.mjs && node tests/egress_catalogue.mjs && node tests/egress_ban.mjs && node tests/relay_fanout.mjs && node tests/durable_store.mjs && node tests/a1_quarantine.mjs && node tests/a7_deletion.mjs && node tests/lane2_caps.mjs && node tests/nipda_admission.mjs && node tests/render_states.mjs && node tests/deploy_verify.mjs && node tests/return_lane.mjs && node tests/return_lane_scan.mjs && node tests/return_lane_nomiss.mjs && node tests/relay_ingress.mjs && node tests/tripwire_union.mjs && node tests/tripwire_detection.mjs && node tests/deploy_runner.mjs && node tests/console_host.mjs",
     "console": "node tools/serve-console.mjs"
   },
   "dependencies": {

--- a/tests/suite_count.mjs
+++ b/tests/suite_count.mjs
@@ -1,0 +1,74 @@
+// tests/suite_count.mjs — the suite roster is a constant maintained by hand, so check it (#172).
+//
+// `CLAUDE.md` makes the number load-bearing:
+//
+//   "If a run reports fewer than N, the branch is on a stale base."
+//
+// That is a stale-base detector whose calibration was maintained by hand, and it drifted four
+// times in two days. When it is wrong it does not fail loudly — it sits quiet through exactly the
+// situation it exists to catch, which is this repo's own rule about an alarm that always fires and
+// one that never fires failing identically.
+//
+// Three things must agree, and the interesting one is the second:
+//
+//   1. every invocation in package.json's `test` script names a file that exists
+//   2. every tests/*.mjs on disk is INVOKED — an orphan test file is worse than a missing one,
+//      because it looks like coverage in the tree and runs nowhere
+//   3. every prose count (CLAUDE.md, README.md, GETTING_STARTED.md) equals the invocation count
+//
+// This file counts itself, which is consistent rather than clever: it is invoked from the same
+// script it reads.
+import { readdirSync, readFileSync, existsSync } from 'node:fs'
+import { join, dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+let fails = 0
+const ok = (name, cond, detail = '') => {
+  console.log(`${cond ? 'ok  ' : 'FAIL'} — ${name}${cond || !detail ? '' : ` — ${detail}`}`)
+  if (!cond) fails++
+}
+
+const pkg = JSON.parse(readFileSync(join(ROOT, 'package.json'), 'utf8'))
+const script = pkg.scripts.test
+
+// The invocation roster, in script order.
+const invoked = [...script.matchAll(/node\s+(tests\/[\w.-]+\.mjs)/g)].map(m => m[1])
+const onDisk = readdirSync(join(ROOT, 'tests')).filter(f => f.endsWith('.mjs')).map(f => `tests/${f}`)
+
+console.log(`suite roster: ${invoked.length} invocation(s), ${onDisk.length} file(s) on disk`)
+
+// 1. No invocation may name a file that does not exist — that fails at run time anyway, but it
+//    fails as a confusing "cannot find module" rather than as a roster problem.
+const ghosts = invoked.filter(f => !existsSync(join(ROOT, f)))
+ok('every invoked suite exists on disk', ghosts.length === 0, `missing: ${ghosts.join(', ')}`)
+
+// 2. An ORPHAN is the failure worth catching: a test file sitting in the tree, looking like
+//    coverage, that no run ever executes. It cannot go red because it never goes anywhere.
+const orphans = onDisk.filter(f => !invoked.includes(f))
+ok('every test file on disk is actually invoked (no orphans)', orphans.length === 0, `never run: ${orphans.join(', ')}`)
+
+// 3. Duplicates would inflate the count without adding coverage.
+const dupes = invoked.filter((f, i) => invoked.indexOf(f) !== i)
+ok('no suite is invoked twice', dupes.length === 0, `duplicated: ${[...new Set(dupes)].join(', ')}`)
+
+// 4. Every restated count must equal the roster. This is the drift the issue documents: four
+//    hand-syncs in two days, and on the last one the README's roster listed 17 while claiming 19.
+const N = invoked.length
+const DOCS = ['CLAUDE.md', 'README.md', 'docs/GETTING_STARTED.md']
+for (const rel of DOCS) {
+  const path = join(ROOT, rel)
+  if (!existsSync(path)) { ok(`${rel}: present`, false, 'file missing'); continue }
+  const text = readFileSync(path, 'utf8')
+  const claims = [...text.matchAll(/(\d+)\s+suites/g)].map(m => Number(m[1]))
+  const floors = [...text.matchAll(/fewer than\s+(\d+)/g)].map(m => Number(m[1]))
+  const wrong = [...claims, ...floors].filter(n => n !== N)
+  if (!claims.length && !floors.length) {
+    ok(`${rel}: states no count (nothing to drift)`, true)
+  } else {
+    ok(`${rel}: every stated count is ${N}`, wrong.length === 0, `found ${[...new Set(wrong)].join(', ')}`)
+  }
+}
+
+console.log(fails ? `\nsuite_count: ${fails} FAILED` : '\nsuite_count: all checks passed')
+process.exit(fails ? 1 : 0)


### PR DESCRIPTION
Closes #172.

The count has drifted four times in two days. Every fix was correct and every fix was manual — the definition of a constant that wants a check. And `CLAUDE.md` makes it load-bearing:

> **If a run reports fewer than N, the branch is on a stale base.**

That's a stale-base detector calibrated by hand. When it's wrong it doesn't fail loudly; it sits quiet through exactly the situation it exists to catch — this repo's own rule about an alarm that always fires and one that never fires failing identically.

## What it asserts

- **every invocation names a file that exists** — otherwise it fails at run time as a confusing `cannot find module` rather than as a roster problem
- **every `tests/*.mjs` on disk is invoked** — the one worth having. An orphan test file *looks like coverage in the tree and runs nowhere*, and it can never go red because it never goes anywhere.
- **no suite is invoked twice** — a duplicate inflates the number without adding coverage
- **every restated count agrees** — `CLAUDE.md`, `README.md`, `GETTING_STARTED.md`, including the `fewer than N` floor, which *is* the stale-base detector

It counts itself, which is consistent rather than clever: it's invoked from the same script it reads.

## Negative controls

Both halves watched failing on purpose:

```
FAIL — CLAUDE.md: every stated count is 20 — found 19
FAIL — every test file on disk is actually invoked (no orphans) — never run: tests/__orphan_control__.mjs
```

Roster is now 20 and the three docs are synced — for the last time by hand.

Drafted with assistance from [Claude Code](https://claude.com/claude-code)