### PR TITLE
deploy-runner: record DEPLOYED_SHA only after verify passes (#136)

### DIFF
--- a/deploy/deploy-runner.sh
+++ b/deploy/deploy-runner.sh
@@ -170,19 +170,34 @@ log "shipping code into $TREE"
 log "installing deps in $TREE"
 ( cd "$TREE" && sh -c "$NPM_CMD" ) || { alarm "dependency install failed in $TREE"; exit 1; }
 
-# record the SHA atomically BEFORE restart, so a crash mid-restart still leaves the tree's
-# provenance truthful for the next verify.
-printf '%s\n' "$TARGET_SHA" > "$TREE/DEPLOYED_SHA.tmp" && mv "$TREE/DEPLOYED_SHA.tmp" "$TREE/DEPLOYED_SHA"
-
 log "restarting $UNIT"
 sh -c "$RESTART_CMD \"$UNIT\"" || { alarm "restart of $UNIT failed"; exit 1; }
 
 # --- post-deploy: what is on disk MUST equal git at the sha we shipped -------------------
 log "verifying deployed tree against $SHORT"
 if sh "$HUB/deploy/verify-deployed.sh" "$LANE" "$TREE" "$TARGET_SHA"; then
+  # DEPLOYED_SHA is written ONLY here — after verify passes (#136).
+  #
+  # It used to be written before the restart, reasoning that a crash mid-restart should still
+  # leave the tree's provenance truthful. That ordering costs more than it buys: if verify FAILS,
+  # the file already claims success, so the next tick reads "already current", skips, and a
+  # PERSISTENT DRIFT ALARMS EXACTLY ONCE. An alarm that fires once for an ongoing fault reads as
+  # handled — the same shape this repo keeps re-learning.
+  #
+  # Writing it only on a verified deploy self-heals instead. A crash anywhere before this line
+  # leaves the old SHA, so the next tick re-deploys: rsync is idempotent, the dep install is
+  # idempotent, and a redundant restart costs seconds. The tree is re-verified and the alarm
+  # repeats every tick until someone fixes it, which is what a standing fault should do.
+  #
+  # The trade, stated: provenance becomes "last VERIFIED sha" rather than "last shipped sha".
+  # That is the more useful of the two — it is the question verify-deployed.sh asks anyway.
+  printf '%s\n' "$TARGET_SHA" > "$TREE/DEPLOYED_SHA.tmp" && mv "$TREE/DEPLOYED_SHA.tmp" "$TREE/DEPLOYED_SHA"
   log "deploy OK — $TREE now at $SHORT, verified"
   exit 0
 else
   alarm "post-deploy drift at $SHORT — deployed tree does NOT match git; investigate now"
+  # Deliberately does not quote the skip-path wording: a log line that contains the phrase a
+  # grep looks for is a log line that defeats the grep.
+  alarm "DEPLOYED_SHA left unchanged, so the next tick re-deploys and re-alarms rather than skipping this tree as up to date"
   exit 1
 fi

--- a/tests/deploy_runner.mjs
+++ b/tests/deploy_runner.mjs
@@ -147,6 +147,36 @@ try {
   check(d.code === 1, 'post-deploy drift -> exit 1')
   check(/ALARM/.test(d.out) && /drift/i.test(d.out), 'drift -> ALARM emitted, not a silent pass')
 
+  // (6b) #136 — a FAILED verify must NOT record the SHA, and the fault must alarm on EVERY tick.
+  //
+  // This is the property the whole issue rests on. The SHA used to be written before verify, so
+  // a tree that failed verification still claimed success: the next tick read "already current",
+  // skipped, and a standing drift alarmed exactly ONCE. An alarm that fires once for an ongoing
+  // fault is indistinguishable from one that was handled.
+  check(!existsSync(join(d.tree, 'DEPLOYED_SHA')),
+    'drift -> DEPLOYED_SHA NOT recorded (an unverified deploy is not a deploy)')
+
+  // Second tick against the SAME broken tree: it must re-deploy and re-alarm, never go quiet.
+  const d2 = (() => {
+    const env = {
+      ...process.env, WB_HUB: hub, WB_TREE: d.tree, WB_REF: TARGET, WB_NO_FETCH: '1',
+      STUB_CI_STATE: 'success', WB_CI_STATE_CMD: 'echo "$STUB_CI_STATE" #',
+      WB_NPM_CMD: 'printf "\\n// injected drift\\n" >> src/bridge.mjs',
+      WB_RESTART_CMD: 'true #',
+    }
+    try {
+      return { code: 0, out: execFileSync('sh', ['-c', `sh "${SCRIPT}" read 2>&1`], { cwd: REPO, env, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }) }
+    } catch (e) { return { code: e.status ?? 1, out: (e.stdout || '') + (e.stderr || '') } }
+  })()
+  check(d2.code === 1, 'drift, second tick -> STILL exit 1 (a standing fault keeps failing)')
+  check(/ALARM/.test(d2.out), 'drift, second tick -> alarms AGAIN, not once')
+  // Assert the POSITIVE — that it re-shipped — rather than the absence of the skip wording. A
+  // first draft checked !/already current/ and failed against the runner's own alarm text, which
+  // quotes that phrase: a negative string assertion is only as good as every other string in the
+  // output, and this repo has an alarm whose job is to mention the thing it prevented.
+  check(/shipping code into/.test(d2.out),
+    'drift, second tick -> re-deploys instead of skipping the tree as up to date')
+
   // (7) WB_TREE unset (every production run) must not trip `set -e` on the override guard.
   // DRY_RUN so it resolves + gates green, then reports, without writing to the real /opt tree.
   let dc = 0, dOut = ''


### PR DESCRIPTION
Closes #136.

## The bug

`DEPLOYED_SHA` was written **before** the restart, and therefore before verify. So a tree that *failed* verification still claimed success — the next tick read "already current", skipped, and **a standing drift alarmed exactly once.**

An alarm that fires once for an ongoing fault is indistinguishable from one that was handled. That's the same shape as a detector that never fires.

## The fix

Write it only on the verified path. A crash anywhere before that line leaves the old SHA, so the next tick simply re-deploys — `rsync` is idempotent, the dep install is idempotent, a redundant restart costs seconds — then re-verifies and re-alarms. A standing fault keeps failing, which is what it should do.

The old comment was protecting something real (*"a crash mid-restart should leave provenance truthful"*), so it's answered rather than ignored: **provenance becomes "last VERIFIED sha" instead of "last shipped sha"** — which is the question `verify-deployed.sh` is asking anyway.

## The property nothing tested

The existing drift case checked exit 1 and an ALARM on the *first* tick. The issue is entirely about the *second*. Four new checks:

- a failed verify records **no** SHA
- second tick against the same broken tree → still exit 1
- second tick → alarms **again**
- second tick → **re-ships** rather than skipping

Restoring the old ordering turns all four red.

## One thing worth keeping in the record

My first version of the second-tick check asserted `!/already current/` — and **failed against the runner's own alarm text**, because I'd written an alarm that quoted the phrase it was preventing.

Two fixes, both worth having: the alarm no longer quotes the skip-path wording (a log line containing the phrase a grep looks for is a log line that defeats the grep), and the check now asserts the **positive** — that it re-shipped. A negative string assertion is only as good as every other string in the output.

`npm run lint` clean · `npm test` **19/19**. No suite added, so no count conflict with #178/#179.

Not merging this myself, per #177.

---

Drafted with assistance from [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pj7AyMK4XPsib7tdR8P8JB)_