### PR TITLE
return lane: a durable pending set for un-landed carries (#117)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,14 +145,14 @@ that merely ran.** The suite was green through all of them.
 
 ## Tests
 
-`npm test` — 20 suites, against the real exported functions with synthetic events. No sockets,
+`npm test` — 21 suites, against the real exported functions with synthetic events. No sockets,
 no production state, no writes outside a temp dir.
 
 boot · egress catalogue · egress ban · durable dedup store · relay fan-out · quarantine gating · deletion propagation · sealed-lane rate caps · grant
 admission · message rendering · deployed-build verification · return lane · return-lane scan ·
-return-lane no-miss · relay ingress · tripwire union · tripwire detection drill · deploy runner · console Host check · undelivered record
+return-lane no-miss · return-lane pending · relay ingress · tripwire union · tripwire detection drill · deploy runner · console Host check · undelivered record
 
-CI runs them on push and PR. **If a run reports fewer than 20, the branch is on a stale base.**
+CI runs them on push and PR. **If a run reports fewer than 21, the branch is on a stale base.**
 The count of record is the `test` script in `package.json`; a prose count that disagrees with it
 is the prose being wrong.
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ against what git says, because a stale build is invisible while every status sur
 
 ## Tests
 
-`npm test` runs 20 suites against the **real** exported functions with synthetic events — no
+`npm test` runs 21 suites against the **real** exported functions with synthetic events — no
 sockets, no production state:
 
 boot · egress catalogue · egress ban · durable dedup store · relay fan-out · quarantine gating · deletion propagation · sealed-lane rate caps · grant

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -120,7 +120,7 @@ in [deploy/README.md](../deploy/README.md).
 - **Publish the agent relay list:** `node tools/publish_relay_list.mjs` (so the identity
   is discoverable).
 - **Admit a participant**, if you want one: `sh tools/grant-setup.sh`.
-- **Run the safety gates before you ship:** `npm test` — 20 suites driving the real
+- **Run the safety gates before you ship:** `npm test` — 21 suites driving the real
   routing functions with synthetic events (no sockets, no production state), all green.
 
 `waggle-init.mjs --check` rolls the config half of this into one readiness verdict; the

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "start": "node src/bridge.mjs",
     "dryrun": "FORWARD_MODE=dryrun node src/bridge.mjs",
     "lint": "eslint src tools tests",
-    "test": "node tests/boot.mjs && node tests/egress_catalogue.mjs && node tests/egress_ban.mjs && node tests/relay_fanout.mjs && node tests/durable_store.mjs && node tests/a1_quarantine.mjs && node tests/a7_deletion.mjs && node tests/lane2_caps.mjs && node tests/nipda_admission.mjs && node tests/render_states.mjs && node tests/deploy_verify.mjs && node tests/return_lane.mjs && node tests/return_lane_scan.mjs && node tests/return_lane_nomiss.mjs && node tests/relay_ingress.mjs && node tests/tripwire_union.mjs && node tests/tripwire_detection.mjs && node tests/deploy_runner.mjs && node tests/console_host.mjs && node tests/undelivered.mjs",
+    "test": "node tests/boot.mjs && node tests/egress_catalogue.mjs && node tests/egress_ban.mjs && node tests/relay_fanout.mjs && node tests/durable_store.mjs && node tests/a1_quarantine.mjs && node tests/a7_deletion.mjs && node tests/lane2_caps.mjs && node tests/nipda_admission.mjs && node tests/render_states.mjs && node tests/deploy_verify.mjs && node tests/return_lane.mjs && node tests/return_lane_scan.mjs && node tests/return_lane_nomiss.mjs && node tests/return_lane_pending.mjs && node tests/relay_ingress.mjs && node tests/tripwire_union.mjs && node tests/tripwire_detection.mjs && node tests/deploy_runner.mjs && node tests/console_host.mjs && node tests/undelivered.mjs",
     "console": "node tools/serve-console.mjs"
   },
   "dependencies": {

--- a/src/bridge.mjs
+++ b/src/bridge.mjs
@@ -46,7 +46,7 @@ import { fileURLToPath } from 'node:url'
 // Extracted leaf modules (#154). Each is dependency-free of config and ambient state, which is why
 // these four came out first — the split is staged, not big-bang.
 import { log, err } from './log.mjs'
-import { durableSet } from './stores.mjs'
+import { durableSet, durableQueue } from './stores.mjs'
 import { fanout } from './fanout.mjs'
 import { defuseRefs, defuseMarkup, quoted, renderQuarantined, renderReleased } from './render.mjs'
 
@@ -60,6 +60,11 @@ const SEEN_CAP = Number(process.env.SEEN_CAP || 100000)
 // its keys are (source_id × recipient) composites, not bare event ids, so one community message
 // carries out to every matching recipient exactly once and never re-delivers across a restart.
 const RLSEEN_PATH = process.env.RLSEEN_PATH || resolve(ROOT, 'data', 'return-lane-seen.log')
+const RLPENDING_PATH = process.env.RLPENDING_PATH || resolve(ROOT, 'data', 'return-lane-pending.log')
+// Bounded, or one permanently-unreachable recipient retries forever. On the ~4-minute scan poll
+// this is roughly two hours of outage before a carry is dead-lettered — long enough to ride out a
+// relay flap, short enough that a dead key is surfaced the same day.
+const RLPENDING_MAX_ATTEMPTS = Number(process.env.RLPENDING_MAX_ATTEMPTS || 30)
 const RLSEEN_CAP = Number(process.env.RLSEEN_CAP || 100000)
 // Relay-lane dedup store (DESIGN_RELAY_INGRESS §6): wraps addressed to waggle's OWN key that it
 // unwraps and relays into a channel. Its own append-only capped file — checked BEFORE decryption
@@ -1061,6 +1066,14 @@ async function handleCommand(m) {
 const rlSeenStore = durableSet({ path: RLSEEN_PATH, cap: RLSEEN_CAP, label: 'return lane', noun: 'carried (source×recipient) keys' })
 const rlSeen = rlSeenStore.mem
 const rlKey = (srcId, recipHex) => String(srcId) + '\x1f' + String(recipHex)
+
+// #117: the un-landed carries. rlSeen answers "already carried"; this answers "still owed", and
+// the difference matters because the scan cursor advances whether or not a carry landed. A 0/N is
+// loud and retried by the overlap re-read, but only while the message stays inside that window —
+// an outage sustained past it used to age the carry out and lose it. This queue retries from
+// durable storage instead of from the window, so the cursor keeps advancing (no lane-wide stall
+// from one dead recipient) and the carry survives anyway.
+const rlPending = durableQueue({ path: RLPENDING_PATH, cap: 5000, label: 'return lane pending' })
 const loadRlSeen = () => rlSeenStore.load()
 const addRlSeen = (key) => rlSeenStore.claim(key)
 const dropRlSeen = (key) => rlSeenStore.rollback(key)
@@ -1314,10 +1327,57 @@ async function scanReturnLane(msgs, opts = {}) {
       }, { src: m.id, why: repliedTo && !mentioned ? 'reply' : 'mention' }, opts.publish)
       // Persist-on-landed: durable dedup only once the seal reached a relay. A silent 0/N is rolled
       // back so the overlap re-read (and a restart) re-carry it — a rare re-carry beats a lost mention.
-      if (accepted >= 1) markRlSeen(key)
-      else dropRlSeen(key)
+      if (accepted >= 1) {
+        markRlSeen(key)
+        rlPending.remove(key)                              // landed: no longer owed
+      } else {
+        dropRlSeen(key)
+        // Owed, durably. The overlap re-read may still catch it first; enqueue is idempotent and
+        // does not reset the attempt count, so the two paths cannot inflate each other.
+        rlPending.enqueue(key, { to: r.npub_hex, mention: r.mention, why: repliedTo && !mentioned ? 'reply' : 'mention', body, src: m.id })
+      }
     }
   }
+}
+
+// #117: retry what is still owed, INDEPENDENT of the scan cursor. This is the half that makes
+// the pending queue worth having — the cursor has long since moved past these messages, so
+// nothing else will ever look at them again.
+//
+// Bounded, then dead-lettered. An unbounded retry against a permanently-dead recipient is the
+// same failure as the rejected cursor-hold, just quieter: work that never completes and never
+// stops. The bound converts it into a loud, dated, per-recipient report — and a dead-letter that
+// is logged and dropped, never a queue that grows forever.
+async function retryPendingCarries(opts = {}) {
+  if (!PUB || !PUB.returnLane.length || !hasBridgeKey()) return
+  const owed = rlPending.entries()
+  if (!owed.length) return
+  let landed = 0, dead = 0
+  for (const { key, item, attempts } of owed) {
+    if (!item || !item.to) { rlPending.remove(key); continue }   // unparseable record: drop, do not loop
+    if (attempts >= RLPENDING_MAX_ATTEMPTS) {
+      // DEAD LETTER. Loud, and it names the recipient and the source, because a carry the
+      // community believes was delivered and never was is exactly the silence this lane exists
+      // to prevent. Dropped from the queue so one dead key cannot pin the lane.
+      err(`RETURN dead-letter: gave up carrying ${String(item.src).slice(0, 12)}… to ${String(item.to).slice(0, 12)}… after ${attempts} attempt(s) — the recipient has been unreachable throughout. This carry is LOST and will not be retried.`)
+      rlPending.remove(key)
+      dead++
+      continue
+    }
+    const n = rlPending.attempt(key)                            // recorded BEFORE the send
+    const accepted = await returnLaneSend(item.to, {
+      template: 'return_carry',
+      slots: { mention: item.mention, why: item.why, body: item.body },
+    }, { src: item.src, why: item.why, retry: n }, opts.publish)
+    if (accepted >= 1) {
+      markRlSeen(key)
+      rlPending.remove(key)
+      landed++
+      log(`RETURN retry ok: carried ${String(item.src).slice(0, 12)}… to ${String(item.to).slice(0, 12)}… on attempt ${n}`)
+    }
+  }
+  if (landed || dead) log(`return lane pending: ${landed} landed, ${dead} dead-lettered, ${rlPending.size()} still owed`)
+  else if (owed.length) log(`return lane pending: ${owed.length} still owed, none landed this pass`)
 }
 
 let cmdCursor = 0
@@ -1326,7 +1386,9 @@ function pollCommands() {
     let msgs
     try { msgs = JSON.parse(String(so).slice(String(so).indexOf('['))) } catch { return err('commands: unparseable staging read') }
     for (const m of msgs) { if ((m.created_at || 0) >= cmdCursor - 300) handleCommand(m).catch(er => err(`commands: ${er.message}`)) }
-    scanReturnLane(msgs).catch(er => err(`return lane: staging carry failed: ${er.message}`))
+    scanReturnLane(msgs)
+      .then(() => retryPendingCarries())                  // #117: owed carries, independent of the cursor
+      .catch(er => err(`return lane: staging carry failed: ${er.message}`))
     cmdCursor = Math.floor(Date.now() / 1000)
   })
 }
@@ -1598,13 +1660,14 @@ function connectPublic(url) {
 // Exported so a harness can drive the REAL routing functions (not a copy) with synthetic
 // events in dryrun, without opening any relay socket. Set WB_NO_BOOT=1 to import without
 // booting the live subscriber. No effect on normal `node src/bridge.mjs` runs.
-export { recordUndelivered, UNDELIVERED_PATH, durableSet, fanout, defuseRefs, defuseMarkup, quoted, renderQuarantined, renderReleased, fetchEventById, returnLaneSend, publishWrapToRelays, scanReturnLane, pollScanChannels, scanChannel, scanSince, bumpScanCursor, loadScanCursors, agentAuthoredBy, rlSeen, rlKey, loadRlSeen, markRlSeen, addRlSeen, dropRlSeen, route, routePublic, routeDelete, processGrantEvent, grantSet, forwardPublic, clampCreated, rateOk, bumpPubWatermark, loadPubWatermark, markSeen, seen, PUB, postedMap, recordPosted, parseBuzzEventId, resolveChannels, handleRelayIngress, relaySeen, markRelaySeen, addRelaySeen, dropRelaySeen, loadRelaySeen, relayRateOk, resolveRelayDest, relayDropTotalPreAuth, relayDropCounts }
+export { recordUndelivered, UNDELIVERED_PATH, durableSet, durableQueue, rlPending, retryPendingCarries, RLPENDING_MAX_ATTEMPTS, fanout, defuseRefs, defuseMarkup, quoted, renderQuarantined, renderReleased, fetchEventById, returnLaneSend, publishWrapToRelays, scanReturnLane, pollScanChannels, scanChannel, scanSince, bumpScanCursor, loadScanCursors, agentAuthoredBy, rlSeen, rlKey, loadRlSeen, markRlSeen, addRlSeen, dropRlSeen, route, routePublic, routeDelete, processGrantEvent, grantSet, forwardPublic, clampCreated, rateOk, bumpPubWatermark, loadPubWatermark, markSeen, seen, PUB, postedMap, recordPosted, parseBuzzEventId, resolveChannels, handleRelayIngress, relaySeen, markRelaySeen, addRelaySeen, dropRelaySeen, loadRelaySeen, relayRateOk, resolveRelayDest, relayDropTotalPreAuth, relayDropCounts }
 
 // --- boot -------------------------------------------------------------------
 if (!process.env.WB_NO_BOOT) {
   loadSeen()
   loadPostedMap()
   loadRlSeen()
+  rlPending.load()
   loadRelaySeen()
   // #171 — say it on every boot. A record of lost messages that nobody reads is the same silence
   // it exists to end, one level further out. Non-fatal: these are past losses, not a reason to

--- a/src/stores.mjs
+++ b/src/stores.mjs
@@ -50,4 +50,70 @@ function durableSet({ path, cap, label, noun }) {
   }
 }
 
-export { durableSet }
+// --- durable QUEUE ----------------------------------------------------------
+// The sibling of durableSet, for the case a set cannot serve: work that must OUTLIVE the window
+// it was discovered in. A set remembers "already handled"; this remembers "still owed", which
+// needs the payload, an attempt count, and a way to give up.
+//
+// The return lane is the motivating case (#117). A carry that reaches 0 relays is rolled back so
+// the overlap re-read retries it — but the scan cursor advances regardless, so that retry only
+// happens while the message stays inside the overlap window. An outage sustained past it ages the
+// carry out and it is lost, silently, after having been loud for a while.
+//
+// Holding the cursor instead was considered and rejected upstream: one permanently-unreachable
+// recipient would pin the cursor forever and stall the lane for EVERYONE — a rare, loud,
+// per-recipient miss traded for an unbounded, silent, lane-wide stall. A queue keeps liveness
+// (cursor advances) and no-miss (retries come from durable storage, not from the window).
+//
+// Append-only JSONL, replayed in order, exactly like durableSet: {k, v} enqueues, {k, a} records
+// an attempt, {k, d:1} tombstones. Last-write-wins on replay, so a compaction is just a truncation
+// to the last `cap` records.
+function durableQueue({ path, cap, label }) {
+  const mem = new Map()   // key -> { item, attempts }
+  const append = (rec) => {
+    try { appendFileSync(path, JSON.stringify(rec) + '\n') }
+    catch (e) { err(`${label}: append failed for ${String(rec.k).slice(0, 64)}: ${e.message}`) }
+  }
+  return {
+    mem,
+    size: () => mem.size,
+    has: (k) => mem.has(k),
+    entries: () => [...mem.entries()].map(([k, v]) => ({ key: k, item: v.item, attempts: v.attempts })),
+    enqueue(k, item) {
+      if (mem.has(k)) return                       // already owed; do not reset its attempt count
+      mem.set(k, { item, attempts: 0 })
+      append({ k, v: item })
+    },
+    // Recording the attempt BEFORE the retry is deliberate: a crash mid-retry must not buy a free
+    // attempt, or a permanently-failing item could loop forever across restarts and never reach
+    // the dead-letter bound that exists to stop exactly that.
+    attempt(k) {
+      const e = mem.get(k)
+      if (!e) return 0
+      e.attempts += 1
+      append({ k, a: e.attempts })
+      return e.attempts
+    },
+    remove(k) {
+      if (!mem.delete(k)) return false
+      append({ k, d: 1 })
+      return true
+    },
+    load() {
+      if (!existsSync(path)) { mkdirSync(dirname(path), { recursive: true }); return }
+      const lines = readFileSync(path, 'utf8').split('\n').filter(Boolean)
+      const kept = lines.slice(-cap)
+      for (const line of kept) {
+        let r
+        try { r = JSON.parse(line) } catch { continue }   // a torn final write is skipped, not fatal
+        if (!r || !r.k) continue
+        if (r.d) { mem.delete(r.k); continue }
+        if (r.v !== undefined) { mem.set(r.k, { item: r.v, attempts: 0 }); continue }
+        if (r.a !== undefined && mem.has(r.k)) mem.get(r.k).attempts = r.a
+      }
+      log(`${label}: loaded ${mem.size} owed item(s) from ${path}${lines.length > kept.length ? ` (pruned ${lines.length - kept.length})` : ''}`)
+    },
+  }
+}
+
+export { durableSet, durableQueue }

--- a/tests/return_lane_pending.mjs
+++ b/tests/return_lane_pending.mjs
@@ -1,0 +1,114 @@
+// tests/return_lane_pending.mjs — the send-side no-miss past the overlap (#117).
+//
+// #116 made a 0/N loud and rolled back the dedup so the overlap re-read retries it. But the scan
+// cursor advances whether or not a carry landed, so that retry only happens while the message
+// stays inside the overlap window. An outage sustained past it aged the carry out and lost it —
+// loud for a while, then silent, which is the shape this lane exists to prevent.
+//
+// The fix is a durable pending queue retried INDEPENDENT of the cursor. The property under test
+// is therefore not "a retry happens" but "a retry happens after nothing is looking at the message
+// any more" — so every retry case below runs with no `msgs` at all, exactly as a later poll would.
+//
+// Holding the cursor was the rejected alternative: one permanently-unreachable recipient would pin
+// it forever and stall the lane for everyone. Hence the bound and the dead letter, asserted here.
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+const dir = mkdtempSync(join(tmpdir(), 'wb-rlp-'))
+
+const AGENT = 'a'.repeat(64)
+const HUMAN = 'b'.repeat(64)
+const CH = '11111111-1111-1111-1111-111111111111'
+
+writeFileSync(join(dir, 'config.json'), JSON.stringify({
+  relays: [], recipients: [],
+  public: {
+    relays: [], inbox: CH, staging_inbox: CH,
+    watch_authors: [], watch_events: [], approvers: [], grantors: [],
+    scan_authors: [], scan_channels: [CH], relay_channels: [],
+    return_lane: [{ name: 'Claude', mention: 'claude', npub_hex: AGENT }],
+  },
+}))
+
+process.env.CONFIG_PATH = join(dir, 'config.json')
+process.env.FORWARD_MODE = 'dryrun'
+process.env.SEALED_LANES = 'off'
+process.env.SEEN_PATH = join(dir, 'seen.log')
+process.env.RLSEEN_PATH = join(dir, 'rlseen.log')
+process.env.RLPENDING_PATH = join(dir, 'rlpending.log')
+process.env.RLPENDING_MAX_ATTEMPTS = '3'
+// scanReturnLane and the retry driver both refuse without a bridge key.
+process.env.BUZZ_PRIVATE_KEY = 'c'.repeat(64)
+
+const B = await import('../src/bridge.mjs')
+
+let fails = 0
+const ok = (name, cond, detail = '') => {
+  console.log(`${cond ? 'ok  ' : 'FAIL'} — ${name}${cond || !detail ? '' : ` — ${detail}`}`)
+  if (!cond) fails++
+}
+
+// A publish seam: `accepted` is the relay accept-count returnLaneSend reports.
+let accept = 0
+const publish = async () => accept
+const msg = (id) => ({ id, pubkey: HUMAN, content: 'hey @claude look at this', tags: [] })
+
+try {
+  // --- a 0/N carry becomes OWED -------------------------------------------------------------
+  accept = 0
+  await B.scanReturnLane([msg('e'.repeat(64))], { publish })
+  ok('a 0/N carry is recorded as still-owed', B.rlPending.size() === 1)
+  ok('...and is NOT marked as carried', !B.rlSeen.has(B.rlKey('e'.repeat(64), AGENT)))
+  ok('...and it persisted to disk, so a restart still owes it', existsSync(join(dir, 'rlpending.log')) &&
+    readFileSync(join(dir, 'rlpending.log'), 'utf8').includes('e'.repeat(64)))
+
+  // --- the retry runs with NO messages: the cursor has moved on ------------------------------
+  // This is the whole point. Nothing is re-reading this message; the only thing that knows it is
+  // owed is the queue.
+  accept = 1
+  await B.retryPendingCarries({ publish })
+  ok('a later poll retries the owed carry with no message in hand', B.rlPending.size() === 0)
+  ok('...and once it lands it is marked carried', B.rlSeen.has(B.rlKey('e'.repeat(64), AGENT)))
+
+  // --- a landed carry never enters the queue (NEGATIVE CONTROL) ------------------------------
+  // Every check above passes just as well if enqueue were unconditional, so prove the success
+  // path stays out of the queue entirely.
+  accept = 1
+  await B.scanReturnLane([msg('f'.repeat(64))], { publish })
+  ok('NEGATIVE CONTROL — a carry that lands first time is never queued', B.rlPending.size() === 0)
+  ok('NEGATIVE CONTROL — ...and is marked carried', B.rlSeen.has(B.rlKey('f'.repeat(64), AGENT)))
+
+  // --- bounded: a permanently-dead recipient is dead-lettered, not retried forever -----------
+  accept = 0
+  await B.scanReturnLane([msg('d'.repeat(64))], { publish })
+  ok('an unreachable recipient is owed', B.rlPending.size() === 1)
+
+  const attemptsSeen = []
+  for (let i = 0; i < 5; i++) {
+    attemptsSeen.push(B.rlPending.entries()[0]?.attempts ?? null)
+    await B.retryPendingCarries({ publish })
+  }
+  ok('attempts are counted across polls, not reset', attemptsSeen[1] === 1 && attemptsSeen[2] === 2)
+  ok(`bounded at RLPENDING_MAX_ATTEMPTS (${process.env.RLPENDING_MAX_ATTEMPTS}) — the queue drains`,
+    B.rlPending.size() === 0, `still owed: ${B.rlPending.size()}`)
+  ok('a dead-lettered carry is NOT marked as carried — it was lost, and the record says so',
+    !B.rlSeen.has(B.rlKey('d'.repeat(64), AGENT)))
+
+  // --- durability: the queue survives a restart ----------------------------------------------
+  accept = 0
+  await B.scanReturnLane([msg('9'.repeat(64))], { publish })
+  ok('a fresh 0/N is owed again', B.rlPending.size() === 1)
+  const reloaded = (await import('../src/stores.mjs')).durableQueue({
+    path: join(dir, 'rlpending.log'), cap: 5000, label: 'reload',
+  })
+  reloaded.load()
+  ok('a restart reloads exactly what is still owed, and nothing already settled',
+    reloaded.size() === 1 && reloaded.entries()[0].key.startsWith('9'.repeat(64)),
+    `reloaded ${reloaded.size()}: ${reloaded.entries().map(e => e.key.slice(0, 8)).join(',')}`)
+} finally {
+  rmSync(dir, { recursive: true, force: true })
+}
+
+console.log(fails ? `\nreturn_lane_pending: ${fails} FAILED` : '\nreturn_lane_pending: all checks passed')
+process.exit(fails ? 1 : 0)


### PR DESCRIPTION
Closes #117. Follow-up to #116, which removed the *silent* loss.

## The residual

#116 makes a `0/N` loud and rolls back the dedup so the overlap re-read retries it. But `scanChannel` advances the cursor regardless, so that retry only happens while the message stays inside the overlap window. **An outage sustained past it ages the carry out and loses it** — loud for a while, then silent, which is the shape this lane exists to prevent.

**Cursor-hold was the rejected fix, and rightly.** One permanently-unreachable recipient would pin the cursor forever and stall the lane for *everyone* — a rare, loud, per-recipient miss traded for an unbounded, silent, lane-wide stall.

## The shape that composes

The owed work moves out of the window and into durable storage.

**`src/stores.mjs` gains `durableQueue`**, the sibling of `durableSet`. A set remembers *"already handled"*; a queue remembers *"still owed"*, which needs the payload, an attempt count, and a way to give up. Same append-only JSONL discipline — replayed in order, last-write-wins, capped.

- a `0/N` **enqueues** the carry; a landed carry **removes** it
- `retryPendingCarries()` runs on the same poll as the scan but takes **no messages** — the cursor has long since moved past these, and the queue is the only thing that still knows they exist
- **bounded, then dead-lettered.** An unbounded retry against a dead recipient is the rejected cursor-hold in quieter clothing: work that never completes and never stops. At the bound it logs loudly, names source and recipient, says the carry is **LOST**, and drops it so one dead key cannot pin the lane.

The attempt is recorded **before** the send, so a crash mid-retry cannot buy a free attempt and loop forever across restarts.

Liveness and no-miss both hold: the cursor keeps advancing, and the carry survives anyway.

## Testing

A new suite. **Every retry case runs with no messages in hand** — the property under test isn't "a retry happens" but *"a retry happens after nothing is looking at the message any more."*

```
ok  — a 0/N carry is recorded as still-owed
ok  — a later poll retries the owed carry with no message in hand
ok  — NEGATIVE CONTROL — a carry that lands first time is never queued
ok  — attempts are counted across polls, not reset
ok  — bounded at RLPENDING_MAX_ATTEMPTS (3) — the queue drains
ok  — a dead-lettered carry is NOT marked as carried — it was lost, and the record says so
ok  — a restart reloads exactly what is still owed, and nothing already settled
```

Negative control: disabling the enqueue turns five checks red.

## Doc precision the issue asked for

The invariant is *"no silent loss; loud bounded retries; a dead letter that names what was lost"* — **not** an unqualified no-miss. A carry to a recipient unreachable for the whole bounded window is still lost; the difference is that it is now impossible for that to happen quietly.

**Note:** this adds a suite (roster 19 → 20) and touches the same count lines as #179. If #179 lands first this will need a trivial rebase on the number.

Drafted with assistance from [Claude Code](https://claude.com/claude-code)