### PR TITLE
deploy: run the sealed lane as a non-root user (#134 step 6)

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -175,12 +175,10 @@ could be rsynced by one instance while the other had just moved it to a differen
 4. **read lane:** `sudo systemctl enable --now deploy-runner@read.timer`. It runs as
    `bridge`, which already owns `/opt/waggle-read` and holds the scoped `sudo systemctl
    restart waggle-read.service` grant (`deploy/sudoers-bridge`). No new authority.
-5. **sealed lane — get it off root in the same pass.** `/opt/waggle-sealed` is administered
-   as **root** today; do not deploy it as root. Create a scoped `deploy` user that owns the
-   sealed tree and `/opt/waggle-hub-sealed`, holding *only* `sudo systemctl restart
-   waggle-sealed.service`, add the drop-in from the unit header (`User=deploy`), then
-   `sudo systemctl enable --now deploy-runner@sealed.timer`. Now neither lane is deployed by
-   root, and no principal holds a general shell on production.
+5. **sealed lane — see "Sealed lane: off root, and its deploy runner" below.** It is a
+   separate pass with its own ordering (create the user, hand it the tree, restart the lane
+   as that user, *then* arm its runner), because moving a running lane off root is the part
+   that can leave it down if the steps are taken out of order.
 6. Confirm — by reading the result, not the exit code: `systemctl list-timers
    'deploy-runner@*'`, `cat /opt/waggle-<lane>/DEPLOYED_SHA`, and a green
    `verify-deployed.sh <lane> /opt/waggle-<lane> <sha>`.
@@ -189,6 +187,36 @@ For a **private** repo, drop a read-only token in `/opt/waggle-hub-<lane>/deploy
 (`GH_TOKEN=…`, `0600`, never committed) — a read cap, still no write authority on the box.
 
 Nothing arms until it passes a review and a green `verify-deployed.sh` against the box.
+
+## Sealed lane: off root, and its deploy runner
+
+The read lane has run as `bridge` since the Phase-1 migration. The sealed lane did not: it had no
+`User=` at all, so it ran as **root** — the last principal holding that privilege on production,
+and the reason "no principal holds a general shell here" was not yet true.
+
+Order matters. Each step leaves the lane in a working state, so a stop anywhere is safe.
+
+1. **Create the user** (no login, no home of its own beyond the tree):
+   `sudo useradd --system --home-dir /opt/waggle-sealed --shell /usr/sbin/nologin sealed`
+2. **Hand it the tree**, and re-assert the key's mode under its new owner:
+   `sudo chown -R sealed:sealed /opt/waggle-sealed` then `sudo chmod 0600 /opt/waggle-sealed/.env`.
+   **Do NOT make the tree group-writable** to let anything else ship into it — directory write
+   grants *rename* of entries whatever their own modes are, which is exactly the privesc closed on
+   the read tree on 2026-08-01. Own it, do not share it.
+3. **Scoped sudo**, validated before install:
+   `sudo visudo -cf deploy/sudoers-sealed && sudo install -m 0440 -o root -g root deploy/sudoers-sealed /etc/sudoers.d/sealed`
+4. **Install the unit and restart the lane as its new user:**
+   `sudo cp deploy/waggle-sealed.service /etc/systemd/system/ && sudo systemctl daemon-reload && sudo systemctl restart waggle-sealed.service`.
+   Confirm by reading, not by exit code: `systemctl show waggle-sealed.service -p User --value`
+   must print `sealed`, and the journal must show the lane resubscribing.
+5. **Only then, its deploy runner.** Hub clone owned by the same user:
+   `sudo git clone <repo> /opt/waggle-hub-sealed && sudo chown -R sealed:sealed /opt/waggle-hub-sealed`,
+   the drop-in from the unit header (`User=sealed`, `Group=sealed`), a hand-run
+   `DRY_RUN=1` tick, one real tick read by eye, and then
+   `sudo systemctl enable --now deploy-runner@sealed.timer`.
+
+**The tripwire is unaffected.** It merges both lanes' send-journals in an `ExecStartPre` that runs
+as root, so it keeps reading `/opt/waggle-sealed/data/send-journal.log` whoever owns it.
 
 ## ⚠ Root-SSH disable is lockout-sensitive
 

--- a/deploy/deploy-runner@.service
+++ b/deploy/deploy-runner@.service
@@ -11,14 +11,15 @@
 # IDENTITY (the point of #129 — no standing write, scoped per tree):
 #   read   -> runs as 'bridge', which already holds scoped `sudo systemctl restart
 #             waggle-read.service` (deploy/sudoers-bridge) and owns /opt/waggle-read.
-#   sealed -> /opt/waggle-sealed runs as ROOT today; do NOT run its deploy as root. Create a
-#             scoped 'deploy' user that owns /opt/waggle-sealed + /opt/waggle-hub-sealed and
-#             holds ONLY `sudo systemctl restart waggle-sealed.service`, then add an override
+#   sealed -> the lane itself runs as the 'sealed' user (deploy/waggle-sealed.service). Its
+#             deploy must not run as root either. The same user owns
+#             /opt/waggle-sealed + /opt/waggle-hub-sealed and holds ONLY the scoped
+#             `sudo systemctl restart waggle-sealed.service` grant (deploy/sudoers-sealed), then add an override
 #             so this instance runs as that user:
 #               /etc/systemd/system/deploy-runner@sealed.service.d/override.conf
 #                 [Service]
-#                 User=deploy
-#                 Group=deploy
+#                 User=sealed
+#                 Group=sealed
 #             Getting sealed off a root deploy path is the same-pass hardening the issue asks
 #             for — landing it here means neither lane is deployed by root.
 #

--- a/deploy/sudoers-sealed
+++ b/deploy/sudoers-sealed
@@ -1,0 +1,5 @@
+# Installed to /etc/sudoers.d/sealed. Validate with `visudo -cf` BEFORE installing.
+# EXACT commands only, no wildcards — the sealed user can manage its own unit and nothing else.
+# This is what lets the deploy runner restart the lane after shipping, without any principal
+# holding a general shell on production.
+sealed ALL=(root) NOPASSWD: /usr/bin/systemctl start waggle-sealed.service, /usr/bin/systemctl stop waggle-sealed.service, /usr/bin/systemctl restart waggle-sealed.service, /usr/bin/systemctl status waggle-sealed.service

--- a/deploy/waggle-sealed.service
+++ b/deploy/waggle-sealed.service
@@ -1,34 +1,40 @@
-# Sealed-lane unit (DM + Concord planes) — the EXISTING production service, checked in.
-# Runs as root today; migrating it off root is out of scope for Phase 1 (see deploy/README.md).
-# Its config.json must have NO "public" block — boot log must read:
-#   "public read lane: inactive (no cfg.public.inbox)"
-# The read lane runs separately as waggle-read.service under the 'bridge' user.
+# waggle — sealed lanes (Armada DMs + Concord planes → Buzz inboxes).
+#
+# Runs as a DEDICATED NON-ROOT USER (#134 step 6). Until 2026-08-02 this unit had no `User=` at
+# all, so the sealed lane ran as root: the one lane still holding that privilege, and the reason
+# "no principal holds a general shell on production" was not yet true. The read lane has run as
+# `bridge` since the Phase-1 migration; this is the same treatment for the same reason.
+#
+# The lane terminates untrusted network input and shells out to the `buzz` CLI. Neither wants root.
+#
+#   sudo useradd --system --home-dir /opt/waggle-sealed --shell /usr/sbin/nologin sealed
+#   sudo chown -R sealed:sealed /opt/waggle-sealed
+#   sudo chmod 0600 /opt/waggle-sealed/.env      # the poster key — owner-only, and the owner is now `sealed`
+#   sudo install -m 0440 -o root -g root deploy/sudoers-sealed /etc/sudoers.d/sealed
+#
+# See deploy/README.md → "Sealed lane: off root, and its deploy runner".
 [Unit]
 Description=waggle — sealed lanes (Armada DMs + Concord planes → Buzz inboxes)
 After=network-online.target
 Wants=network-online.target
 
 [Service]
+User=sealed
+Group=sealed
 WorkingDirectory=/opt/waggle-sealed
 ExecStart=/usr/bin/node src/bridge.mjs
 EnvironmentFile=/opt/waggle-sealed/.env
-# Sealed alternative (docs/KEY_CUSTODY.md). systemd-creds keeps the key encrypted at rest,
-# bound to this host, so a stolen disk or a leaked backup yields ciphertext:
-#
-#   systemd-creds encrypt --name=buzzkey /dev/stdin /etc/credstore.encrypted/buzzkey
-#
-# then swap the line above for the two below and have the service read the key from
-# $CREDENTIALS_DIRECTORY/buzzkey instead of BUZZ_PRIVATE_KEY:
-#
-#   LoadCredentialEncrypted=buzzkey:/etc/credstore.encrypted/buzzkey
-#   Environment=BUZZ_PRIVATE_KEY_FILE=%d/buzzkey
-#
-# This protects the COLD copy only. The process still holds the plaintext in memory to sign,
-# so it does nothing against a live host compromise - that answer is the disposable identity,
-# the tripwire, and rotation. See docs/KEY_CUSTODY.md before choosing.
 Environment=PATH=/usr/local/bin:/usr/bin:/bin
 Restart=always
 RestartSec=5
+# Same sandbox as the read lane. ReadWritePaths is data/ ONLY: the lane's durable state (dedup
+# sets, watermarks, posted-map, send-journal) lives there, and nothing it does at runtime should
+# be able to rewrite its own code — the shape of the privesc closed on the read tree.
+NoNewPrivileges=yes
+ProtectSystem=strict
+ReadWritePaths=/opt/waggle-sealed/data
+ProtectHome=yes
+PrivateTmp=yes
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Part of #134 (step 6). **The repo half — and it was the actual blocker.**

`deploy/waggle-sealed.service` had **no `User=` at all**, so the sealed lane runs as **root**: the last principal holding that privilege on production, and the reason *"no principal holds a general shell here"* was not yet true. The checked-in unit was byte-identical to the installed one, so there was nothing correct to install — the host pass would have meant hand-editing a unit on a live box. Now it's "install these files".

The read lane has run as `bridge` since the Phase-1 migration. Same treatment, same reason: this lane terminates untrusted network input and shells out to the `buzz` CLI.

## What's in it

- **`deploy/waggle-sealed.service`** — `User`/`Group=sealed`, plus the read lane's sandbox: `NoNewPrivileges`, `ProtectSystem=strict`, `ProtectHome`, `PrivateTmp`, and `ReadWritePaths` scoped to **`data/` only**, so the lane cannot rewrite its own code.
- **`deploy/sudoers-sealed`** — exact commands, no wildcards, mirroring `sudoers-bridge`. This is what lets its deploy runner restart the lane without any principal holding a general shell.
- **`deploy/README.md`** — the ordered pass, written so a stop at **any** step leaves the lane working: create the user → hand it the tree → restart as that user → **only then** arm its runner. Moving a running lane off root is the part that leaves it down if taken out of order.

## Two things carried into the docs because they're easy to get wrong

1. **Do not make the tree group-writable** to let anything ship into it. Directory write grants *rename* of entries whatever their own modes are — exactly the privesc closed on the read tree on 08-01. Own it, don't share it.
2. **The tripwire is unaffected.** Its journal merge is an `ExecStartPre` running as root, so it keeps reading `/opt/waggle-sealed/data/send-journal.log` whoever owns it. I checked this before writing the unit, because a detection gate silently losing a lane is the failure mode that would matter most here.

## Verified before writing

Read off the box: the tree is `root:root`, `.env` is `0600 root:root`, `data/` is `drwxr-x--- root:root`, and **neither a `deploy` nor a `sealed` user exists yet**. No hub, no `DEPLOYED_SHA`.

Nothing here touches a lane at merge time — `deploy/` isn't in the ship list, so this lands as a no-op deploy under #169's gate.

Drafted with assistance from [Claude Code](https://claude.com/claude-code)