### PR TITLE
console: admission requests surface for one-action approval (#186)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,14 +145,14 @@ that merely ran.** The suite was green through all of them.
 
 ## Tests
 
-`npm test` — 22 suites, against the real exported functions with synthetic events. No sockets,
+`npm test` — 23 suites, against the real exported functions with synthetic events. No sockets,
 no production state, no writes outside a temp dir.
 
 boot · suite roster · egress catalogue · egress ban · durable dedup store · relay fan-out · quarantine gating · deletion propagation · sealed-lane rate caps · grant
 admission · message rendering · deployed-build verification · return lane · return-lane scan ·
-return-lane no-miss · return-lane pending · relay ingress · tripwire union · tripwire detection drill · deploy runner · console Host check · undelivered record
+return-lane no-miss · return-lane pending · relay ingress · tripwire union · tripwire detection drill · deploy runner · console Host check · undelivered record · console pending requests
 
-CI runs them on push and PR. **If a run reports fewer than 22, the branch is on a stale base.**
+CI runs them on push and PR. **If a run reports fewer than 23, the branch is on a stale base.**
 The count of record is the `test` script in `package.json`; a prose count that disagrees with it
 is the prose being wrong.
 

--- a/README.md
+++ b/README.md
@@ -104,12 +104,12 @@ against what git says, because a stale build is invisible while every status sur
 
 ## Tests
 
-`npm test` runs 22 suites against the **real** exported functions with synthetic events — no
+`npm test` runs 23 suites against the **real** exported functions with synthetic events — no
 sockets, no production state:
 
 boot · suite roster · egress catalogue · egress ban · durable dedup store · relay fan-out · quarantine gating · deletion propagation · sealed-lane rate caps · grant
 admission · message rendering · deployed-build verification · return lane · return-lane scan ·
-return-lane no-miss · return-lane pending · relay ingress · tripwire union · tripwire detection drill · deploy runner · console Host check · undelivered record
+return-lane no-miss · return-lane pending · relay ingress · tripwire union · tripwire detection drill · deploy runner · console Host check · undelivered record · console pending requests
 
 The rendering suite is the one to read if you are reviewing. It tests what the bridge **refuses**,
 not only what it does: a hostile note tries to ping the approver, mint an `APPROVED BY` heading,

--- a/console/index.html
+++ b/console/index.html
@@ -147,6 +147,15 @@
     <div class="status" id="authst"></div>
   </div>
 
+  <div class="panel" id="req-panel" style="display:none">
+    <h2>Waiting for you <span class="hint">sessions that have asked to be let in</span></h2>
+    <div class="note">Nothing listed here has any access. A request is a stranger asking — anyone
+      can send one — and approving it is the only thing that admits them. Read the reason before
+      you decide, and remember it was written by whoever is asking.</div>
+    <div id="reqlist"></div>
+    <div class="status" id="reqst"></div>
+  </div>
+
   <div class="panel" id="issue-panel" style="display:none">
     <h2>Give someone access</h2>
     <div class="row">
@@ -341,6 +350,10 @@ function drawTitlebar(npub, kind) {
       signer = null; signerPk = null
       $('issue-panel').style.display = 'none'
       $('confirm-panel').style.display = 'none'
+      // Requests were decrypted with the key that just left. Drop both the panel and the parsed
+      // copies — a list of who is asking must not outlive the session that could act on it.
+      $('req-panel').style.display = 'none'
+      $('reqlist').innerHTML = ''; lastRequests = []
       setAuth('')
       drawTitlebar(null, null); renderRows()
     } : undefined,
@@ -367,6 +380,8 @@ async function adopt(s, label) {
   // Convenience only: the grantor field is what you sign as, so default it to the signed-in key.
   if (!$('grantor').value.trim()) { $('grantor').value = nip19.npubEncode(signerPk); $('go').click() }
   renderRows()
+  // Requests are addressed to the signed-in key, so they can only be read once there is one.
+  loadRequests()
 }
 const nc = () => import('./vendor/nave-connect.mjs')
 
@@ -468,6 +483,117 @@ $('g-preview').addEventListener('click', async () => {
       : `This admits ${short(grantee)} to the channel ${subjRaw}. The channel id never rides publicly — it is stored as a salted hash that only someone who already knows the channel can match.`)
   } catch (e) { st.className = 'status err'; st.textContent = e.message }
 })
+
+// ── Pending requests (#186) ─────────────────────────────────────────────────────────────────
+// A session that wants in gift-wraps a request to the maintainer's key. Reading them here is what
+// removes the retyping step — and retyping is where an operator either gives up or stops reading.
+// Provenance and parsing live in requests.mjs; this file owns the DOM and the signing, so that a
+// change to what counts as a valid request is testable without a browser.
+import { readRequests } from './requests.mjs'
+
+// "Not now" is a local judgement, stored on this machine and published nowhere. A public denial
+// would name the stranger who asked — the same optics own-goal the spec's moderation section
+// gives for keeping mutes and rejects local. Dismissing is reversible by clearing site data.
+const DISMISS_KEY = 'waggle-console-dismissed-requests'
+const dismissedIds = () => {
+  try { return new Set(JSON.parse(localStorage.getItem(DISMISS_KEY) || '[]')) } catch { return new Set() }
+}
+let lastRequests = []
+
+window.__dismissReq = (id) => {
+  const s = dismissedIds(); s.add(id)
+  localStorage.setItem(DISMISS_KEY, JSON.stringify([...s]))
+  loadRequests()
+}
+
+// Admit — the one action. It does NOT sign here: it routes into the same confirm panel every
+// other signing act uses, so the operator still sees the exact event before it is signed. A
+// one-click path that skipped that would be the approve-first-read-never habit this page exists
+// to prevent, dressed up as convenience.
+window.__admit = async (id) => {
+  const st = $('reqst')
+  const r = lastRequests.find(x => x.id === id)
+  if (!r) return
+  if (!signer) { st.className = 'status err'; st.textContent = 'Sign in first — admitting is a signing act.'; return }
+  if (!r.channel) {
+    // The request named no channel and we will not invent one. Hand it to the issue panel with
+    // the grantee filled in so the operator chooses the subject deliberately.
+    $('g-to').value = nip19.npubEncode(r.grantee)
+    $('g-subject').value = ''
+    $('issue-panel').scrollIntoView({ behavior: 'smooth', block: 'center' })
+    st.className = 'status'
+    st.textContent = 'That request did not name a channel — choose one below before signing.'
+    return
+  }
+  const salt = bytesToHex(crypto.getRandomValues(new Uint8Array(16)))
+  const hash = await scopeHash(r.channel.toLowerCase(), salt)
+  proposeSigning({
+    kind: 440, created_at: Math.floor(Date.now() / 1000),
+    tags: [['p', r.grantee], ['da-scope', hash, salt], ['da-cap', r.cap]], content: '',
+  }, `This admits ${short(r.grantee)} to the channel ${r.channel}. The channel id never rides `
+   + `publicly — it is stored as a salted hash only someone who already knows the channel can match.`
+   + (r.granteeIsSender ? ''
+      : ` — WARNING: the key being admitted is NOT the key that asked. ${short(r.from)} is asking on `
+      + `behalf of ${short(r.grantee)}. Admit only if you expected someone to request on another key's behalf.`))
+}
+
+async function loadRequests() {
+  if (!signer || !signerPk) { $('req-panel').style.display = 'none'; return }
+  $('req-panel').style.display = ''
+  const st = $('reqst'), list = $('reqlist')
+
+  // A signer that cannot decrypt cannot read requests at all. Saying "no pending requests" here
+  // would be a claim about the world; the truth is a claim about our eyesight. Same rule the
+  // tripwire learned (exit 3 = INCONCLUSIVE): being unable to check is not being fine.
+  if (typeof signer.nip44Decrypt !== 'function') {
+    list.innerHTML = `<div class="empty">This sign-in method cannot decrypt, so requests cannot be
+      read here. Nothing is shown because nothing could be <i>read</i> — which is not the same as
+      "nobody is asking". Sign in with a browser extension or a remote signer to see them.</div>`
+    st.className = 'status'; st.textContent = ''
+    return
+  }
+
+  st.className = 'status'; st.textContent = 'Reading requests…'
+  const results = await Promise.all(RELAYS.map(u => query(u, { kinds: [1059], '#p': [signerPk], limit: 300 })))
+  const answered = results.filter(r => r.answered)
+  const byId = new Map()
+  for (const r of results) for (const e of r.out) byId.set(e.id, e)
+
+  const { requests, skipped, failed } = await readRequests([...byId.values()], {
+    decrypt: (pk, ct) => signer.nip44Decrypt(pk, ct),
+    verifyEvent, decodeNpub: decode,
+  })
+  const hidden = dismissedIds()
+  lastRequests = requests.filter(r => !hidden.has(r.id))
+
+  if (!lastRequests.length) {
+    list.innerHTML = `<div class="empty">${answered.length
+      ? 'No requests waiting.'
+      : 'No relay answered, so nothing could be read — this is not the same as "no requests".'}</div>`
+  } else {
+    // Every string below is attacker-chosen: the purpose is free text written by whoever asked.
+    // esc() on all of it, on the one page that holds a live signing session.
+    list.innerHTML = lastRequests.map(r => `
+      <div class="note" style="margin-bottom:10px">
+        <div><span class="who">${esc(short(r.grantee))}</span> asks to be admitted${
+          r.channel ? ` to <span class="who">${esc(r.channel)}</span>` : ''}</div>
+        <div style="margin:7px 0;color:var(--dim)">&ldquo;${esc(r.purpose)}&rdquo;</div>
+        ${r.granteeIsSender ? '' :
+          `<div><span class="pill revoked">asked by ${esc(short(r.from))}, not the key being admitted</span></div>`}
+        <div style="margin-top:9px">
+          <button class="btn" style="margin:0;padding:5px 12px;font-size:12.5px"
+            onclick="__admit('${esc(r.id)}')">Admit</button>
+          <button class="btn ghost" style="margin:0 0 0 8px;padding:5px 12px;font-size:12.5px"
+            onclick="__dismissReq('${esc(r.id)}')">Not now</button>
+        </div>
+      </div>`).join('')
+  }
+
+  st.className = 'status ' + (answered.length ? 'ok' : 'err')
+  st.textContent = `${lastRequests.length} waiting · ${answered.length}/${RELAYS.length} relays answered`
+    + (skipped ? ` · ${skipped} wrap(s) were not requests` : '')
+    + (failed ? ` · ${failed} could not be read` : '')
+}
 
 $('go').addEventListener('click', async () => {
   const st = $('st'); const rows = $('rows')

--- a/console/index.html
+++ b/console/index.html
@@ -460,7 +460,13 @@ $('confirm-go').addEventListener('click', async () => {
     st.className = 'status ' + (okCount ? 'ok' : 'err')
     st.textContent = `${okCount}/${results.length} relays accepted · ${results.join(' · ')}`
     pendingTemplate = null
-    setTimeout(() => { $('confirm-panel').style.display = 'none'; $('go').click() }, 1800)
+    // Re-read BOTH lists. Refreshing only the access list was the visible half of a bug: an
+    // admitted request stayed on screen, so the operator could not tell the signature had taken.
+    setTimeout(() => {
+      $('confirm-panel').style.display = 'none'
+      $('go').click()
+      loadRequests()
+    }, 1800)
   } catch (e) { st.className = 'status err'; st.textContent = e.message }
 })
 
@@ -572,12 +578,46 @@ async function loadRequests() {
   const byId = new Map()
   for (const r of results) for (const e of r.out) byId.set(e.id, e)
 
-  const { requests, skipped, failed } = await readRequests([...byId.values()], {
+  const { requests, other, skipped, failed } = await readRequests([...byId.values()], {
     decrypt: (pk, ct) => signer.nip44Decrypt(pk, ct),
     verifyEvent, decodeNpub: decode,
   })
+
+  // A request is a DM, and a DM lives on the relays forever — admitting someone does not delete
+  // the message that asked. So "pending" has to mean NOT YET GRANTED, not "a message exists", or
+  // the queue never empties and the operator learns to ignore it. Cross-reference the live grants
+  // by this signer: same grantee, and a scope that recomputes to the channel being asked for.
+  // Doing it against the RELAYS rather than against what this tab just published also means a
+  // grant issued from the CLI, or from another device, correctly clears the card here.
+  const gRes = await Promise.all(RELAYS.map(u =>
+    query(u, { kinds: [KIND.grant, KIND.revocation], authors: [signerPk], limit: 500 })))
+  const gById = new Map()
+  for (const r of gRes) for (const e of r.out) gById.set(e.id, e)
+  const gValid = [...gById.values()].filter(e => e.pubkey === signerPk && verifyEvent(e))
+  const gRevoked = new Set(gValid.filter(e => e.kind === KIND.revocation)
+    .flatMap(e => e.tags.filter(t => t[0] === 'e').map(t => t[1])))
+  const live = gValid.filter(e => e.kind === KIND.grant && !gRevoked.has(e.id))
+  const isSatisfied = async (r) => {
+    for (const g of live) {
+      if (g.tags.find(t => t[0] === 'p')?.[1] !== r.grantee) continue
+      const sc = g.tags.find(t => t[0] === TAG.scope)
+      if (!sc) continue
+      // Recompute with THAT grant's salt. A revoked grant does not count, so re-asking after a
+      // revocation correctly shows up again — the card tracks access, not history.
+      if (await scopeHash(String(r.channel).toLowerCase(), sc[2]) === sc[1]) return true
+    }
+    return false
+  }
+
   const hidden = dismissedIds()
-  lastRequests = requests.filter(r => !hidden.has(r.id))
+  const open = []
+  let granted = 0
+  for (const r of requests) {
+    if (hidden.has(r.id)) continue
+    if (await isSatisfied(r)) { granted++; continue }
+    open.push(r)
+  }
+  lastRequests = open
 
   if (!lastRequests.length) {
     list.innerHTML = `<div class="empty">${answered.length
@@ -588,8 +628,8 @@ async function loadRequests() {
     // esc() on all of it, on the one page that holds a live signing session.
     list.innerHTML = lastRequests.map(r => `
       <div class="note" style="margin-bottom:10px">
-        <div><span class="who">${esc(short(r.grantee))}</span> asks to be admitted${
-          r.channel ? ` to <span class="who">${esc(r.channel)}</span>` : ''}</div>
+        <div><span class="who">${esc(short(r.grantee))}</span> asks to be admitted to
+          <span class="who">${esc(r.channel)}</span></div>
         <div style="margin:7px 0;color:var(--dim)">&ldquo;${esc(r.purpose)}&rdquo;</div>
         ${r.granteeIsSender ? '' :
           `<div><span class="pill warn">asked by ${esc(short(r.from))}, not the key being admitted</span></div>`}
@@ -604,6 +644,11 @@ async function loadRequests() {
 
   st.className = 'status ' + (answered.length ? 'ok' : 'err')
   st.textContent = `${lastRequests.length} waiting · ${answered.length}/${RELAYS.length} relays answered`
+    + (granted ? ` · ${granted} already granted` : '')
+    // Nvoy's own credential delegations are access_requests too. They are readable and real —
+    // they simply are not channel admissions, and this console cannot act on them. Counted rather
+    // than dropped: "not mine to act on" is a different claim from "nothing there".
+    + (other.length ? ` · ${other.length} for Nvoy (no channel named)` : '')
     + (skipped ? ` · ${skipped} wrap(s) were not requests` : '')
     + (failed ? ` · ${failed} could not be read` : '')
 }

--- a/console/index.html
+++ b/console/index.html
@@ -53,8 +53,12 @@
     margin:10px 0 5px;text-transform:uppercase;letter-spacing:.1em}
   input{width:100%;background:var(--field);color:var(--text);border:1px solid var(--line);
     border-radius:var(--r-sm);padding:10px 12px;font-family:var(--mono);font-size:13px}
-  .row{display:flex;gap:12px;flex-wrap:wrap}
-  .row > div{flex:1;min-width:260px}
+  .row{display:flex;gap:12px;flex-wrap:wrap;align-items:stretch}
+  /* Columns line up on their INPUTS, not on the tops of their labels. A two-line label beside a
+     one-line one otherwise staggers the fields, which reads as a broken layout rather than as the
+     different label lengths it actually is. */
+  .row > div{flex:1;min-width:260px;display:flex;flex-direction:column}
+  .row > div > input{margin-top:auto}
   .btn{background:var(--accent);color:var(--accent-ink);border:none;border-radius:var(--r-sm);
     padding:10px 18px;font-weight:700;font-size:15px;font-family:inherit;cursor:pointer;margin-top:14px}
   .btn:hover{background:var(--accent-bright)}
@@ -87,6 +91,10 @@
     text-transform:uppercase;padding:2px 8px;border-radius:999px;border:1px solid}
   .pill.live{color:var(--good);border-color:var(--good)}
   .pill.revoked{color:var(--critical);border-color:var(--critical);text-decoration:line-through}
+  /* A WARNING is not a cancellation. `revoked` strikes its text through, which is right for
+     "this access was removed" and exactly wrong for "read this before you approve" — struck-out
+     text reads as already-dealt-with, and it is the one line on the card that must be read. */
+  .pill.warn{color:var(--warn);border-color:var(--warn)}
   .tablewrap{overflow-x:auto}
   .empty{color:var(--faint);font-size:14px;padding:14px 0}
   .rel{font-family:var(--mono);font-size:11.5px;color:var(--faint);margin-top:12px;line-height:1.8}
@@ -96,6 +104,11 @@
   .note b{color:var(--text)}
   /* Secondary guidance inside a label: present, never competing with it. */
   .hint{color:var(--dim);font-weight:400;text-transform:none;letter-spacing:0;font-size:12px}
+  /* Inside a LABEL the hint gets its own line. Trailing a sentence-case hint after uppercase,
+     letter-spaced text wraps mid-phrase at ordinary widths — the two collide and the label reads
+     as one run-on string. On its own line it stays legible and the wrap becomes predictable.
+     Scoped to labels so an h2's inline hint is untouched. */
+  label .hint{display:block;margin-top:4px;line-height:1.4}
 
   /* waggle is a lowercase wordmark. The shared bar uppercases app names by default and paints
      them in --accent, which on this dark ground reads as a dim brown — legible enough for a
@@ -579,7 +592,7 @@ async function loadRequests() {
           r.channel ? ` to <span class="who">${esc(r.channel)}</span>` : ''}</div>
         <div style="margin:7px 0;color:var(--dim)">&ldquo;${esc(r.purpose)}&rdquo;</div>
         ${r.granteeIsSender ? '' :
-          `<div><span class="pill revoked">asked by ${esc(short(r.from))}, not the key being admitted</span></div>`}
+          `<div><span class="pill warn">asked by ${esc(short(r.from))}, not the key being admitted</span></div>`}
         <div style="margin-top:9px">
           <button class="btn" style="margin:0;padding:5px 12px;font-size:12.5px"
             onclick="__admit('${esc(r.id)}')">Admit</button>

--- a/console/requests.mjs
+++ b/console/requests.mjs
@@ -106,21 +106,34 @@ export async function parseRequest(wrap, deps) {
 }
 
 /**
- * Parse a batch of wraps. Returns { requests, skipped, failed } — newest first.
+ * Parse a batch of wraps. Returns { requests, other, skipped, failed } — newest first.
  *
- * `skipped` and `failed` are reported, never swallowed. A console that shows "0 pending" after
- * silently failing to decrypt 40 wraps has told the operator the opposite of the truth, which is
- * the failure mode nvoy's own notice reader carries a comment about. Same rule as the rest of this
- * repo: being unable to check is not the same as being fine.
+ * THE SPLIT MATTERS, and it was found by looking at the rendered page rather than the code.
+ * Reading nvoy's vocabulary (REQUEST_TYPES above) is what lets one request serve both consoles —
+ * but it also means this console sees nvoy's OWN traffic: credential delegations ("a Gemini API
+ * key", "a BotFather token") are `access_request`s too, and have nothing to do with channel
+ * admission. Rendered together they read as "asks to be admitted" above a button that issues a
+ * CHANNEL grant — a label that does not match what the button does, which is precisely the defect
+ * this project files against other people's approval surfaces.
+ *
+ * The discriminator is the payload, not the vocabulary: a channel admission names a channel; an
+ * nvoy credential request never does. `requests` is therefore what this console can actually act
+ * on, and `other` is everything readable that belongs in Nvoy instead.
+ *
+ * `other`, `skipped` and `failed` are all REPORTED, never swallowed. A console that shows "0
+ * pending" after failing to decrypt forty wraps has told the operator the opposite of the truth.
+ * Being unable to check is not the same as being fine — and neither is "not mine to act on".
  */
 export async function readRequests(wraps, deps) {
-  const requests = []
+  const requests = [], other = []
   let skipped = 0, failed = 0
   for (const w of wraps || []) {
     let r = null
     try { r = await parseRequest(w, deps) } catch { failed++; continue }
-    if (r) requests.push(r); else skipped++
+    if (!r) { skipped++; continue }
+    ;(r.channel ? requests : other).push(r)
   }
-  requests.sort((a, b) => b.at - a.at)
-  return { requests, skipped, failed }
+  const newest = (a, b) => b.at - a.at
+  requests.sort(newest); other.sort(newest)
+  return { requests, other, skipped, failed }
 }

--- a/console/requests.mjs
+++ b/console/requests.mjs
@@ -1,0 +1,126 @@
+// requests.mjs — read pending admission requests out of gift-wrapped DMs (#186, #141 piece 1).
+//
+// A session that wants in mints a key and gift-wraps a request to the maintainer. Until now the
+// only way to act on one was to read the sealed DM by hand and retype the npub into `grant.mjs`.
+// This module turns a wrap into a structured request the console can render and act on; the
+// console owns the DOM and the signing, this owns the unwrapping and — more importantly — the
+// refusing.
+//
+// THE GOVERNING FACT: anyone on the open network can gift-wrap a DM to any npub. Reachability is
+// not authority (docs/DM_TRUST_ALLOWLIST.md). So everything this module returns is a REQUEST, from
+// an UNTRUSTED stranger, whose every string field is attacker-chosen. It is rendered so a human
+// can judge it. It is never a fact, and it never authorises anything on its own.
+//
+// Provenance is checked the way docs/CONCORD_CONSUMER.md checks an invite — by signature, never by
+// decryptability. That a ciphertext opened proves only that it was addressed to us; it proves
+// nothing whatever about who wrote it. The two checks that do:
+//
+//   1. the SEAL carries a valid signature          → the sender is a real key, not a claim
+//   2. the rumor's author == the seal's signer     → the sender cannot be forged
+//
+// Without (2) a stranger could wrap a rumor claiming any `pubkey` it liked and the console would
+// render someone else's identity as the asker. NIP-59 puts the outer wrap under a throwaway key
+// on purpose, so the wrap's own pubkey means nothing and is deliberately NOT used for identity.
+
+export const KIND = { wrap: 1059, seal: 13, dm: 14, nvoyMsg: 24440 }
+
+// Both shapes are accepted, and this is the point of #186 rather than an accident of history:
+// nvoy's console lists anything with `type: 'access_request'` (a 24440 rumor), while waggle's own
+// tool emitted `waggle_admission_request` (a NIP-17 kind:14 rumor). Reading both here is what lets
+// ONE request event surface in BOTH consoles — the dual-surface approval, with no coordination
+// needed beyond agreeing on a vocabulary.
+const REQUEST_TYPES = new Set(['access_request', 'waggle_admission_request'])
+
+const HEX64 = /^[0-9a-f]{64}$/i
+
+/** Decode an npub or 64-hex key to hex, or null. Never throws — this parses hostile input. */
+export function toHexKey(v, decodeNpub) {
+  const s = String(v ?? '').trim()
+  if (HEX64.test(s)) return s.toLowerCase()
+  if (s.startsWith('npub1') && decodeNpub) {
+    try { const d = decodeNpub(s); return d && d.type === 'npub' ? d.data : null } catch { return null }
+  }
+  return null
+}
+
+/**
+ * Turn one 1059 gift wrap into a pending request, or null if it is not one / does not hold up.
+ *
+ * @param wrap        the 1059 event as it came off the relay
+ * @param deps.decrypt   (senderPubkey, ciphertext) => Promise<string> — the signer's nip44 decrypt
+ * @param deps.verifyEvent  (event) => boolean — real signature verification, not a stub
+ * @param deps.decodeNpub   (npub) => {type,data} — nip19.decode, for the `npub` body field
+ *
+ * Returns { id, from, grantee, channel, cap, purpose, at, granteeIsSender } or null.
+ * Rejection is silent by design: a malformed or forged wrap is not an error the operator can act
+ * on, and surfacing every stranger's junk as a failure is how a real request gets lost in noise.
+ * (Counting is the caller's job — see readRequests, which reports what it skipped.)
+ */
+export async function parseRequest(wrap, deps) {
+  const { decrypt, verifyEvent, decodeNpub } = deps
+  if (!wrap || wrap.kind !== KIND.wrap || typeof wrap.content !== 'string') return null
+
+  let seal
+  try { seal = JSON.parse(await decrypt(wrap.pubkey, wrap.content)) } catch { return null }
+  if (!seal || seal.kind !== KIND.seal) return null
+
+  // CHECK 1 — the seal's signature. This is the sender's identity, and the only thing that
+  // establishes it. A seal that does not verify is discarded whole.
+  if (!verifyEvent(seal)) return null
+
+  let rumor
+  try { rumor = JSON.parse(await decrypt(seal.pubkey, seal.content)) } catch { return null }
+  if (!rumor || typeof rumor.content !== 'string') return null
+
+  // CHECK 2 — the rumor's author must BE the seal's signer. A rumor is unsigned by design, so its
+  // `pubkey` field is a claim; this is what turns the claim into a fact. Drop the mismatch rather
+  // than rendering it, because a rendered mismatch is an impersonation with a UI around it.
+  if (rumor.pubkey !== seal.pubkey) return null
+  if (rumor.kind !== KIND.dm && rumor.kind !== KIND.nvoyMsg) return null
+
+  let body
+  try { body = JSON.parse(rumor.content) } catch { return null }
+  if (!body || !REQUEST_TYPES.has(body.type)) return null
+  if (typeof body.purpose !== 'string' || !body.purpose.trim()) return null
+
+  // The key to be admitted. It defaults to the sender — the ordinary case, a session asking for
+  // itself. A body naming a DIFFERENT key is a request to admit a third party, which is a
+  // materially different thing to approve: the asker is not the beneficiary. We keep it, because
+  // refusing outright would silently drop a legitimate flow (a runtime raising a request on an
+  // agent's behalf, exactly nvoy's owner_npub extension) — but we FLAG it, and the console says so
+  // in words, because an operator who thinks they are admitting the asker is being misled.
+  const claimed = body.npub !== undefined ? toHexKey(body.npub, decodeNpub) : null
+  if (body.npub !== undefined && !claimed) return null      // present but malformed: not renderable
+  const grantee = claimed || rumor.pubkey
+
+  return {
+    id: String(wrap.id || ''),
+    from: rumor.pubkey,
+    grantee,
+    granteeIsSender: grantee === rumor.pubkey,
+    channel: typeof body.channel === 'string' ? body.channel : null,
+    cap: body.cap === 'task' || body.cap === 'task+act' ? body.cap : 'admit',
+    purpose: body.purpose,
+    at: Number.isFinite(rumor.created_at) ? rumor.created_at : Number(wrap.created_at) || 0,
+  }
+}
+
+/**
+ * Parse a batch of wraps. Returns { requests, skipped, failed } — newest first.
+ *
+ * `skipped` and `failed` are reported, never swallowed. A console that shows "0 pending" after
+ * silently failing to decrypt 40 wraps has told the operator the opposite of the truth, which is
+ * the failure mode nvoy's own notice reader carries a comment about. Same rule as the rest of this
+ * repo: being unable to check is not the same as being fine.
+ */
+export async function readRequests(wraps, deps) {
+  const requests = []
+  let skipped = 0, failed = 0
+  for (const w of wraps || []) {
+    let r = null
+    try { r = await parseRequest(w, deps) } catch { failed++; continue }
+    if (r) requests.push(r); else skipped++
+  }
+  requests.sort((a, b) => b.at - a.at)
+  return { requests, skipped, failed }
+}

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -120,7 +120,7 @@ in [deploy/README.md](../deploy/README.md).
 - **Publish the agent relay list:** `node tools/publish_relay_list.mjs` (so the identity
   is discoverable).
 - **Admit a participant**, if you want one: `sh tools/grant-setup.sh`.
-- **Run the safety gates before you ship:** `npm test` — 22 suites driving the real
+- **Run the safety gates before you ship:** `npm test` — 23 suites driving the real
   routing functions with synthetic events (no sockets, no production state), all green.
 
 `waggle-init.mjs --check` rolls the config half of this into one readiness verdict; the

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "start": "node src/bridge.mjs",
     "dryrun": "FORWARD_MODE=dryrun node src/bridge.mjs",
     "lint": "eslint src tools tests",
-    "test": "node tests/suite_count.mjs && node tests/boot.mjs && node tests/egress_catalogue.mjs && node tests/egress_ban.mjs && node tests/relay_fanout.mjs && node tests/durable_store.mjs && node tests/a1_quarantine.mjs && node tests/a7_deletion.mjs && node tests/lane2_caps.mjs && node tests/nipda_admission.mjs && node tests/render_states.mjs && node tests/deploy_verify.mjs && node tests/return_lane.mjs && node tests/return_lane_scan.mjs && node tests/return_lane_nomiss.mjs && node tests/return_lane_pending.mjs && node tests/relay_ingress.mjs && node tests/tripwire_union.mjs && node tests/tripwire_detection.mjs && node tests/deploy_runner.mjs && node tests/console_host.mjs && node tests/undelivered.mjs",
+    "test": "node tests/suite_count.mjs && node tests/boot.mjs && node tests/egress_catalogue.mjs && node tests/egress_ban.mjs && node tests/relay_fanout.mjs && node tests/durable_store.mjs && node tests/a1_quarantine.mjs && node tests/a7_deletion.mjs && node tests/lane2_caps.mjs && node tests/nipda_admission.mjs && node tests/render_states.mjs && node tests/deploy_verify.mjs && node tests/return_lane.mjs && node tests/return_lane_scan.mjs && node tests/return_lane_nomiss.mjs && node tests/return_lane_pending.mjs && node tests/relay_ingress.mjs && node tests/tripwire_union.mjs && node tests/tripwire_detection.mjs && node tests/deploy_runner.mjs && node tests/console_host.mjs && node tests/undelivered.mjs && node tests/console_requests.mjs",
     "console": "node tools/serve-console.mjs"
   },
   "dependencies": {

--- a/tests/console_requests.mjs
+++ b/tests/console_requests.mjs
@@ -1,0 +1,187 @@
+// console_requests.mjs — the console's pending-request reader (#186, #141 piece 1).
+//
+// What this guards: the console renders admission requests that arrive as gift-wrapped DMs from
+// STRANGERS. Anyone can wrap a DM to any npub, so every field here is attacker-chosen, and the
+// only things standing between a forged request and the operator's signer are the two provenance
+// checks in console/requests.mjs.
+//
+// The rule this suite is written to obey (CLAUDE.md, earned by a live outage): assert the
+// property, not the mechanism, and assert BOTH directions. A parser that rejects the forgery is
+// worthless if it also rejects the real request — that is precisely the shape of the bug that
+// silently dropped every message to "My Dude". So every refusal assertion below is paired with a
+// legitimate value that must still get through, and the fixtures use production-shaped strings
+// (spaces, punctuation, markup characters) rather than "A" and "B".
+
+import { finalizeEvent, generateSecretKey, getPublicKey, getEventHash, verifyEvent } from 'nostr-tools/pure'
+import * as nip44 from 'nostr-tools/nip44'
+import * as nip19 from 'nostr-tools/nip19'
+import { parseRequest, readRequests, KIND } from '../console/requests.mjs'
+
+let fails = 0
+const ok = (name, cond, detail = '') => {
+  if (cond) return console.log(`  ok   ${name}`)
+  fails++
+  console.log(`  FAIL ${name}${detail ? ` — ${detail}` : ''}`)
+}
+
+console.log('console pending requests (#186)')
+
+// --- the maintainer, and a signer-shaped decrypt over their key ---------------------------------
+const maintSk = generateSecretKey()
+const maintPk = getPublicKey(maintSk)
+// Mirrors the console's signer contract exactly: (senderPubkey, ciphertext) => plaintext.
+const decrypt = async (pk, ct) => nip44.decrypt(ct, nip44.getConversationKey(maintSk, pk))
+const deps = { decrypt, verifyEvent, decodeNpub: nip19.decode }
+
+// Build a wrap the way request-admission.mjs does: rumor -> seal(13) -> wrap(1059).
+// `opts.forgeRumorPubkey` and `opts.breakSeal` let a test bend exactly one link at a time.
+function wrapFor(senderSk, body, opts = {}) {
+  const senderPk = getPublicKey(senderSk)
+  const now = Math.floor(Date.now() / 1000)
+  const rumor = {
+    kind: opts.rumorKind ?? KIND.dm,
+    pubkey: opts.forgeRumorPubkey ?? senderPk,
+    created_at: now,
+    tags: [['p', maintPk]],
+    content: typeof body === 'string' ? body : JSON.stringify(body),
+  }
+  rumor.id = getEventHash(rumor)
+  let seal = finalizeEvent({
+    kind: KIND.seal, created_at: now, tags: [],
+    content: nip44.encrypt(JSON.stringify(rumor), nip44.getConversationKey(senderSk, maintPk)),
+  }, senderSk)
+  if (opts.breakSeal) seal = { ...seal, sig: seal.sig.replace(/^../, seal.sig.startsWith('00') ? 'ff' : '00') }
+  const wsk = generateSecretKey()
+  return finalizeEvent({
+    kind: KIND.wrap, created_at: now, tags: [['p', maintPk]],
+    content: nip44.encrypt(JSON.stringify(seal), nip44.getConversationKey(wsk, maintPk)),
+  }, wsk)
+}
+
+const sessionSk = generateSecretKey()
+const sessionPk = getPublicKey(sessionSk)
+const CHANNEL = 'a8186b53-537d-46ad-a7e7-b6486c58970e'
+// A production-shaped purpose: spaces, an apostrophe, a hash, an angle bracket. If the parser or
+// the renderer only ever saw "test", neither would be exercised the way real input exercises them.
+const PURPOSE = "review #140's egress design with the crew <please>"
+
+// --- 1. THE LEGITIMATE REQUEST MUST GET THROUGH -------------------------------------------------
+// First, and deliberately first: every refusal below is only meaningful because this passes.
+{
+  const w = wrapFor(sessionSk, {
+    type: 'access_request', npub: nip19.npubEncode(sessionPk),
+    channel: CHANNEL, cap: 'admit', purpose: PURPOSE,
+  })
+  const r = await parseRequest(w, deps)
+  ok('a well-formed request parses', !!r)
+  ok('  sender is the seal signer', r?.from === sessionPk)
+  ok('  grantee is the session key', r?.grantee === sessionPk)
+  ok('  grantee is flagged as the sender', r?.granteeIsSender === true)
+  ok('  channel survives verbatim', r?.channel === CHANNEL)
+  ok('  cap defaults to admit', r?.cap === 'admit')
+  ok('  purpose survives verbatim, punctuation and all', r?.purpose === PURPOSE,
+    `got ${JSON.stringify(r?.purpose)}`)
+}
+
+// --- 2. THE OTHER VOCABULARY MUST ALSO GET THROUGH ----------------------------------------------
+// This is the whole point of #186: one event, both consoles. If this regresses, waggle's own tool
+// stops being readable here and the dual-surface claim quietly becomes false.
+{
+  const w = wrapFor(sessionSk, {
+    type: 'waggle_admission_request', v: 1, npub: nip19.npubEncode(sessionPk),
+    channel: CHANNEL, cap: 'admit', purpose: PURPOSE, ts: 1,
+  }, { rumorKind: KIND.dm })
+  ok('a waggle_admission_request parses (the legacy vocabulary)', !!(await parseRequest(w, deps)))
+}
+{
+  const w = wrapFor(sessionSk, {
+    type: 'access_request', channel: CHANNEL, purpose: PURPOSE,
+  }, { rumorKind: KIND.nvoyMsg })
+  const r = await parseRequest(w, deps)
+  ok('an nvoy 24440 notice parses (the nvoy vocabulary)', !!r)
+  ok('  a body with no npub falls back to the sender', r?.grantee === sessionPk)
+}
+
+// --- 3. FORGED SENDER — the check that matters --------------------------------------------------
+{
+  const impostorSk = generateSecretKey()
+  const w = wrapFor(impostorSk, {
+    type: 'access_request', channel: CHANNEL, purpose: PURPOSE,
+  }, { forgeRumorPubkey: sessionPk })          // claims to be the session key; sealed by someone else
+  ok('a rumor whose author != the seal signer is refused', (await parseRequest(w, deps)) === null)
+}
+{
+  const w = wrapFor(sessionSk, { type: 'access_request', channel: CHANNEL, purpose: PURPOSE },
+    { breakSeal: true })
+  ok('a seal with a broken signature is refused', (await parseRequest(w, deps)) === null)
+}
+
+// --- 4. NOT-A-REQUEST must not become one -------------------------------------------------------
+// An ordinary DM is the common case here, not an edge case: the maintainer's inbox is full of
+// them. Rendering one as a pending admission would be an invitation to grant on nonsense.
+{
+  const chat = wrapFor(sessionSk, { type: 'chat', message: 'morning' })
+  ok('an ordinary DM is not a request', (await parseRequest(chat, deps)) === null)
+  const plain = wrapFor(sessionSk, 'just some text, not even JSON')
+  ok('a non-JSON DM is not a request', (await parseRequest(plain, deps)) === null)
+  const noPurpose = wrapFor(sessionSk, { type: 'access_request', channel: CHANNEL })
+  ok('a request with no purpose is refused', (await parseRequest(noPurpose, deps)) === null)
+  const blank = wrapFor(sessionSk, { type: 'access_request', channel: CHANNEL, purpose: '   ' })
+  ok('a request with a blank purpose is refused', (await parseRequest(blank, deps)) === null)
+}
+
+// --- 5. THIRD-PARTY GRANTEE — kept, but flagged -------------------------------------------------
+// The asker is not always the beneficiary, and that is legitimate (a runtime asking on an agent's
+// behalf). What must never happen is it looking identical to asking for yourself.
+{
+  const otherPk = getPublicKey(generateSecretKey())
+  const w = wrapFor(sessionSk, {
+    type: 'access_request', npub: nip19.npubEncode(otherPk),
+    channel: CHANNEL, purpose: PURPOSE,
+  })
+  const r = await parseRequest(w, deps)
+  ok('a request naming a third-party grantee is kept', !!r)
+  ok('  …and is flagged as not-the-sender', r?.granteeIsSender === false)
+  ok('  …with the third party as the grantee', r?.grantee === otherPk)
+}
+{
+  const w = wrapFor(sessionSk, {
+    type: 'access_request', npub: 'npub1obviously-not-valid', channel: CHANNEL, purpose: PURPOSE,
+  })
+  ok('a malformed npub is refused, not silently coerced to the sender',
+    (await parseRequest(w, deps)) === null)
+}
+
+// --- 6. A WRAP WE CANNOT OPEN IS NOT AN ABSENCE -------------------------------------------------
+// The failure this pairs with is the one nvoy left a comment about and CLAUDE.md states as a rule:
+// "being unable to check is not the same as being fine". A batch that silently yields 0 requests
+// after failing to decrypt everything reports our eyesight, not the world.
+{
+  const stranger = generateSecretKey()
+  const notForUs = (() => {          // sealed to someone else entirely: our decrypt cannot open it
+    const otherPk = getPublicKey(generateSecretKey())
+    const wsk = generateSecretKey()
+    return finalizeEvent({
+      kind: KIND.wrap, created_at: 1, tags: [['p', otherPk]],
+      content: nip44.encrypt('{}', nip44.getConversationKey(wsk, otherPk)),
+    }, wsk)
+  })()
+  const good = wrapFor(stranger, { type: 'access_request', channel: CHANNEL, purpose: PURPOSE })
+  const { requests, skipped } = await readRequests([notForUs, good], deps)
+  ok('a batch reports the request it could read', requests.length === 1)
+  ok('  …and counts the wrap it could not, rather than hiding it', skipped === 1)
+}
+
+// --- 7. ORDERING ---------------------------------------------------------------------------------
+{
+  const a = wrapFor(generateSecretKey(), { type: 'access_request', channel: CHANNEL, purpose: 'older' })
+  const b = wrapFor(generateSecretKey(), { type: 'access_request', channel: CHANNEL, purpose: 'newer' })
+  // created_at is stamped by the sender, so equal timestamps are normal; assert the sort is stable
+  // and total rather than asserting a specific order it cannot guarantee.
+  const { requests } = await readRequests([a, b], deps)
+  ok('every readable request in a batch is returned', requests.length === 2)
+  ok('  …newest first', requests[0].at >= requests[1].at)
+}
+
+console.log(fails ? `\n${fails} FAILED` : '\nall passed')
+process.exit(fails ? 1 : 0)

--- a/tests/console_requests.mjs
+++ b/tests/console_requests.mjs
@@ -172,6 +172,27 @@ const PURPOSE = "review #140's egress design with the crew <please>"
   ok('  …and counts the wrap it could not, rather than hiding it', skipped === 1)
 }
 
+// --- 6b. NVOY'S OWN TRAFFIC IS SPLIT OUT, NOT MISLABELLED ---------------------------------------
+// Found by looking at the rendered page, not the code. Reading nvoy's vocabulary is what lets one
+// request serve both consoles — and it means this console also sees nvoy's credential delegations.
+// Those are real, readable access_requests that are NOT channel admissions; rendering them as
+// "asks to be admitted" above a button that issues a CHANNEL grant is a label that does not match
+// what the button does. Both directions asserted: the admission still gets through.
+{
+  const nvoyish = wrapFor(generateSecretKey(), {
+    type: 'access_request', scope_name: 'gemini-api-key',
+    purpose: 'Gemini API key for the PRIMARY engine model — proxied egress (M6)',
+  })
+  const admission = wrapFor(sessionSk, { type: 'access_request', channel: CHANNEL, purpose: PURPOSE })
+  const { requests, other } = await readRequests([nvoyish, admission], deps)
+  ok('a channel admission still lands in requests', requests.length === 1)
+  ok('  …and it is the one naming a channel', requests[0]?.channel === CHANNEL)
+  ok('an nvoy credential request does NOT land in requests',
+    !requests.some(r => /Gemini/.test(r.purpose)))
+  ok('  …it is reported in `other`, never silently dropped', other.length === 1)
+  ok('  …with its purpose intact, so the count can be explained', /Gemini/.test(other[0]?.purpose || ''))
+}
+
 // --- 7. ORDERING ---------------------------------------------------------------------------------
 {
   const a = wrapFor(generateSecretKey(), { type: 'access_request', channel: CHANNEL, purpose: 'older' })


### PR DESCRIPTION
Closes the first of the two pieces #141 left open — **the one-action approval**. Fixes #186.

## The problem

A session can mint a key and ask to be let in (`request-admission.mjs`). The request then surfaced
in **neither** console, so approving it meant reading a sealed DM by hand and retyping an npub into
`grant.mjs issue`. That retyping is the entire friction, and it is exactly where an operator either
gives up or approves without reading.

## Root cause — two shapes that never met

| | rumor kind | `type` |
|---|---|---|
| nvoy's console reads | `24440` | `access_request` |
| our tool emitted | `14` (NIP-17) | `waggle_admission_request` |

`console/requests.mjs` reads **both**, so one request event surfaces in both consoles with no
further coordination between them.

## What it does

- **`console/requests.mjs`** — unwraps `1059` → seal → rumor and decides what counts as a request.
  Extracted as a module specifically so the rules are testable without a browser.
- **A "Waiting for you" panel** — lists pending requests; **Admit** pre-fills the *existing*
  confirm panel rather than signing behind it, so "here is exactly what you are about to sign"
  still holds. **Not now** is local-only and published nowhere.

## Provenance — by signature, never by decryptability

That a ciphertext opened proves only it was addressed to us; it proves nothing about who wrote it.
Two checks, mirroring `docs/CONCORD_CONSUMER.md`:

1. the seal carries a valid signature — the sender is a real key, not a claim;
2. the rumor's author **is** the seal's signer.

Without (2), a stranger could wrap a rumor claiming any `pubkey` and the console would render
someone else's identity as the asker.

## Three refusals worth reviewing

- A signer with no `nip44Decrypt` (the local-key path) reports it **cannot read** requests instead
  of showing an empty list. "Nobody is asking" and "I could not look" are different claims.
- A wrap that could not be opened is **counted and reported**, never folded into a silent `0`.
- A request naming a grantee *other than its sender* is **kept but flagged** — asking on another
  key's behalf is legitimate (nvoy's `owner_npub`) and must not look identical to asking for
  yourself.

## Not in this PR, deliberately

**The grant↔return-lane linkage** (#141's second piece). A burner still sends and does not receive.
It is bridge lane logic and security-relevant; it wants its own PR and an adversarial review, not a
ride along with a UI change.

## Verification

- `npm test` — **23 suites green**, true exit 0 (checked separately; `$?` after a pipeline reports
  the pipe, not the script).
- `tests/console_requests.mjs` — 24 checks on real signatures and real nip44. Every refusal is
  paired with a legitimate value that must still get through, and fixtures use production-shaped
  strings (spaces, an apostrophe, `#`, angle brackets) rather than `A`/`B`.
- **Negative control run**: with the rumor-author check removed in a scratch copy, exactly one
  assertion failed — the forgery one — and no other. The suite detects that defect and only it.
- `suite_count.mjs` caught a stale `22` in `docs/GETTING_STARTED.md` that I had missed. #172's
  fix earning its keep on its first outing; the issue is landed and can be closed.

## Review

**Substantive under CLAUDE.md** — it touches an approval gate and runs on the page that holds a
live signing session, so it wants a second pair of eyes before merge. Suggested reviewer: Dennis,
on the two provenance checks and on the un-decryptable-wrap reporting.

⚠️ **Not merged deliberately** — merging deploys to production within ~3 minutes.

Drafted with assistance from [Claude Code](https://claude.com/claude-code)