### PR TITLE
bridge: inbound Concord decrypt, CROOT-gated (#191)

### DIFF
--- a/src/bridge.mjs
+++ b/src/bridge.mjs
@@ -49,6 +49,7 @@ import { log, err } from './log.mjs'
 import { durableSet, durableQueue } from './stores.mjs'
 import { fanout } from './fanout.mjs'
 import { defuseRefs, defuseMarkup, quoted, renderQuarantined, renderReleased } from './render.mjs'
+import { hex as concordHex, publicChannel, openChannelWrap } from './concord_lib.mjs'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const ROOT = resolve(__dirname, '..')
@@ -101,20 +102,60 @@ const TARGETS = Object.keys(RECIPIENTS)
 // --- Concord channel planes (additive; empty => pure DM bridge, no behavior change) --------
 // A public Concord channel's chat is a stream of kind:1059 wraps authored BY the channel's
 // derived plane pubkey (Concord inverts NIP-59: the outer p-tag is random, routing is by
-// `authors`). We forward each sealed wrap to every configured member's inbox; the agent
-// derives the plane key from ITS OWN community_root (held in-runtime) and decrypts.
-// NON-CUSTODIAL: we hold the plane PUBKEY only — a public address, never community_root.
+// `authors`). Two delivery modes, one gate:
+//
+//   DEFAULT (no read-key): forward the SEALED wrap to every member's inbox; the agent derives
+//   the plane key from ITS OWN community_root (held in-runtime) and decrypts. NON-CUSTODIAL: we
+//   hold the plane PUBKEY only — a public address, never community_root.
+//
+//   OPT-IN (#191, option 1): if the box is given the community read-key WB_COMMUNITY_ROOT and a
+//   channel carries a channel_id, we DERIVE the plane key here and deliver PLAINTEXT — the seat
+//   never touches Concord. This is a DELIBERATE, reversible READ concession for that channel: the
+//   box can now read it. It is a read-only trade — no member's SIGNING key is ever held (that
+//   invariant is unchanged; seal-back stays in each seat's own runtime). Pull the env var and
+//   redeploy to return to sealed-forward. Absent the root, absent a channel_id, or on ANY
+//   derivation mismatch, every channel falls back to the sealed-forward behavior above, byte for
+//   byte — so a wrong or missing read-key can only ever be as safe as today, never worse.
+//
 // config.channels[]: { name, plane_pubkey, channel_id?, epoch?, recipients: [<recipient name>...] }
-const PLANES = {} // plane_pubkey_hex -> { name, recipients: [ {name, inbox} ] }
+// community_root is a SECRET read-capability — it arrives ONLY via the WB_COMMUNITY_ROOT env var,
+// never config.json, and is never logged.
+const PLANES = {} // plane_pubkey_hex -> { name, recipients, channelId?, epoch?, planeKey? }
 const NAME_TO_REC = {}
 for (const hex of TARGETS) NAME_TO_REC[RECIPIENTS[hex].name] = RECIPIENTS[hex]
+// Decode the read-key once, loudly. A malformed value disables decrypt (sealed-forward) rather
+// than crashing the bridge — the concord_lib guards throw on a bad root, and we catch that here.
+let COMMUNITY_ROOT = null
+if (process.env.WB_COMMUNITY_ROOT) {
+  try { COMMUNITY_ROOT = concordHex(process.env.WB_COMMUNITY_ROOT) }
+  catch (e) { err(`WARN: WB_COMMUNITY_ROOT is set but not valid hex (${e.message}) — inbound decrypt DISABLED, forwarding SEALED`) }
+}
 for (const c of cfg.channels || []) {
   if (!c.plane_pubkey) { err(`WARN: channel '${c.name}' has no plane_pubkey — skipping`); continue }
   const recips = (c.recipients || []).map(n => NAME_TO_REC[n]).filter(Boolean)
   const missing = (c.recipients || []).filter(n => !NAME_TO_REC[n])
   if (missing.length) err(`WARN: channel '${c.name}' names unknown recipient(s): ${missing.join(', ')}`)
   if (!recips.length) { err(`WARN: channel '${c.name}' has no resolvable recipients — skipping`); continue }
-  PLANES[c.plane_pubkey.toLowerCase()] = { name: c.name, recipients: recips }
+  const planePk = c.plane_pubkey.toLowerCase()
+  const entry = { name: c.name, recipients: recips, channelId: c.channel_id || null, epoch: c.epoch ?? null }
+  // Opt-in decrypt: derive the plane key and PROVE it against the configured plane_pubkey before
+  // trusting it. A mismatch means the read-key, channel_id, or epoch is wrong — we then decline to
+  // decrypt (sealed-forward) rather than deliver something derived from a bad key. This is the
+  // guard James and Neil signed off: the box only reads a channel it can prove it has the key for.
+  if (COMMUNITY_ROOT && entry.channelId) {
+    try {
+      const pk = publicChannel(COMMUNITY_ROOT, concordHex(entry.channelId), entry.epoch ?? 0)
+      if (pk.pub !== planePk) {
+        err(`WARN: channel '${c.name}' derived plane ${pk.pub.slice(0, 12)}… != configured ${planePk.slice(0, 12)}… — read-key/channel_id/epoch mismatch; forwarding SEALED (no decrypt)`)
+      } else {
+        entry.planeKey = pk
+        log(`channel '${c.name}': inbound decrypt ENABLED — box holds the read-key, deliveries are PLAINTEXT (reversible read concession)`)
+      }
+    } catch (e) {
+      err(`WARN: channel '${c.name}' plane derivation failed (${e.message}) — forwarding SEALED (no decrypt)`)
+    }
+  }
+  PLANES[planePk] = entry
 }
 const PLANE_AUTHORS = Object.keys(PLANES)
 
@@ -567,12 +608,36 @@ function forward(rec, ev, src) {
     return
   }
   if (process.env.WB_STUB_SEND) { log(`FORWARD[stub] -> ${rec.name} inbox ${rec.inbox}: 1059 ${ev.id.slice(0, 12)}…`); return }
-  emit({
-    template: 'sealed_envelope',
-    dest: rec.inbox,
-    slots: { name: rec.name, channel: (src && src.channel) || undefined, wrapJson: JSON.stringify(ev) },
-  }).then(({ stdout }) => {
-    log(`FORWARD[buzz] ok -> ${rec.name} inbox: ${src && src.channel ? `${src.channel} ` : 'DM '}1059 ${ev.id.slice(0, 12)}…`)
+
+  // #191 option 1: if the box holds this channel's plane key, decrypt HERE and deliver plaintext.
+  // Any failure — a malformed wrap, an epoch we can't open — falls back to the sealed_envelope
+  // below rather than dropping the message. The fallback is load-bearing: both this and route()
+  // mark the event seen before the send resolves, so a throw that reached emit would lose the
+  // message permanently. Decrypt-or-seal is decided synchronously, before that point.
+  let descriptor = null
+  let decrypted = false
+  if (src && src.planeKey) {
+    try {
+      const { rumor } = openChannelWrap(src.planeKey, ev)
+      descriptor = {
+        template: 'channel_plaintext',
+        dest: rec.inbox,
+        slots: { channel: src.channel, sender: rumor.pubkey, body: String(rumor.content == null ? '' : rumor.content), replyTo: ev.id },
+      }
+      decrypted = true
+    } catch (e) {
+      err(`FORWARD decrypt ERR -> ${rec.name}: ${e.message} — sealed fallback for ${ev.id.slice(0, 12)}…`)
+    }
+  }
+  if (!descriptor) {
+    descriptor = {
+      template: 'sealed_envelope',
+      dest: rec.inbox,
+      slots: { name: rec.name, channel: (src && src.channel) || undefined, wrapJson: JSON.stringify(ev) },
+    }
+  }
+  emit(descriptor).then(({ stdout }) => {
+    log(`FORWARD[buzz] ok -> ${rec.name} inbox: ${decrypted ? 'plaintext ' : ''}${src && src.channel ? `${src.channel} ` : 'DM '}1059 ${ev.id.slice(0, 12)}…`)
     journalSend(parseBuzzEventId(stdout), { kind: 9, dest: rec.inbox, lane: 'sealed' })
   }).catch(e => {
     err(`FORWARD[buzz] ERR -> ${rec.name}: ${e.message}`)
@@ -601,7 +666,7 @@ function route(ev) {
     // provisioned inbox, so a dryrun or a placeholder inbox never suppresses later backfill.
     const willDeliver = FORWARD_MODE === 'buzz' && recips.some(r => !r.inbox.startsWith('INBOX_UUID_'))
     if (willDeliver) markSeen(ev.id)
-    for (const r of recips) forward(r, ev, { channel: plane.name })
+    for (const r of recips) forward(r, ev, { channel: plane.name, planeKey: plane.planeKey })
     return
   }
 

--- a/src/concord_lib.mjs
+++ b/src/concord_lib.mjs
@@ -137,6 +137,26 @@ export const guestbookPlane = (root, cid, epoch) => groupKey('concord/guestbook'
 export const publicChannel  = (root, channelId, rootEpoch) => groupKey('concord/channel', sec32(root, 'publicChannel'), channelId, rootEpoch);
 export const privateChannel = (channelKey, channelId, channelEpoch) => groupKey('concord/channel', sec32(channelKey, 'privateChannel'), channelId, channelEpoch);
 
+// Unwrap a public-channel Concord wrap (kind:1059) with a plane key from publicChannel().
+// CORD-03 §1: the channel stream is SELF-ADDRESSED — the seal and the inner rumor both open
+// with the plane's OWN conversation key (getConversationKey(plane_sk, plane_pub)), NOT an ECDH
+// seal to the outer p-tag (which is a random decoy). Two shapes per CORD-01: a kind:20013
+// seal carries an encrypted rumor in `content`; anything else carries the rumor as plaintext
+// JSON. Returns { seal, rumor }.
+//
+// The author check is the ROUTING invariant, not a nicety: a wrap is attributed to this channel
+// ONLY because its author IS the derived plane pubkey. Skipping it would let a wrap authored by
+// any other key be decrypted-and-attributed here the moment its content happened to open — so the
+// caller must never render a rumor whose wrap failed this check.
+export function openChannelWrap(planeKey, ev) {
+  if (!ev || ev.pubkey !== planeKey.pub) {
+    throw new Error(`wrap author ${String(ev && ev.pubkey).slice(0, 12)}… is not the plane pubkey ${planeKey.pub.slice(0, 12)}…`);
+  }
+  const seal = JSON.parse(nip44.v2.decrypt(ev.content, planeKey.conv));
+  const rumor = seal.kind === 20013 ? JSON.parse(nip44.v2.decrypt(seal.content, planeKey.conv)) : JSON.parse(seal.content);
+  return { seal, rumor };
+}
+
 // --- keyless control-entity coordinates (CORD-04/05). These are the ones the old
 //     omit-the-id helper silently got wrong. They are `eid`s carried by editions ON
 //     the Control Plane (CORD-04 §4, examples.md:464-466) — raw 32-byte values, not

--- a/src/egress.mjs
+++ b/src/egress.mjs
@@ -15,7 +15,7 @@
 // INV-A3-4  wrapJson is single-line by contract (§2.4), enforced at render time
 // INV-A3-5  every slot of every template declares one of the closed slot types
 import { execFile } from 'node:child_process'
-import { renderQuarantined, renderReleased } from './render.mjs'
+import { renderQuarantined, renderReleased, renderChannelPlain } from './render.mjs'
 
 // --- The closed slot-type set (§2.2, INV-A3-5) -----------------------------------------------
 //
@@ -154,6 +154,18 @@ const CATALOGUE = {
         : `New Armada DM — sealed, unwrap with your key:`
       return `@${name}\n\n${label}\n\n\`\`\`json\n${wrapJson}\n\`\`\`\n`
     },
+  },
+
+  // Site 1b — forward(), inbound Concord DECRYPT (#191, option 1). When the box holds the
+  // community read-key, a channel wrap is delivered as PLAINTEXT instead of a sealed_envelope, so
+  // the seat reads it without touching Concord. `body` is `carried_body` — the ONLY slot that
+  // accepts arbitrary bytes, neutralised by the renderer and attributed to its channel author, so
+  // a hostile #general post cannot reconstruct waggle's own words or ping a member in the inbox.
+  // `sender` is the rumor author's real pubkey; `replyTo` is the inbound wrap id for seal-back.
+  channel_plaintext: {
+    action: 'send',
+    slots: { channel: 'channel', sender: 'npub', body: 'carried_body', replyTo: 'id' },
+    render: (s) => renderChannelPlain(s),
   },
 
   // Site 2a — forwardPublic(), quarantined. The renderer is the guard; it is unchanged.

--- a/src/render.mjs
+++ b/src/render.mjs
@@ -58,5 +58,19 @@ export function renderReleased({ body, name, npubShort, liveRefs = false }) {
   return `**${name || npubShort}**  ·  \`${npubShort}\`  ·  _via waggle_\n\n${liveRefs ? body : defuseRefs(body)}`
 }
 
+// Inbound Concord channel post (#191, option 1), delivered DECRYPTED into a seat's inbox because
+// the box holds the community read-key. The seat reads plaintext and — if it chooses to answer —
+// runs the deterministic seal-back keyed on `reply-to`. The body was authored by whoever posted
+// in the channel, so it is NEUTRALISED (defuseRefs): a #general post containing "@someone" must
+// not spuriously ping a Buzz member in the seat's inbox. `sender` is the rumor author's real
+// pubkey (the routing invariant already proved the wrap was authored by the channel plane).
+// `replyTo` is the inbound wrap id, surfaced verbatim so the seat can seal a reply to it.
+export function renderChannelPlain({ channel, sender, body, replyTo }) {
+  const who = String(sender).slice(0, 12)
+  return `**#${channel}** · \`${who}…\` · _via waggle (decrypted)_\n\n` +
+    defuseRefs(body) +
+    `\n\n\`reply-to: ${replyTo}\``
+}
+
 // Repost a PLAINTEXT public note into a Buzz channel. `dest` is the community inbox for a
 // trusted (allowlisted) note, or the STAGING inbox for a quarantined external reply (A1).


### PR DESCRIPTION
Closes #191. Sibling tickets: #190 (provision CROOT into box env), #192 (deploy + live #general round-trip verify).

Originating conversation: waggle-test channel `a8186b53-537d-46ad-a7e7-b6486c58970e`, thread root `007b747e…` — James asked for procedural inbound #general decrypt so a seat replies without reasoning through Concord. He chose **option (1): the box decrypts**, Neil signed off.

## What this does
Moves the inbound Concord decrypt off the seat runtime and into the bridge, as a deliberate and reversible **read** concession.

- `concord_lib.openChannelWrap()` — unwrap a public-channel `kind:1059` with a plane key from `publicChannel()`. The **wrap-author == plane-pubkey check is the routing invariant**: a rumor whose wrap fails it is never decrypted-and-attributed to the channel.
- `bridge.mjs` — if `WB_COMMUNITY_ROOT` is present **and** a channel carries a `channel_id`, derive the plane key and **prove it against the configured `plane_pubkey`** before trusting it. On absence, malformed root, mismatch, or **any** decrypt failure, fall back to today's sealed-forward **byte for byte**. A wrong or missing read-key can only ever be as safe as today, never worse.
- `egress.mjs` — `channel_plaintext` template. `body` is `carried_body` (the one arbitrary-bytes slot), neutralised by the renderer and attributed to its channel author, so a hostile `#general` post can't reconstruct waggle's own words or ping a member in the seat's inbox.
- `render.mjs` — `renderChannelPlain()` surfaces `reply-to` so the seat can seal a reply.

## Security trade (the deliberate part)
The box gains the ability to **read** the configured channel. It does **not** gain any seat's **signing** key — that invariant is unchanged and asserted by the existing egress-ban suite (no `finalizeEvent`, no `BRIDGE_SK` outside `nostr_egress.mjs`). Seal-back stays in each seat's own runtime. Reversible: pull `WB_COMMUNITY_ROOT`, redeploy, box is fully blind again.

## Tests
Full suite green (23 suites, exit 0) — the egress-ban and catalogue suites cover the new template's slot-typing and confirm no signing capability was added.

**Known gap, flagged deliberately:** there is no dedicated *unit* test for `openChannelWrap` (roundtrip + author-check rejection). The validation shape this path actually needs is the **live #general round-trip in #192** (real wrap, real key on the box). I'll add a unit test as a fast-follow if you'd like belt-and-suspenders on the author-check.

Drafted with assistance from [Claude Code](https://claude.com/claude-code)