### PR TITLE
fix(lint): drop unused path in propose-admission (unbreaks main)

### DIFF
--- a/tools/propose-admission.mjs
+++ b/tools/propose-admission.mjs
@@ -88,7 +88,6 @@ try { sk = raw.startsWith('nsec1') ? nip19.decode(raw).data : Uint8Array.from(Bu
 if (!sk || sk.length !== 32) die('NACT_AUTH_NSEC is not a 32-byte key')
 const authPk = getPublicKey(sk)
 const url = `${NACT}/api/propose`
-const path = new URL(url).pathname
 const payload = createHash('sha256').update(body).digest('hex')
 const authEv = finalizeEvent({ kind: 27235, created_at: Math.floor(Date.now() / 1000),
   tags: [['u', url], ['method', 'POST'], ['payload', payload]], content: '' }, sk)


### PR DESCRIPTION
#193 merged with a red lint step — an unused `path` var in propose-admission.mjs. CI runs `eslint` separately from `npm test`, so a local test run passed while lint failed. This removes the dead binding. Production was never at risk (the runner ships only CI-green commits). Lint clean + 23 suites green.

Drafted with assistance from [Claude Code](https://claude.com/claude-code)