### PR TITLE
docs: in-door consent design (#131, #132, #133)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,14 +145,14 @@ that merely ran.** The suite was green through all of them.
 
 ## Tests
 
-`npm test` — 23 suites, against the real exported functions with synthetic events. No sockets,
+`npm test` — 24 suites, against the real exported functions with synthetic events. No sockets,
 no production state, no writes outside a temp dir.
 
 boot · suite roster · egress catalogue · egress ban · durable dedup store · relay fan-out · quarantine gating · deletion propagation · sealed-lane rate caps · grant
 admission · message rendering · deployed-build verification · return lane · return-lane scan ·
-return-lane no-miss · return-lane pending · relay ingress · tripwire union · tripwire detection drill · deploy runner · console Host check · undelivered record · console pending requests
+return-lane no-miss · return-lane pending · relay ingress · tripwire union · tripwire detection drill · deploy runner · console Host check · undelivered record · console pending requests · in-door consent
 
-CI runs them on push and PR. **If a run reports fewer than 23, the branch is on a stale base.**
+CI runs them on push and PR. **If a run reports fewer than 24, the branch is on a stale base.**
 The count of record is the `test` script in `package.json`; a prose count that disagrees with it
 is the prose being wrong.
 

--- a/README.md
+++ b/README.md
@@ -104,12 +104,12 @@ against what git says, because a stale build is invisible while every status sur
 
 ## Tests
 
-`npm test` runs 23 suites against the **real** exported functions with synthetic events — no
+`npm test` runs 24 suites against the **real** exported functions with synthetic events — no
 sockets, no production state:
 
 boot · suite roster · egress catalogue · egress ban · durable dedup store · relay fan-out · quarantine gating · deletion propagation · sealed-lane rate caps · grant
 admission · message rendering · deployed-build verification · return lane · return-lane scan ·
-return-lane no-miss · return-lane pending · relay ingress · tripwire union · tripwire detection drill · deploy runner · console Host check · undelivered record · console pending requests
+return-lane no-miss · return-lane pending · relay ingress · tripwire union · tripwire detection drill · deploy runner · console Host check · undelivered record · console pending requests · in-door consent
 
 The rendering suite is the one to read if you are reviewing. It tests what the bridge **refuses**,
 not only what it does: a hostile note tries to ping the approver, mint an `APPROVED BY` heading,

--- a/docs/CONSENT.md
+++ b/docs/CONSENT.md
@@ -1,0 +1,307 @@
+# In-door consent — the participant must agree to be brought in
+
+**Status:** DESIGN, for crew review (#131 + #132 as one story; #133 framed and recommended-against).
+Nothing here is built. The build is a separate PR after this design is reviewed and accepted.
+
+> Leads named on the issues: **@Dennis** — prior art + the consent-record primitive (the inverted
+> grant). **@Kerouac** — the participant-facing request + the ToS language. **@My Dude** — spec
+> synthesis + the `bridge.mjs` enforcement point. **@Neil** — the config/enforcement surface.
+
+---
+
+## 1. The principle, in one line
+
+**waggle must not ingest a person's content into the hive without that person's consent** — and the
+door has two sides, so the gate must too.
+
+The spec already holds the out-door half:
+
+> **§3.9 — Out-door consent.** *"The out door is per-note, explicit, member-initiated opt-in. The
+> bridge never federates a member's content automatically, in bulk, or by default."*
+
+That governs the person whose content **leaves**. There is no matching invariant for the person
+whose content is pulled **in**. This document defines it, for both in-paths, as one story.
+
+**It is not about privacy.** Their notes are already public; reading them is not a violation. What
+they never agreed to is **association and re-publication** — having their content piped into a
+private, walled, commercial community and re-authored under the bridge's own key, so they appear to
+be *in* a space they never joined, under terms they never saw. *"You may read my public posts"* is
+not *"you may mirror me into your community as your own `kind:9`, under its ToS."*
+
+And it dissolves a live unease: **§3.3 / B-2**, where re-authoring a third party's content makes the
+operator warrant rights he does not hold. **Consent at the source removes that exposure** — the
+content is now published into the community *with the author's agreement*, not despite its absence.
+
+---
+
+## 2. The consent gradient (the map of where we stand)
+
+Ingest is not one thing. It arrives on three ramps, and they already differ in how consensual they
+are — the estate half-built this gradient without ever naming it as *consent*.
+
+| ramp | who chose | consent today | gated today by | this doc |
+|---|---|---|---|---|
+| **granted participant** (§4.1) | the participant — holds a key, chose to join | **explicit** | a signed 440 admission | fine as is |
+| **reply to our note** (`watch_events`) | the replier — chose to address a member | **implied, thin** | §4 quarantine (community side only) | **#132** — add the author gate |
+| **feed-mirror** (`watch_authors`) | *nobody asked them* — we take the whole feed | **none** | author-allowlist (our choice, not theirs) | **#131** — add the author gate |
+
+The wall has a door each way, and an in-door should open only when **both** sides agree:
+
+| direction | community gate | external-party gate |
+|---|---|---|
+| out (member → Nostr) | — (member's own content) | §3.9 ✅ |
+| in — feed-mirror (`watch_authors`) | — | **#131 — missing** |
+| in — reply (`watch_events`) | §4 quarantine ✅ | **#132 — missing** |
+
+The community can already say *"let this in."* **The participant has never been asked *"do you
+consent to be brought in, under these terms?"*** Both in-paths are missing that gate. #131 and #132
+add it; they are one mechanism applied at two capture points, and ship as one spec.
+
+---
+
+## 3. What is genuinely new — and why it may be a primitive, not a config field
+
+This **inverts the grant direction.** Every grant in the estate flows *authority → subject*
+(maintainer admits a participant; maintainer delegates data to an agent). Consent flows the other
+way: *subject → bridge*. **The grantor is the data subject, not the authority.**
+
+Nostr has no native "accept." A `kind:3` follow is **unilateral** — I can follow you, aggregate you,
+mirror you, and you are never asked and cannot refuse in-protocol. So *consent to be aggregated* is
+a handshake the protocol **lacks**. That is the deep reason this is not a checkbox: we are defining
+a missing primitive, and it may be worth a NIP.
+
+The closest proven prior art is **ActivityPub's Follow / Accept**: a locked account *must* accept a
+follow before the follower receives anything. The shape we need is the same — *request → the subject
+decides → only then does content flow* — adapted to Nostr, where there is no server holding the
+subject's account to enforce it, so the acceptance must be **a signed event the bridge verifies.**
+
+---
+
+## 4. The consent record — the mechanism, weighed
+
+The issue is emphatic: *do not treat "scoped data grant" as the answer; weigh it.* Here is the weigh.
+
+### Candidate A — a participant-issued NIP-DA `440` (recommended)
+
+The participant signs a `440` granting waggle a **`da-cap: mirror`** capability, scoped to the
+community (salted-hash of the channel id, exactly as an admission scopes). Same wire format as a
+channel admit — **but authored by the participant, granting *to* waggle**, rather than by the
+maintainer granting *to* a participant.
+
+```
+kind 440                              (signed by the PARTICIPANT — the inverted grantor)
+  ['p', <waggle bridge pubkey>]       the grantee is the bridge
+  ['da-scope', sha256(community ‖ salt), salt]   which community they consent to be mirrored into
+  ['da-cap', 'mirror']                the capability granted: mirror my public content into it
+  ['tos', <sha256 of the exact ToS text shown>]  binds the consent to the terms presented (§7)
+  content: ""
+```
+
+- **Revocation is a plain `441`** e-tagging it — same shape as every revoke in the estate, and the
+  participant holds the revoke key because they are the grantor. Revoke → the mirror stops.
+- **It reuses everything.** The bridge already verifies `440`s (`grantSet`, `src/bridge.mjs:565`);
+  the same verify-sig-author-scope-cap path applies. `tools/grant.mjs`-style issuance applies.
+- **It is visible on the grant plane we just built.** Nvoy's universal reader
+  (`console/capgrants.mjs`) surfaces *every public `440` a key signed* — so a participant's consent
+  grant shows on **their** plane (they see and revoke their own consent) and inbound consents are
+  legible to the maintainer. The consent record is a first-class citizen of the plane, for free.
+- **It is not a semantic stretch.** A `da-cap` grant is already **bodyless** — a channel admit
+  carries no data set either. `mirror` is another capability alongside `admit`/`task`. The *only*
+  novelty is the inverted grantor, which is exactly the novelty we want to name.
+
+### Candidate B — a purpose-built consent event (a new kind)
+
+A dedicated `kind` meaning *"I, this key, consent to <bridge> aggregating my content into
+<community> under <ToS>, until revoked."*
+
+- **For:** semantically precise; a clean, standalone, NIP-shaped primitive that says what it means;
+  no risk of "why is a data-delegation kind being used for consent?"
+- **Against:** new wire format, new verification, new tooling, a new provisional kind to version; it
+  does **not** appear on the grant plane; more surface to build and maintain, for a semantic
+  cleanliness that A already achieves via the bodyless-capability pattern.
+
+### Recommendation
+
+**Candidate A**, and document the `da-cap: mirror` participant-issued grant *as* the consent
+primitive. It gives us the missing handshake **and** reuses issuance, verification, revocation, and
+the grant plane — while the inverted grantor is stated plainly as the novel thing. If the crew wants
+harder semantic separation between "delegating data" and "consenting to aggregation," B is the
+fallback and this section is where that call is made. **Dennis leads this decision.**
+
+*(One honest wrinkle either way: the consent record is a public event that names the participant's
+key and the community hash. That is the same optics trade §4.1 already accepted for admissions — an
+auditable signed consent beats a hidden allowlist — but it means "X consented to be mirrored into
+community-hash-Y" is publicly legible. Acceptable, and stated.)*
+
+---
+
+## 5. The handshake
+
+Both in-paths run the same four beats. They differ only in what **triggers** beat 1.
+
+```
+1. TRIGGER
+     #131 feed-mirror:  the maintainer wants to mirror author X (a watch_authors add).
+     #132 reply lane:   an external author replies to a member's federated note (watch_events catch).
+2. REQUEST + DISCLOSURE  — a NIP-17 DM to X's npub that IS the disclosure (many won't know the
+     bridge exists): "a bridge caught/would mirror your content into a private community; here is
+     exactly what that means [§7 ToS]; reply with a consent grant to allow it, or ignore to decline."
+3. CONSENT               — X signs the §4 record (a 440 to waggle, cap mirror, scope this community,
+     tos = hash of the exact terms shown). The bridge verifies it.
+4. FLOW                  — only now does X's content proceed: for #131 the mirror begins; for #132
+     the held reply is released into the §4 community quarantine for the *community* gate.
+```
+
+**Who sends the beat-2 DM — and does it violate "waggle carries, it never authors"?** A real design
+question, flagged for the crew. The request is not *content authored into the community*; it is an
+**operational disclosure to an external party about the bridge's own operation** — closer to a
+service ToS notice than to speech. Two options:
+- **(a) the bridge sends it**, as a strictly templated, non-conversational disclosure (no free
+  text — it rides the `src/egress.mjs` closed-slot machinery, so it can carry only the fixed ToS
+  template + the target npub). This keeps "never authors" intact because there is no authored
+  content, only a fixed form.
+- **(b) the maintainer sends it** as themselves. Cleanest against the immutable, but it re-couples
+  the flow to a human per target and loses the automation the intention asks for.
+
+Recommendation: **(a)**, precisely because the closed-slot egress (`#134` A3) already exists to make
+"the bridge emits only fixed forms, never free text" enforceable — a consent-request template is a
+natural new slot type. **My Dude / Neil to confirm against the egress catalogue.**
+
+---
+
+## 6. The edge cases that decide whether this is safe or harmful
+
+These are not footnotes — get them wrong and the consent mechanism *becomes* the harm.
+
+- **The consent DM is itself an unsolicited message (#132 Q3).** DMing everyone who replies is the
+  bridge spamming strangers. Non-negotiable rules: **DM once per target, ever**; **respect silence**
+  (no re-ask — silence is a *no*); **respect an explicit no permanently** (never re-ask a decliner);
+  rate-limit the request lane globally. A per-target "asked / declined / consented" record, durable,
+  gates the DM. If we cannot send the ask without spamming, we do not mirror — full stop.
+- **Default-closed (#131 Q2, #132 Q4).** No response = no ingestion. Their content stays on public
+  Nostr and never enters the community. Being unable to obtain consent is not permission — it is a
+  decline. This mirrors the repo's standing rule (`docs/AGENT_BRIEF.md`: "being unable to check is
+  not permission").
+- **Ordering — hold invisibly, not in quarantine (#132 Q1).** A reply must **not** appear in the
+  community quarantine before the author has consented. Quarantine is inside the walled space;
+  showing un-consented content there is the very association the person hasn't agreed to, and the
+  community seeing it pre-consent can't be undone. So: capture → **hold invisibly (config/log only,
+  never rendered)** → send the ask → on consent, *then* it enters the §4 quarantine for the
+  community gate. **Consent gate first, community gate second.** Both required, order fixed.
+- **Standing, not per-message (#132 Q2).** Consent once, revocable, covers future content — matching
+  the grant model. Per-message consent would re-spam and is rejected.
+- **Migration / grandfathering (#131 Q6).** Today `watch_authors` holds only consenting crew (James,
+  My Dude) — no live violation, the *capability* is the gap. Crew are **members**, not mirrored
+  strangers; they are grandfathered by participation (their key is in the roster, they built this).
+  The invariant binds every **non-member** entry: no consent record, no mirror. New `watch_authors`
+  or `watch_events` entries outside the roster require a verified consent record before the lane
+  will forward them, logged on refusal.
+
+---
+
+## 7. The terms the participant actually sees (Kerouac's lane)
+
+The ToS in the beat-2 DM must be short, plain, and complete enough that consent is *informed*. It
+must say, at minimum:
+
+1. **What the mirror does** — your public Nostr content will be reposted into a private, walled Buzz
+   community you are not a member of.
+2. **Where it lands and who sees it** — members of that community, inside their space, under that
+   community's terms.
+3. **The re-authoring, honestly** — today your content is reposted **under the bridge's key with an
+   attribution to you**, not as your own signed event (a platform limitation, A8; until it lands,
+   moderation and the platform's content license attach to the *operator's* copy, not to you).
+4. **That it is separate from your public presence** — your notes remain yours on the open network;
+   this governs only the mirrored copy inside the community.
+5. **That you can revoke anytime** — a `441` (or the console's revoke) stops the mirror; already-seen
+   content cannot be un-seen (physics), but no new content crosses.
+
+The `tos` tag on the consent record (§4) is the **sha256 of the exact text shown**, so a consent is
+provably bound to the terms it was given under — if the ToS changes materially, prior consents do
+not silently cover the new terms.
+
+---
+
+## 8. The enforcement point
+
+Grounded in the live code (`src/bridge.mjs`):
+
+- `routePublic(ev)` (`:877`) classifies each caught public note; `forwardPublic(ev, …)` (`:810`)
+  does the repost. `grantSet` (`:565`) is the admitted-participant set (from `440`s), already
+  consulted at `:902` and for live `@mention` refs at `:838`.
+- **#131 feed-mirror:** add a **consent set** alongside `grantSet` — `mirrorConsent: participantPub
+  → {recordId, tosHash}`, built from verified participant-issued `mirror` `440`s exactly as
+  `grantSet` is built from admission `440`s (`:590`). In `routePublic`, a `watch_authors` match
+  forwards **only if** `mirrorConsent.has(ev.pubkey)`; else it is dropped and logged
+  (`no consent — held`, never a silent drop, per §7's firehose discipline).
+- **#132 reply lane:** the `watch_events` catch is held in the new **invisible** pre-consent state
+  (§6 ordering) until `mirrorConsent.has(ev.pubkey)`; on consent it is handed to the existing §4
+  quarantine (A1) for the community gate. Two independent gates, both must pass, participant first.
+- **Revocation** rides the existing `441` path (`:575` already removes a grantee from `grantSet` on
+  a matching `441`) — the same handler drops the consent record, and the mirror stops on the next
+  read. No restart.
+- **Config coupling (Neil):** `watch_authors` / `watch_events` entries outside the roster are inert
+  until a consent record exists — so an operator *adding* an author is no longer the moment content
+  flows; the participant's *consent* is. Findable and flowing stay two switches, as §3.5 already
+  insists for the `#p` watch.
+
+---
+
+## 9. Relationship to the DM trust allowlist — adjacent, not the same
+
+`docs/DM_TRUST_ALLOWLIST.md` governs authority to **instruct** an agent (evaluated at the agent's
+runtime edge, post-decrypt). This governs authority to **ingest** a person's content (evaluated at
+the bridge, before mirroring). Different actor, different question, different enforcement point.
+They touch only in that both involve external parties and NIP-17 DMs. Keep them distinct: a sender
+being allowed to *instruct* says nothing about a subject consenting to be *mirrored*, and vice versa.
+
+---
+
+## 10. #133 — community-to-community: framed, and recommended against (for now)
+
+The third family member is the deepest, and it sits on a prior question the other two don't touch.
+
+**The layer beneath consent: Buzz is deliberately non-federated.** §3.4, verified against Block's
+source: *"no outbound-federation code exists anywhere in `buzz-relay` — non-federation is a
+deliberate product property."* So Buzz-to-Buzz federation via waggle would **add a capability Block
+deliberately omitted, between two walls each designed to stay walled.** That is categorically
+different from our public-Nostr and MCP-agent work, which extends *Nostr's* native openness. It is a
+§3.4 / B-1 "are we honoring the platform's intent?" question, not an interop question.
+
+**Recommendation: decline actual channel-to-channel federation; use UC-2's neutral space.** §5 UC-2
+already gives two communities a way to collaborate — a neutral sealed Concord channel *beside* both
+walls, each side running its own waggle, neither wall opened, no membership shared. That meets the
+real need (inter-community collaboration) **without** manufacturing the federation Block chose not to
+build. Actual federation should not be built on the strength of this document.
+
+**If it is ever pursued, the consent structure nests and both levels are required:**
+
+| level | who consents | to what |
+|---|---|---|
+| community | the two maintainer keys | to federate at all (a signed agreement between them) |
+| individual | each member whose content crosses | to appear in the *other* community under *its* terms — **this is #131/#132 at the boundary** |
+
+A maintainer agreeing to federate **does not** consent on behalf of members; the individual gate
+still applies to everyone whose content actually crosses. And a new problem the individual cases
+don't have — **ToS reconciliation**: when a member's content crosses A→B, whose terms govern it, A's
+or B's? The §3.3/B-2 exposure multiplies to community scale. Revocation is two-level and independent
+(a community ends the link; a member stops their own content crossing). **Research/design only —
+possibly no build ever.** Its own epic if it ever moves.
+
+---
+
+## 11. Deliverable status and the build that follows
+
+This document is the **design** the issues asked for: intention, handshake, consent record, ToS,
+enforcement point, and revocation, with the mechanism weighed. It is **not built.**
+
+The build, in order, after this is reviewed and accepted:
+1. the consent record + verification (a `consent.mjs` primitive, pure and tested, mirroring
+   `capgrants.mjs` — verify a participant `mirror` `440`, resolve its `441`);
+2. the request/disclosure DM as a closed-slot egress template (§5a), rate-limited and once-per-target;
+3. the `mirrorConsent` set and the two enforcement gates in `bridge.mjs` (§8) — **security-relevant
+   lane logic; lands as its own PR with adversarial review, never a tack-on**;
+4. the ToS text (§7), Kerouac.
+
+Default-closed until it lands: **do not point `watch_authors` or a `#p`/`watch_events` widen at
+anyone outside the consenting crew in the meantime.**

--- a/docs/CONSENT.md
+++ b/docs/CONSENT.md
@@ -1,11 +1,41 @@
 # In-door consent — the participant must agree to be brought in
 
-**Status:** DESIGN, for crew review (#131 + #132 as one story; #133 framed and recommended-against).
-Nothing here is built. The build is a separate PR after this design is reviewed and accepted.
+**Status:** DESIGN, **reviewed by the crew 2026-08-02** (#131 + #132 as one story; #133 framed and
+recommended-against). Nothing is built beyond the reference primitive (`src/consent.mjs`, §11). The
+build is a separate PR after acceptance.
 
 > Leads named on the issues: **@Dennis** — prior art + the consent-record primitive (the inverted
 > grant). **@Kerouac** — the participant-facing request + the ToS language. **@My Dude** — spec
 > synthesis + the `bridge.mjs` enforcement point. **@Neil** — the config/enforcement surface.
+
+## 0. Review outcome (2026-08-02) — folded in below, each item verified against source
+
+- **Mechanism decided — Candidate A (Dennis).** Participant-issued `440`, `da-cap:mirror`. Dennis
+  verified the reference primitive (`tests/consent.mjs` 15/15; `scopeHash` byte-matches
+  `bridge.mjs:561`). **Binding safety condition:** `mirror` is a **reserved capability estate-wide**
+  — every `440` reader disambiguates on `cap == 'mirror' && grantee == bridge && author == subject`
+  and never treats it as a data delegation (§4, §8).
+- **Two errors corrected (My Dude, verified).** (1) The disclosure DM rides **`nostr_egress.mjs`**
+  (sealed lane), not `egress.mjs` (Buzz-only) — §5. (2) The consent set **cannot reuse `grantSet`'s
+  builder** — `processGrantEvent:569` drops non-maintainer authors; it needs its own subscription,
+  and revocation its own lane — §8.
+- **The prefill-signer (Dennis, resolving Kerouac's flag).** A stranger won't hand-roll a `440`, so
+  the bridge/console emits the **fully-formed `440` minus the signature** (scope hash precomputed
+  with the bridge's salt, `da-cap:mirror`, `tos`); the participant only **signs and publishes**. Two
+  surfaces, byte-identical events: a console one-click, and a `nostrconnect:`/NIP-07 deep-link in the
+  DM. The signature is still theirs — the whole primitive (§5).
+- **ToS drafted (Kerouac)** — cover line + canonical block, all five §7 points, in
+  `~/.buzz/OUTBOX/CONSENT_TOS_S7.md`. **Hash convention (required, not tidy):** hash the **canonical
+  block only**, target npub **excluded** (keeps `expectedTosHash` one-per-community, O(1)); with
+  `{COMMUNITY}`/`{TERMS_URL}` and a literal **`v1`** *inside* the hash (§7).
+- **The send-side durable ask-record (My Dude add).** §6's anti-spam gate needs a durable record
+  (same class as `RLSEEN_PATH`/`UNDELIVERED_PATH`) checked **before** emitting the beat-2 DM — no
+  emit without an ask-record check (§6, §8).
+- **⚠ Two policy calls flagged for @James** (mechanism can't close them): the **ToS-version** rule
+  (a material `v1→v2` permits *one* fresh ask per target for the new version; an explicit **no is
+  permanent across all versions**; key asked/consented on `(target, tosVersion)`, declined on
+  `target` alone), and the fact that the disclosure DM is waggle's **first unsolicited outbound seal
+  to a stranger**, so §6's gate is load-bearing (§6).
 
 ---
 
@@ -157,15 +187,21 @@ question, flagged for the crew. The request is not *content authored into the co
 **operational disclosure to an external party about the bridge's own operation** — closer to a
 service ToS notice than to speech. Two options:
 - **(a) the bridge sends it**, as a strictly templated, non-conversational disclosure (no free
-  text — it rides the `src/egress.mjs` closed-slot machinery, so it can carry only the fixed ToS
-  template + the target npub). This keeps "never authors" intact because there is no authored
-  content, only a fixed form.
+  text — a fixed form, no free-prose slot). This keeps "never authors" intact because there is no
+  authored content, only a fixed form.
 - **(b) the maintainer sends it** as themselves. Cleanest against the immutable, but it re-couples
   the flow to a human per target and loses the automation the intention asks for.
 
-Recommendation: **(a)**, precisely because the closed-slot egress (`#134` A3) already exists to make
-"the bridge emits only fixed forms, never free text" enforceable — a consent-request template is a
-natural new slot type. **My Dude / Neil to confirm against the egress catalogue.**
+Recommendation: **(a)** — but on the **right transport, corrected in review (My Dude, verified
+against source).** The disclosure DM does **not** ride `src/egress.mjs`: that module speaks only
+Buzz channel posts (every template ends at `buzz messages send`). The beat-2 ask is a **NIP-17
+sealed `1059` to an external npub** — a different transport, which already exists with the same
+closed-slot discipline as **`src/nostr_egress.mjs`** (`sealAndWrap({template, to, slots})`, its own
+closed `NOSTR_TEMPLATE_NAMES` catalogue, and it *refuses a string body* at `:161`). So the mechanism
+is a **new `consent_request` template in `nostr_egress.mjs`'s catalogue**, not a slot type in
+`egress.mjs`. The intent (fixed form, "carries never authors" held by type) is exactly right; the
+module was wrong. **This is also waggle's first *unsolicited* outbound seal to a stranger — its
+safety lives entirely in the §6 anti-spam gate.**
 
 ---
 
@@ -229,17 +265,34 @@ Grounded in the live code (`src/bridge.mjs`):
 - `routePublic(ev)` (`:877`) classifies each caught public note; `forwardPublic(ev, …)` (`:810`)
   does the repost. `grantSet` (`:565`) is the admitted-participant set (from `440`s), already
   consulted at `:902` and for live `@mention` refs at `:838`.
-- **#131 feed-mirror:** add a **consent set** alongside `grantSet` — `mirrorConsent: participantPub
-  → {recordId, tosHash}`, built from verified participant-issued `mirror` `440`s exactly as
-  `grantSet` is built from admission `440`s (`:590`). In `routePublic`, a `watch_authors` match
-  forwards **only if** `mirrorConsent.has(ev.pubkey)`; else it is dropped and logged
-  (`no consent — held`, never a silent drop, per §7's firehose discipline).
+- **#131 feed-mirror:** add a **consent set** `mirrorConsent: participantPub → {recordId, tosHash}`.
+  **Corrected in review (My Dude, verified against source): it CANNOT reuse `grantSet`'s builder.**
+  `processGrantEvent` rejects any `440` whose author is not a maintainer grantor (`bridge.mjs:569`,
+  `if (!grantors.includes(ev.pubkey)) return`) — and consent authors are *external participants*, so
+  every consent would drop at `:569` before it was read. The consent set needs its **own
+  subscription** — a REQ for `440`s p-tagging the bridge with `da-cap:mirror`, from **any** author —
+  feeding `readConsents()`, a separate lane from `grantSet` by construction. In `routePublic`, a
+  `watch_authors` match forwards **only if** `mirrorConsent.has(ev.pubkey)`; else dropped and logged
+  (`no consent — held`, never a silent drop).
+  - *Why this is still safe against the `440` overload (Dennis + My Dude):* inside `bridge.mjs`,
+    `grantSet`'s builder uses a **positive cap allowlist** (`:589 cap !== 'admit' && cap !==
+    'admit+read'`), so a `mirror` `440` falls through and never pollutes `grantSet`. bridge.mjs is
+    safe as written. The *reserve-`mirror`-estate-wide* requirement (Dennis) therefore binds
+    **blocklist-shaped** consumers — `capgrants.mjs`, any future `440` reader — which must
+    disambiguate on the full tuple `cap == 'mirror' && grantee == bridge && author == subject` and
+    never treat `mirror` as a data delegation.
 - **#132 reply lane:** the `watch_events` catch is held in the new **invisible** pre-consent state
   (§6 ordering) until `mirrorConsent.has(ev.pubkey)`; on consent it is handed to the existing §4
   quarantine (A1) for the community gate. Two independent gates, both must pass, participant first.
-- **Revocation** rides the existing `441` path (`:575` already removes a grantee from `grantSet` on
-  a matching `441`) — the same handler drops the consent record, and the mirror stops on the next
-  read. No restart.
+- **Revocation — its own lane, not the existing `441` path (corrected, My Dude).** The `:575`
+  handler matches on `grantId` only and is reached solely past the `:569` grantor gate — i.e.
+  maintainer-authored `441`s. Consent revocation has the stricter rule the primitive already
+  enforces (`consent.mjs`: a `441` counts *only if signed by the same participant who granted*), so
+  it lives in the same separate `readConsents` lane. Mirror stops on the next read. No restart.
+- **The scope landmine (Dennis, confirmed):** `verifyConsent`/`readConsents` must be called with
+  `communityId = PUB.inbox` — the exact secret admissions scope to (`bridge.mjs:588`,
+  `scopeHash(PUB.inbox, …)`), byte-identical to `consent.mjs`'s `scopeHash`. Any other value and
+  every consent fails closed on scope.
 - **Config coupling (Neil):** `watch_authors` / `watch_events` entries outside the roster are inert
   until a consent record exists — so an operator *adding* an author is no longer the moment content
   flows; the participant's *consent* is. Findable and flowing stay two switches, as §3.5 already
@@ -292,16 +345,20 @@ possibly no build ever.** Its own epic if it ever moves.
 
 ## 11. Deliverable status and the build that follows
 
-This document is the **design** the issues asked for: intention, handshake, consent record, ToS,
-enforcement point, and revocation, with the mechanism weighed. It is **not built.**
+This document is the **design** the issues asked for, **reviewed and its mechanism decided** (§0).
+The reference primitive is built; the rest is not.
 
-The build, in order, after this is reviewed and accepted:
-1. the consent record + verification (a `consent.mjs` primitive, pure and tested, mirroring
-   `capgrants.mjs` — verify a participant `mirror` `440`, resolve its `441`);
-2. the request/disclosure DM as a closed-slot egress template (§5a), rate-limited and once-per-target;
-3. the `mirrorConsent` set and the two enforcement gates in `bridge.mjs` (§8) — **security-relevant
-   lane logic; lands as its own PR with adversarial review, never a tack-on**;
-4. the ToS text (§7), Kerouac.
+The build, in order, after acceptance:
+1. **✅ the consent record + verification** — `src/consent.mjs`, pure and tested (`tests/consent.mjs`,
+   15/15), crew-verified. **Done** as the reference deliverable.
+2. the request/disclosure DM as a **new `consent_request` template in `src/nostr_egress.mjs`** (the
+   sealed lane — *not* `egress.mjs`, §5), gated by the §6 durable ask-record, once-per-target
+   (@My Dude owns this + item 3).
+3. the `mirrorConsent` set + its **own** subscription and the two enforcement gates in `bridge.mjs`
+   (§8) — **security-relevant lane logic; its own PR with adversarial review, never a tack-on**.
+4. the ToS text — **✅ drafted** (`~/.buzz/OUTBOX/CONSENT_TOS_S7.md`, @Kerouac); wire in the §7 hash
+   convention when item 2 lands.
+5. **@James** — the two policy calls in §0 (ToS-version ask rule; first-unsolicited-seal posture).
 
 Default-closed until it lands: **do not point `watch_authors` or a `#p`/`watch_events` widen at
 anyone outside the consenting crew in the meantime.**

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -120,7 +120,7 @@ in [deploy/README.md](../deploy/README.md).
 - **Publish the agent relay list:** `node tools/publish_relay_list.mjs` (so the identity
   is discoverable).
 - **Admit a participant**, if you want one: `sh tools/grant-setup.sh`.
-- **Run the safety gates before you ship:** `npm test` — 23 suites driving the real
+- **Run the safety gates before you ship:** `npm test` — 24 suites driving the real
   routing functions with synthetic events (no sockets, no production state), all green.
 
 `waggle-init.mjs --check` rolls the config half of this into one readiness verdict; the

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "start": "node src/bridge.mjs",
     "dryrun": "FORWARD_MODE=dryrun node src/bridge.mjs",
     "lint": "eslint src tools tests",
-    "test": "node tests/suite_count.mjs && node tests/boot.mjs && node tests/egress_catalogue.mjs && node tests/egress_ban.mjs && node tests/relay_fanout.mjs && node tests/durable_store.mjs && node tests/a1_quarantine.mjs && node tests/a7_deletion.mjs && node tests/lane2_caps.mjs && node tests/nipda_admission.mjs && node tests/render_states.mjs && node tests/deploy_verify.mjs && node tests/return_lane.mjs && node tests/return_lane_scan.mjs && node tests/return_lane_nomiss.mjs && node tests/return_lane_pending.mjs && node tests/relay_ingress.mjs && node tests/tripwire_union.mjs && node tests/tripwire_detection.mjs && node tests/deploy_runner.mjs && node tests/console_host.mjs && node tests/undelivered.mjs && node tests/console_requests.mjs",
+    "test": "node tests/suite_count.mjs && node tests/boot.mjs && node tests/egress_catalogue.mjs && node tests/egress_ban.mjs && node tests/relay_fanout.mjs && node tests/durable_store.mjs && node tests/a1_quarantine.mjs && node tests/a7_deletion.mjs && node tests/lane2_caps.mjs && node tests/nipda_admission.mjs && node tests/render_states.mjs && node tests/deploy_verify.mjs && node tests/return_lane.mjs && node tests/return_lane_scan.mjs && node tests/return_lane_nomiss.mjs && node tests/return_lane_pending.mjs && node tests/relay_ingress.mjs && node tests/tripwire_union.mjs && node tests/tripwire_detection.mjs && node tests/deploy_runner.mjs && node tests/console_host.mjs && node tests/undelivered.mjs && node tests/console_requests.mjs && node tests/consent.mjs",
     "console": "node tools/serve-console.mjs"
   },
   "dependencies": {

--- a/src/consent.mjs
+++ b/src/consent.mjs
@@ -1,0 +1,105 @@
+// consent.mjs — verify a participant's in-door consent (design: docs/CONSENT.md, #131/#132).
+//
+// REFERENCE IMPLEMENTATION of the recommended mechanism, pure and standalone — NOT wired into the
+// bridge. It exists to make the design concrete for review; if the crew picks the purpose-built
+// consent-event alternative over the participant-issued 440, this is discarded. It mirrors
+// nvoy console/capgrants.mjs: read events, verify, classify, resolve revocation — no I/O, no state.
+//
+// THE INVERSION IS THE WHOLE POINT. Every other grant in the estate is authored by the AUTHORITY
+// (the maintainer admits a participant). A consent record is authored by the DATA SUBJECT — the
+// participant grants waggle a `mirror` capability over their OWN content. So the checks below key
+// on: the grantee is the bridge (`p` == bridge), the cap is `mirror`, the scope is THIS community,
+// and — the load-bearing one — a revocation only counts if it is signed by the SAME participant who
+// granted. Only the grantor may revoke their own consent.
+
+import { verifyEvent } from 'nostr-tools/pure'
+import { createHash } from 'node:crypto'
+
+export const KIND = { grant: 440, revocation: 441 }
+export const CONSENT_CAP = 'mirror'
+
+// Identical construction to tools/grant.mjs and src/bridge.mjs (scopeHash). If this drifts, a
+// consent scoped to a community will never match the community's own recomputed hash and every
+// consent silently fails closed — so it is written to mirror them literally.
+export function scopeHash(communityId, saltHex) {
+  return createHash('sha256').update(Buffer.concat([
+    Buffer.from('waggle/da-scope/v1'), Buffer.from([0]),
+    Buffer.from(String(communityId)), Buffer.from(saltHex, 'hex'),
+  ])).digest('hex')
+}
+
+const tagVal = (ev, k) => (ev.tags.find(t => t[0] === k) || [])[1]
+
+/**
+ * Verify one event as a mirror-consent grant for THIS bridge + community.
+ *
+ * @param ev                  a candidate 440
+ * @param opts.bridgePubkey   waggle's hex pubkey — the grantee a consent must name
+ * @param opts.communityId    the channel/community id the bridge mirrors into (its own secret)
+ * @param opts.expectedTosHash  if given, the consent's `tos` must match — consent is bound to the
+ *                              exact terms shown, so changed terms don't ride an old yes (§7)
+ * @returns { ok:true, participant, tosHash } | { ok:false, reason }
+ *
+ * The participant (grantor) is the event's AUTHOR — never a `p` tag, never a claim. That is what
+ * makes this consent and not something a third party can forge on the subject's behalf.
+ */
+export function verifyConsent(ev, { bridgePubkey, communityId, expectedTosHash } = {}) {
+  if (!ev || ev.kind !== KIND.grant) return { ok: false, reason: 'not a 440' }
+  if (tagVal(ev, 'da-cap') !== CONSENT_CAP) return { ok: false, reason: 'not a mirror capability' }
+  // The grantee must be THIS bridge — a consent naming some other key is not consent to us.
+  if ((tagVal(ev, 'p') || '').toLowerCase() !== String(bridgePubkey).toLowerCase()) {
+    return { ok: false, reason: 'grantee is not this bridge' }
+  }
+  // Signature first: an unsigned/forged 440 is not authority, and its `pubkey` is a claim until
+  // verifyEvent holds. Wire-form only (a finalize symbol would short-circuit — the tests use real sigs).
+  let sigOk; try { sigOk = verifyEvent(ev) } catch { sigOk = false }
+  if (!sigOk) return { ok: false, reason: 'signature does not verify' }
+  // Scope must recompute to THIS community from the consent's own salt. A consent scoped to another
+  // community does not authorise mirroring into ours.
+  const scope = ev.tags.find(t => t[0] === 'da-scope')
+  if (!scope || !scope[2]) return { ok: false, reason: 'no salted scope' }
+  if (scopeHash(communityId, scope[2]) !== scope[1]) return { ok: false, reason: 'scope is another community' }
+  const tosHash = tagVal(ev, 'tos') || null
+  if (expectedTosHash !== undefined && tosHash !== expectedTosHash) {
+    return { ok: false, reason: 'consent is bound to different terms than the current ToS' }
+  }
+  // The participant is the AUTHOR — the data subject who signed their own consent.
+  return { ok: true, participant: ev.pubkey, tosHash }
+}
+
+/**
+ * Build the live consent set from a batch of 440/441 events.
+ *
+ * @returns { consent: Map(participantPub -> {recordId, tosHash}), revoked, rejected }
+ *   `consent` holds only ACTIVE, this-bridge, this-community consents. `revoked`/`rejected` are
+ *   COUNTED, never swallowed — "nobody has consented" and "we couldn't read the consents" are
+ *   different facts (the house rule: being unable to check is not being fine).
+ *
+ * Revocation rule, stated because it is the subtle one: a 441 revokes a consent ONLY if it is
+ * signed by the SAME key that granted it. A 441 from anyone else — even the bridge, even the
+ * maintainer — does not revoke a participant's consent. The subject alone withdraws their consent.
+ */
+export function readConsents(events, { bridgePubkey, communityId, expectedTosHash } = {}) {
+  const grants = new Map()          // recordId -> { participant, tosHash, ev }
+  const revsByAuthor = new Map()    // "author|targetId" -> true
+  for (const ev of events || []) {
+    if (ev.kind === KIND.grant) {
+      const v = verifyConsent(ev, { bridgePubkey, communityId, expectedTosHash })
+      if (v.ok) grants.set(ev.id, { participant: v.participant, tosHash: v.tosHash, ev })
+    } else if (ev.kind === KIND.revocation) {
+      let sigOk; try { sigOk = verifyEvent(ev) } catch { sigOk = false }
+      if (!sigOk) continue
+      for (const t of ev.tags) if (t[0] === 'e' && t[1]) revsByAuthor.set(`${ev.pubkey}|${t[1]}`, true)
+    }
+  }
+  const consent = new Map()
+  let revoked = 0
+  for (const [recordId, g] of grants) {
+    // Revoked iff the SAME participant published a 441 e-tagging this record.
+    if (revsByAuthor.has(`${g.participant}|${recordId}`)) { revoked++; continue }
+    // Newest active consent per participant wins (a re-consent under new terms supersedes).
+    const prev = consent.get(g.participant)
+    if (!prev || g.ev.created_at >= prev.at) consent.set(g.participant, { recordId, tosHash: g.tosHash, at: g.ev.created_at })
+  }
+  return { consent, revoked, checked: (events || []).length }
+}

--- a/tests/consent.mjs
+++ b/tests/consent.mjs
@@ -1,0 +1,115 @@
+// consent.mjs — assertions over the in-door consent primitive (src/consent.mjs, #131/#132).
+//
+// The promise (docs/CONSENT.md): a participant's OWN signed consent is what admits their content,
+// and only they can withdraw it. So the tests target the ways that promise fails silently:
+//   - a consent forged on the subject's behalf being accepted (the inversion must hold);
+//   - a revocation by anyone-but-the-grantor stopping a valid consent (only the subject withdraws);
+//   - a consent scoped to another community, or bound to different terms, leaking through.
+// Every acceptance is paired with a rejection, real signatures throughout (wire-form, so verifyEvent
+// doesn't short-circuit on the finalize symbol).
+//
+//   node tests/consent.mjs
+
+import { randomBytes, createHash } from 'node:crypto'
+import { generateSecretKey, getPublicKey, finalizeEvent } from 'nostr-tools/pure'
+import { verifyConsent, readConsents, scopeHash, CONSENT_CAP } from '../src/consent.mjs'
+
+let n = 0, pass = 0
+const t = (name, cond) => { n++; if (cond) { pass++; console.log(`ok - ${name}`) } else console.error(`FAIL - ${name}`) }
+
+const bridgeSk = generateSecretKey(), bridgePubkey = getPublicKey(bridgeSk)
+const partSk = generateSecretKey(), participant = getPublicKey(partSk)
+const COMMUNITY = 'a8186b53-537d-46ad-a7e7-b6486c58970e'
+const TOS = createHash('sha256').update('the exact terms shown to the participant').digest('hex')
+
+// Wire-form: strip the finalizeEvent validity symbol so verifyEvent actually re-checks the
+// signature (the bridge only ever sees wire-form events off relays; a symbol-carrying event would
+// short-circuit verification and hide a real forgery — the lesson tests/nipda_admission.mjs states).
+const wire = (ev) => JSON.parse(JSON.stringify(ev))
+
+// Build a consent 440 the way a participant would: THEY sign it, granting `mirror` to the bridge.
+function consentGrant(sk, { community = COMMUNITY, cap = CONSENT_CAP, tos = TOS, grantee = bridgePubkey, created_at = 1000 } = {}) {
+  const salt = randomBytes(16).toString('hex')
+  return wire(finalizeEvent({
+    kind: 440, created_at,
+    tags: [['p', grantee], ['da-scope', scopeHash(community, salt), salt], ['da-cap', cap], ['tos', tos]],
+    content: '',
+  }, sk))
+}
+const opts = { bridgePubkey, communityId: COMMUNITY, expectedTosHash: TOS }
+
+// --- 1. A GENUINE CONSENT IS ACCEPTED, and names the subject as its author ----------------------
+{
+  const g = consentGrant(partSk)
+  const v = verifyConsent(g, opts)
+  t('a participant-signed mirror consent verifies', v.ok === true)
+  t('  the participant is the AUTHOR (the data subject), not a p tag', v.participant === participant)
+  t('  the ToS hash rides with it', v.tosHash === TOS)
+}
+
+// --- 2. THE INVERSION MUST HOLD — no forging consent on someone else's behalf --------------------
+{
+  // An impostor signs a 440 that NAMES the participant nowhere meaningful and grants to the bridge.
+  // Because the participant is the AUTHOR, an impostor can only ever consent for THEMSELVES.
+  const impostorSk = generateSecretKey()
+  const g = consentGrant(impostorSk)
+  const v = verifyConsent(g, opts)
+  t('a consent is only ever for its own signer (no third-party consent)', v.participant === getPublicKey(impostorSk))
+  t('  …and it is NOT attributed to the real participant', v.participant !== participant)
+}
+{
+  // A tampered/forged signature is refused outright.
+  const g = consentGrant(partSk)
+  const forged = { ...g, sig: g.sig.replace(/^../, g.sig.startsWith('00') ? 'ff' : '00') }
+  t('a broken signature is refused', verifyConsent(forged, opts).ok === false)
+}
+
+// --- 3. SCOPE + CAP + GRANTEE must all match this bridge/community -------------------------------
+t('a consent scoped to ANOTHER community is refused',
+  verifyConsent(consentGrant(partSk, { community: 'ffffffff-0000-0000-0000-000000000000' }), opts).ok === false)
+t('a non-mirror capability (e.g. admit) is refused',
+  verifyConsent(consentGrant(partSk, { cap: 'admit' }), opts).ok === false)
+t('a consent naming a DIFFERENT grantee (not this bridge) is refused',
+  verifyConsent(consentGrant(partSk, { grantee: getPublicKey(generateSecretKey()) }), opts).ok === false)
+t('a consent bound to DIFFERENT terms than the current ToS is refused',
+  verifyConsent(consentGrant(partSk, { tos: createHash('sha256').update('old terms').digest('hex') }), opts).ok === false)
+
+// --- 4. readConsents: the set, and the revocation rule (only the grantor withdraws) --------------
+{
+  const g = consentGrant(partSk)
+  const { consent, revoked } = readConsents([g], opts)
+  t('a batch yields the active consent, keyed by participant', consent.has(participant) && revoked === 0)
+}
+{
+  // The participant revokes THEIR OWN consent — a 441 they signed, e-tagging the grant.
+  const g = consentGrant(partSk)
+  const rev = wire(finalizeEvent({ kind: 441, created_at: 2000, tags: [['e', g.id]], content: '' }, partSk))
+  const { consent, revoked } = readConsents([g, rev], opts)
+  t('the participant\'s own 441 revokes their consent', !consent.has(participant) && revoked === 1)
+}
+{
+  // THE LOAD-BEARING CHECK: someone ELSE's 441 (the bridge, the maintainer, a stranger) must NOT
+  // revoke the participant's consent. Only the subject withdraws their own.
+  const g = consentGrant(partSk)
+  const notTheGrantor = wire(finalizeEvent({ kind: 441, created_at: 3000, tags: [['e', g.id]], content: '' }, bridgeSk))
+  const { consent, revoked } = readConsents([g, notTheGrantor], opts)
+  t('a 441 by anyone BUT the grantor does NOT revoke the consent', consent.has(participant) && revoked === 0)
+}
+{
+  // Re-consent under fresh terms supersedes: newest active wins.
+  const older = consentGrant(partSk, { created_at: 1000 })
+  const newer = consentGrant(partSk, { created_at: 5000 })
+  const { consent } = readConsents([older, newer], opts)
+  t('the newest active consent per participant wins', consent.get(participant)?.at === 5000)
+}
+
+// --- 5. an ordinary admission 440 (maintainer→participant) is NOT a consent ----------------------
+{
+  // The exact shape #131 warns not to confuse: a normal channel admit. Wrong cap, wrong grantee,
+  // wrong author direction — it must not read as consent-to-be-mirrored.
+  const admit = consentGrant(bridgeSk, { cap: 'admit', grantee: participant })
+  t('a channel admission is not a mirror consent', verifyConsent(admit, opts).ok === false)
+}
+
+console.log(`\n${pass}/${n} passed`)
+process.exit(pass === n ? 0 : 1)


### PR DESCRIPTION
The design the consent family asked for — `docs/CONSENT.md`. Fixes the *design* half of #131 and
#132 (one story); frames and **recommends against** #133 for now.

## The shape

- **Principle** — waggle must not ingest a person's content without their consent; the symmetric
  twin of §3.9's out-door invariant. Not privacy (notes are public) — **association + re-publication**
  into a walled commercial space under its terms. Also dissolves the §3.3/B-2 rights exposure.
- **What's new** — it **inverts the grant direction**: the grantor is the *data subject*. Nostr's
  `kind:3` is unilateral, so consent-to-be-aggregated is a primitive the protocol lacks (AP's
  Follow/Accept is the prior art).

## The decision that needs your eyes (@Dennis)

**Mechanism, weighed not assumed.** Recommended: a **participant-issued `440` with `da-cap:mirror`**
— a bodyless capability grant exactly like a channel admit, only *inverted* (participant → waggle).
It reuses issuance, `441` revocation, and **shows up on the universal grant plane we just built**,
so a participant sees and revokes their own consent. Fallback: a purpose-built consent kind (cleaner
semantics, but new tooling, off-plane). Your call on which.

## The parts (all in the doc)

- **Handshake** — request+disclosure DM (it *is* the disclosure; many won't know the bridge exists)
  → signed consent → verify → flow. Whether the *bridge* sends the DM (as a closed-slot egress
  template, #134 A3) or the maintainer does — flagged for @My Dude / @Neil.
- **ToS** (@Kerouac) — bound by `sha256` to the consent record, so consent can't silently cover
  changed terms.
- **Enforcement** (@My Dude / @Neil) — a `mirrorConsent` set beside `grantSet`; `watch_authors` and
  `watch_events` both gated; the reply lane **held invisibly pre-consent** so the community never
  sees un-consented content (participant gate first, community quarantine second); revocation on the
  existing `441` path. Cited `bridge.mjs` lines verified.
- **Safety edge cases as load-bearing** — the consent DM must not become the bridge spamming
  strangers (once per target, silence = no, explicit no = permanent); default-closed throughout;
  grandfather the consenting crew.
- **#133** — decline actual Buzz-to-Buzz federation (adds a capability Block deliberately omitted,
  §3.4/B-1); use UC-2's neutral space. If ever pursued: nested consent + ToS reconciliation.

## Not built

Design only. Build follows in order after review; the `bridge.mjs` gates land as their own
adversarially-reviewed PR, never a tack-on. Default-closed until then.

Drafted with assistance from [Claude Code](https://claude.com/claude-code)