### PR TITLE
consent: mint-consent 441 must p-tag the bridge, or revocation fails open

### DIFF
--- a/tools/mint-consent.mjs
+++ b/tools/mint-consent.mjs
@@ -73,7 +73,9 @@ const publish = (ev) => Promise.all(RELAYS.map(url => new Promise(res => {
 if (cmd === 'revoke') {
   const target = flag('--grant') || die('revoke needs --grant <the consent 440 event id>')
   if (!/^[0-9a-f]{64}$/i.test(target)) die('--grant must be a 64-hex event id')
-  const ev = finalizeEvent({ kind: 441, created_at: Math.floor(Date.now() / 1000), tags: [['e', target.toLowerCase()]], content: '' }, sk)
+  // p-tag the bridge: its consent subscription filters on #p:[BRIDGE_PK], so a 441 without it is
+  // invisible to the bridge and the revocation silently fails OPEN (caught in live test 2026-08-03).
+  const ev = finalizeEvent({ kind: 441, created_at: Math.floor(Date.now() / 1000), tags: [['e', target.toLowerCase()], ['p', BRIDGE]], content: '' }, sk)
   console.error(`mint-consent: 441 revoking ${target.slice(0, 12)}… as ${npub}`)
   if (DRY) { console.error('DRY_RUN — nothing published'); console.log(ev.id); process.exit(0) }
   for (const line of await publish(ev)) console.error('  ' + line)


### PR DESCRIPTION
**Found in the first live end-to-end test** of the in-door consent gate (2026-08-03, production read lane). The forward path worked start to finish — **hold → auto-ask DM → participant 440 → mirror** — but the **revocation never took**: the bridge kept mirroring a participant who had revoked.

## Cause — fail-open on revocation

The bridge's consent subscription (`src/bridge.mjs:1807`) only receives events that `#p`-tag the bridge:
```js
['REQ', 'pmc', { kinds: [440, 441], '#p': [BRIDGE_PK], limit: 500 }]
```
The consent **440 p-tags the bridge** (grantee) → ingested in seconds. But `mint-consent`'s revoke built `{ kind: 441, tags: [['e', 440id]] }` with **no p-tag** → never matched the filter → invisible to the bridge. Consent could not be withdrawn. That's a **fail-open on revocation** — the one direction this gate must never fail.

## Fix

The 441 now p-tags the bridge, mirroring the 440. Verified live: after the fix, the bridge logged `mirror consent revoked:` within 8s and the participant's next post `hold[no-consent]`. Full cycle closed: **held → asked → consented → mirrored → revoked → held**.

## Necessary but not sufficient

A **third-party** client revoking without the p-tag still fails open. The robust bridge-side fix — subscribe to `kind:441` **by author** over the consented set (only the same author can revoke anyway) — is filed as a follow-up for @My Dude / @Kerouac, since it's enforcement-path safety, not a self-merge.

Drafted with assistance from [Claude Code](https://claude.com/claude-code)