### PR TITLE
wake: forward a #general post's p-tags so a named seat actually wakes

### DIFF
--- a/src/bridge.mjs
+++ b/src/bridge.mjs
@@ -97,8 +97,8 @@ if (!existsSync(CONFIG_PATH)) {
 }
 const cfg = JSON.parse(readFileSync(CONFIG_PATH, 'utf8'))
 const RELAYS = cfg.relays || []
-const RECIPIENTS = {} // hex -> { name, inbox }
-for (const r of cfg.recipients || []) RECIPIENTS[r.npub_hex] = { name: r.name, inbox: r.inbox }
+const RECIPIENTS = {} // hex -> { name, inbox, npub_hex }
+for (const r of cfg.recipients || []) RECIPIENTS[r.npub_hex] = { name: r.name, inbox: r.inbox, npub_hex: String(r.npub_hex || '').toLowerCase() }
 const TARGETS = Object.keys(RECIPIENTS)
 
 // --- Concord channel planes (additive; empty => pure DM bridge, no behavior change) --------
@@ -738,6 +738,17 @@ function forward(rec, ev, src) {
         template: 'channel_plaintext',
         dest: rec.inbox,
         slots: { channel: src.channel, sender: rumor.pubkey, body: String(rumor.content == null ? '' : rumor.content), replyTo: ev.id },
+      }
+      // Wake gate (#dead-wake, 2026-08-03): buzz-acp's `subscribe=Mentions` fires a seat wake ONLY
+      // on a message carrying that seat's p-tag. A forward is authored by the bridge key and its
+      // display body is de-fanged, so with no explicit recipient p-tag the seat never wakes on a
+      // #general post that named it — the crew went silent on the plane for ~10 h on 2026-08-03.
+      // Propagate the ORIGINAL rumor's p-tags: wake this recipient IFF the post actually p-tagged
+      // them, so a post addressing nobody wakes nobody (no fan-out storm — safe now that meh=queue
+      // means a mid-turn wake queues rather than cancel+merge-restarts). The @name in the body
+      // stays de-fanged; the wake rides the explicit --mention p-tag, not the rendered text.
+      if (rec.npub_hex && (rumor.tags || []).some(t => t[0] === 'p' && String(t[1] || '').toLowerCase() === rec.npub_hex)) {
+        descriptor.mention = rec.npub_hex
       }
       decrypted = true
     } catch (e) {

--- a/src/egress.mjs
+++ b/src/egress.mjs
@@ -380,7 +380,15 @@ export function query(name, params = {}) {
 
 function argvFor(spec, descriptor, content) {
   switch (spec.action) {
-    case 'send':   return ['messages', 'send', '--channel', SLOT_TYPES.channel(descriptor.dest), '--content', content]
+    case 'send': {
+      const a = ['messages', 'send', '--channel', SLOT_TYPES.channel(descriptor.dest), '--content', content]
+      // A recipient p-tag (the seat wake trigger) is a TYPED descriptor field, never a rendered
+      // slot: it must reach argv as --mention, not the body. Opt-in — only forward() sets it, to
+      // wake a seat on a #general post that p-tagged it. Validated as a pubkey; the body stays
+      // de-fanged so the wake rides this explicit p-tag, not the display text.
+      if (descriptor.mention != null) a.push('--mention', SLOT_TYPES.npub(descriptor.mention))
+      return a
+    }
     case 'reply':  return ['messages', 'send', '--channel', SLOT_TYPES.channel(descriptor.dest), '--reply-to', SLOT_TYPES.id(descriptor.parentId), '--content', content]
     case 'edit':   return ['messages', 'edit', '--event', SLOT_TYPES.id(descriptor.targetId), '--content', content]
     case 'delete': return ['messages', 'delete', '--event', SLOT_TYPES.id(descriptor.targetId), '--reason-code', 'nip09', '--public-reason', 'withdrawn by author (NIP-09)']

--- a/tests/egress_catalogue.mjs
+++ b/tests/egress_catalogue.mjs
@@ -190,6 +190,45 @@ console.log('\n-- emit(): the type has no field for a sentence (INV-A3-3) --')
 }
 
 // ---------------------------------------------------------------------------------------------
+// #dead-wake (2026-08-03): a forwarded #general post must carry the recipient's p-tag as an
+// explicit --mention, or buzz-acp's `subscribe=Mentions` never wakes the seat (the crew went
+// silent on the plane for ~10 h). The p-tag is a TYPED descriptor field, never a rendered slot,
+// so it reaches argv and never the de-fanged display body.
+console.log('\n-- emit(): a recipient wake p-tag rides argv, never the body --')
+
+{
+  const calls = []
+  const restore = __setTransportForTests(async (argv) => { calls.push(argv); return JSON.stringify({ event_id: HEX64 }) })
+  const WAKE = 'b'.repeat(64)
+  const chan = () => ({
+    template: 'channel_plaintext', dest: '11111111-1111-1111-1111-111111111111',
+    slots: { channel: 'general', sender: HEX64, body: 'testing the room', replyTo: 'e'.repeat(64) },
+  })
+
+  // Addressed recipient: the post p-tagged them, so the forward carries the wake p-tag.
+  await emit({ ...chan(), mention: WAKE })
+  const withM = calls[0] || []
+  const mi = withM.indexOf('--mention')
+  ok('channel_plaintext with a recipient wakes the seat via --mention', mi !== -1 && withM[mi + 1] === WAKE)
+  const body = withM[withM.indexOf('--content') + 1]
+  ok('the wake p-tag rides argv, not the de-fanged display body', typeof body === 'string' && !body.includes(WAKE))
+
+  // Not-addressed recipient: no p-tag, so a post that named nobody wakes nobody — the mention-gate
+  // that keeps the de-fanged notification-storm bug closed.
+  calls.length = 0
+  await emit(chan())
+  ok('channel_plaintext with no recipient p-tag carries no --mention (no wake-all storm)', !(calls[0] || []).includes('--mention'))
+
+  // NEGATIVE CONTROL — the mention is a typed pubkey, so a caller string (an injected @everyone,
+  // a label) cannot ride --mention into argv the way a rendered slot's text could.
+  let rejectedMention = false
+  try { await emit({ ...chan(), mention: 'not-a-key @everyone' }) } catch { rejectedMention = true }
+  ok('NEGATIVE CONTROL — a non-pubkey mention is refused, never passed to argv', rejectedMention)
+
+  restore()
+}
+
+// ---------------------------------------------------------------------------------------------
 console.log('\n-- The Nostr transport catalogue (§2.5) --')
 
 {


### PR DESCRIPTION
## The dead wake

On 2026-08-03 the crew went silent on the Armada **#general** plane for ~10 h while James posted six times and saw no replies. Diagnosis (measured, both directions):

- **Not a crash** — Buzz Desktop + all 4 seats healthy the whole time.
- **Not inbound** — the `waggle-sealed` journal shows every one of James's posts `FORWARD[buzz] ok` to all four inbox channels.
- **Not backfill** — the posts were *delivered*, not dropped.
- **A dead wake.** buzz-acp wakes a seat only on a message carrying that seat's p-tag (`subscribe=Mentions`). A forward is authored by the bridge (waggle) key and its display body is de-fanged, so `forward()` emitted `messages send --channel <inbox> --content <body>` with **no p-tag** — the post sat unread and no seat woke, so nobody sealed a reply back onto the plane.

Confirmed on the wire: forwarded #general events carry `p:[]` (My Dude pulled them from inbox `906910e0`); and `RESPOND_TO=owner-only` does **not** block a non-owner mention (a non-owner p-tag woke an owner-only seat this session), so the missing p-tag is the whole cause.

## The fix

`forward()` propagates the **original #general rumor's p-tags**. A recipient is p-tagged (via an explicit `--mention`) **iff the post actually p-tagged them** — mention-gated, so a post addressing nobody wakes nobody (no wake-all fan-out storm). The `@name` in the body stays de-fanged; the wake rides the explicit p-tag, not the rendered text.

Safe to re-enable now that `meh=queue` (live 2026-08-03 11:41Z) makes a mid-turn wake **queue** rather than cancel+merge-restart — the notification-storm the de-fang originally closed stays closed.

### Changes
- **`src/bridge.mjs`** — `RECIPIENTS` carry `npub_hex`; `forward()` sets `descriptor.mention` when the decrypted rumor p-tags the recipient (`channel_plaintext` path only; the sealed-envelope fallback can't read the body and is unchanged).
- **`src/egress.mjs`** — `argvFor('send')` appends `--mention <pubkey>` when the descriptor carries one. It is a **typed descriptor field** (validated by `SLOT_TYPES.npub`), never a rendered slot, so a caller string cannot ride it into argv (A3 discipline preserved).
- **`tests/egress_catalogue.mjs`** — addressed → `--mention`; not-addressed → none (no storm); the p-tag rides argv not the body; NEGATIVE CONTROL that a non-pubkey mention is refused.

### Validation
- Full suite green (`npm test` → 27/27 suites, exit 0).
- Recipient delivery key == plane mention key, checked against live prod config (My Dude `0a8e0720` == the 09:41 rumor p-tag).
- **End-to-end live wake** to be confirmed off a seat after deploy (My Dude owns the seat-side observation) — this is review + operational-signoff gated, not a hot-patch.

### Known limitation (client-side, not this PR)
The fix propagates *resolved* p-tags. In the 09:41 post "Testing @My Dude and @neil", Vector resolved "@My Dude" to a p-tag but left "@neil" as plain text — so an unresolved `@name` won't wake that seat until the mention resolves client-side (or we add an opt-in body-name-match fallback, deliberately deferred as the fragile path).

Originating thread: waggle-test channel `a8186b53-537d-46ad-a7e7-b6486c58970e` (federation-pipe latency / #general dead-wake).

🤖 Generated with [Claude Code](https://claude.com/claude-code)