### PR TITLE
deploy: preserve narrow config write policy for read lane (#209)

### DIFF
--- a/deploy/waggle-read.service
+++ b/deploy/waggle-read.service
@@ -38,7 +38,10 @@ Restart=always
 RestartSec=5
 NoNewPrivileges=yes
 ProtectSystem=strict
-ReadWritePaths=/opt/waggle-read/data
+# `config.json` is a director-owned, non-secret policy file. The signed staging-console commands
+# persist watch/mute/follow decisions there, so allow this ONE existing file as well as durable
+# runtime state — never the tree directory (which would permit code replacement as bridge).
+ReadWritePaths=/opt/waggle-read/data /opt/waggle-read/config.json
 ProtectHome=yes
 PrivateTmp=yes
 

--- a/tests/deploy_runner.mjs
+++ b/tests/deploy_runner.mjs
@@ -27,6 +27,13 @@ const SCRIPT = 'deploy/deploy-runner.sh'
 let failed = 0
 const check = (cond, msg) => { if (!cond) { console.error('  ✗', msg); failed++ } else { console.log('  ✓', msg) } }
 
+// The bridge persists signed operator decisions in config.json. ProtectSystem=strict remains
+// load-bearing, so the service may write that one policy file and data/, never its code tree.
+const readUnit = readFileSync(join(REPO, 'deploy', 'waggle-read.service'), 'utf8')
+check(/ProtectSystem=strict/.test(readUnit), 'read lane keeps ProtectSystem=strict')
+check(/ReadWritePaths=\/opt\/waggle-read\/data \/opt\/waggle-read\/config\.json/.test(readUnit),
+  'read lane may persist config.json without gaining write access to the code tree')
+
 // The runner ships with rsync, so without it every deploy-path case fails — eleven red checks
 // that read as eleven regressions and are really one missing binary. Say which it is: exit 3 =
 // INCONCLUSIVE, the same signal tripwire.mjs and verify-firewall.sh use. NOT an all-clear, and


### PR DESCRIPTION
Fixes #209.\n\nThe read lane persists signed operator watchlist decisions in config.json. Its systemd sandbox already keeps ProtectSystem=strict; this permits exactly data/ and the existing config.json file, never the code tree or its directory.\n\nRegression coverage asserts both properties.\n\nVerification: node tests/deploy_runner.mjs; npx eslint src tools tests.\n\nDrafted with assistance from [Claude Code](https://claude.com/claude-code)