### PR TITLE
consent: send click-through signer link

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -23,6 +23,7 @@
     "mirror_consent_hive_name": "<human-readable hive name, e.g. JA Fairweather's hive>",
     "mirror_consent_hive_handle": "<human-readable hive handle, e.g. jaf@dequalsf.com>",
     "mirror_consent_terms_url": "https://<operator>/terms.html",
+    "mirror_consent_url": "https://jafairweather.github.io/nvoy/consent.html",
     "mirror_grandfathered": ["<pre-consent watched author hex, temporary explicit exception>"],
     "since_secs": 10800,
     "backfill_limit": 50,

--- a/src/bridge.mjs
+++ b/src/bridge.mjs
@@ -316,6 +316,7 @@ const PUB = cfg.public ? {
   mirrorConsentHiveName: cfg.public.mirror_consent_hive_name || null,
   mirrorConsentHiveHandle: cfg.public.mirror_consent_hive_handle || null,
   mirrorConsentTermsUrl: cfg.public.mirror_consent_terms_url || null,
+  mirrorConsentUrl: cfg.public.mirror_consent_url || null,
   mirrorAskPerHour: Number(cfg.public.mirror_ask_per_hour != null ? cfg.public.mirror_ask_per_hour : 20),
 } : null
 
@@ -702,11 +703,11 @@ function buildConsentPrefill() {
   }
 }
 async function sendConsentRequest(targetPub, publish = publishWrapToRelays) {
-  if (!hasBridgeKey() || !PUB.mirrorConsentHiveId || !PUB.mirrorConsentHiveName || !PUB.mirrorConsentHiveHandle || !PUB.mirrorConsentTermsUrl || !PUB.mirrorExpectedTosHash) return 0
+  if (!hasBridgeKey() || !PUB.mirrorConsentHiveId || !PUB.mirrorConsentHiveName || !PUB.mirrorConsentHiveHandle || !PUB.mirrorConsentTermsUrl || !PUB.mirrorConsentUrl || !PUB.mirrorExpectedTosHash) return 0
   if (!askRateOk()) { err(`consent ask: rate cap ${PUB.mirrorAskPerHour}/h reached — not asking ${targetPub.slice(0, 12)}… this window`); return 0 }
   const accepted = await returnLaneSend(targetPub, {
     template: 'consent_request',
-    slots: { hiveId: PUB.mirrorConsentHiveId, hiveName: PUB.mirrorConsentHiveName, hiveHandle: PUB.mirrorConsentHiveHandle, termsUrl: PUB.mirrorConsentTermsUrl, prefill: buildConsentPrefill() },
+    slots: { consentUrl: PUB.mirrorConsentUrl, hiveId: PUB.mirrorConsentHiveId, hiveName: PUB.mirrorConsentHiveName, hiveHandle: PUB.mirrorConsentHiveHandle, termsUrl: PUB.mirrorConsentTermsUrl, prefill: buildConsentPrefill() },
   }, { lane: 'consent-ask' }, publish).catch(() => 0)
   if (accepted >= 1) { mirrorAskedStore.commit(targetPub); log(`consent ask -> ${targetPub.slice(0, 12)}… (disclosure DM sealed)`) }
   else err(`consent ask -> ${targetPub.slice(0, 12)}…: seal reached no relay — NOT marked asked, retries on the next hold`)
@@ -716,7 +717,7 @@ async function sendConsentRequest(targetPub, publish = publishWrapToRelays) {
 // and it is neither muted (an explicit prior no) nor grandfathered. Fire-and-forget from the hold.
 // `send` is injectable so the guard logic is testable without a socket.
 function maybeAskConsent(targetPub, send = sendConsentRequest) {
-  if (!PUB.mirrorConsentHiveId || !PUB.mirrorConsentHiveName || !PUB.mirrorConsentHiveHandle || !PUB.mirrorConsentTermsUrl || !hasBridgeKey()) return false
+  if (!PUB.mirrorConsentHiveId || !PUB.mirrorConsentHiveName || !PUB.mirrorConsentHiveHandle || !PUB.mirrorConsentTermsUrl || !PUB.mirrorConsentUrl || !hasBridgeKey()) return false
   if (mirrorAsked.has(targetPub) || mirrorConsent.has(targetPub) || askInFlight.has(targetPub)) return false
   if (PUB.muted.includes(targetPub) || PUB.mirrorGrandfathered.includes(targetPub)) return false
   askInFlight.add(targetPub)
@@ -2091,7 +2092,7 @@ if (!process.env.WB_NO_BOOT) {
     if (PUB.grantors.length) log(`  admission: ${PUB.grantors.length} grantor key(s); NIP-DA kinds ${NIPDA.grant}/${NIPDA.revocation}/${NIPDA.index}`)
     if (PUB.mirrorRequireConsent) {
       log(`  in-door consent: ENFORCING (§8) — mirror/reply gated on consent; ${PUB.mirrorGrandfathered.length} grandfathered; version-binding ${PUB.mirrorExpectedTosHash ? 'ON (tos ' + PUB.mirrorExpectedTosHash.slice(0, 8) + '…)' : 'OFF'}`)
-      log(`  in-door consent ask (§5/§6): ${PUB.mirrorConsentHiveId && PUB.mirrorConsentHiveName && PUB.mirrorConsentHiveHandle && PUB.mirrorConsentTermsUrl && PUB.mirrorExpectedTosHash ? 'ON — hive ' + PUB.mirrorConsentHiveId.slice(0, 12) + '…, disclosure DM once per target, ' + PUB.mirrorAskPerHour + '/h cap, ' + mirrorAsked.size + ' already asked' : 'OFF (need mirror_consent_hive_id, display identity, and terms URL — enforcement gates, nobody is messaged)'}`)
+      log(`  in-door consent ask (§5/§6): ${PUB.mirrorConsentHiveId && PUB.mirrorConsentHiveName && PUB.mirrorConsentHiveHandle && PUB.mirrorConsentTermsUrl && PUB.mirrorConsentUrl && PUB.mirrorExpectedTosHash ? 'ON — hive ' + PUB.mirrorConsentHiveId.slice(0, 12) + '…, disclosure DM once per target, ' + PUB.mirrorAskPerHour + '/h cap, ' + mirrorAsked.size + ' already asked' : 'OFF (need mirror_consent_hive_id, display identity, terms URL, and public consent URL — enforcement gates, nobody is messaged)'}`)
       if (!PUB.mirrorExpectedTosHash) err(`  in-door consent: version-binding UNENFORCED — set public.mirror_expected_tos_hash to the current ToS block hash, or a v1 consent rides v2 terms (§7)`)
     }
     if (PUB.relayChannels.length && hasBridgeKey()) log(`  relay lane: ${PUB.relayChannels.length} allowlisted channel(s); decrypt budget ${PUB.relayDecryptBudget}/min, wrap cap ${PUB.relayMaxWrapBytes}B — a channel waggle has not joined fails as RELAY[buzz] ERR, never a silent §7 drop`)

--- a/src/nostr_egress.mjs
+++ b/src/nostr_egress.mjs
@@ -113,9 +113,9 @@ export function consentTosBlock({ hiveId, hiveName, hiveHandle, termsUrl }) {
   ].join('\n')
 }
 
-// The unsigned 440 the participant signs, carried in the DM as an opaque blob (attributed, never
-// rendered as waggle's words). Validated so the disclosure can only ever ask them to sign a
-// mirror-consent grant to THIS bridge — never an arbitrary event dressed as "sign this".
+// The unsigned 440 the participant signs. It is validated before being put in a fragment-only
+// link to Nvoy's signer page, so the disclosure can only ever ask them to sign a mirror-consent
+// grant to THIS bridge — never an arbitrary event dressed as "sign this".
 const prefill440 = (v) => {
   const ev = (v && typeof v === 'object') ? v : reject('prefill is not an object')
   if (ev.kind !== 440) reject('prefill is not a 440')
@@ -126,6 +126,18 @@ const prefill440 = (v) => {
   if (!tag('tos')?.[1]) reject('prefill carries no tos hash')
   if (ev.sig) reject('prefill must be UNSIGNED — the participant supplies the signature')
   return JSON.stringify(ev)
+}
+
+const consentLink = ({ consentUrl, hiveId, hiveName, hiveHandle, termsUrl, prefill }) => {
+  const base = url(consentUrl, 'consentUrl')
+  const checked = JSON.parse(prefill440(prefill))
+  const request = { hiveId: hex64(hiveId, 'hiveId'), hiveName: handle(hiveName), hiveHandle: String(hiveHandle).replace(/[\r\n`]/g, '').trim(), termsUrl: url(termsUrl, 'termsUrl'), prefill: checked }
+  if (!request.hiveHandle) reject('hiveHandle empty')
+  const out = new URL(base)
+  // A fragment never reaches Pages, HTTP logs, or a Referer header. It holds no secret, but keeps
+  // this unsigned draft out of routine server logs all the same.
+  out.hash = `request=${Buffer.from(JSON.stringify(request)).toString('base64url')}`
+  return out.toString()
 }
 
 const CATALOGUE = {
@@ -177,20 +189,18 @@ const CATALOGUE = {
     },
   },
   // In-door consent request (docs/CONSENT.md §5). waggle's FIRST unsolicited outbound seal to a
-  // stranger — the disclosure IS the ask. Three fixed parts and no free-prose slot: a per-target
-  // cover greeting (NOT hashed), the canonical ToS block (hashed, the source literal above), and
-  // the unsigned prefilled 440 the participant need only sign-and-publish. The safety of SENDING
-  // this at all lives in bridge.mjs's §6 once-per-target ask-record — the catalogue only fixes the
-  // FORM so the bridge can never author free text at a stranger.
+  // stranger — the disclosure IS the ask. Its prose and signing URL are fixed: Nvoy reviews the
+  // canonical terms and asks the participant's own signer to publish the prefilled 440. The safety
+  // of SENDING this at all lives in bridge.mjs's §6 once-per-target ask-record.
   consent_request: {
-    build: ({ hiveId, hiveName, hiveHandle, termsUrl, prefill }) =>
-      `A small invitation from waggle: your public posts may be welcome in a private Buzz hive. ` +
-      `The bees do not carry a single word across until you give the nod. If it is not for you, ` +
-      `simply leave this note alone — silence is a no, and you will not be asked again.\n\n` +
-      consentTosBlock({ hiveId, hiveName, hiveHandle, termsUrl }) +
-      `\n\n---\nTo agree, sign and publish this exact event (it names waggle, capability \`mirror\`, ` +
-      `scoped to this hive, and carries the hash of the terms above — your signature is the ` +
-      `whole consent):\n\n\`\`\`json\n${prefill440(prefill)}\n\`\`\``,
+    build: ({ consentUrl, hiveId, hiveName, hiveHandle, termsUrl, prefill }) => {
+      const link = consentLink({ consentUrl, hiveId, hiveName, hiveHandle, termsUrl, prefill })
+      return `A small invitation from waggle: ${handle(hiveName)}'s hive (${String(hiveHandle).replace(/[\r\n`]/g, '').trim()}) ` +
+        `would love to share your public wisdom in its meadow, with the bees already in the hive. ` +
+        `Nothing crosses until you give the nod.\n\n` +
+        `To see exactly what that means and choose your own Nostr signer, open this consent card:\n${link}\n\n` +
+        `If it is not for you, simply leave this note alone — silence is a no, and you will not be asked again.`
+    },
   },
 }
 

--- a/tests/consent_ask.mjs
+++ b/tests/consent_ask.mjs
@@ -19,6 +19,7 @@ const HIVE = 'c'.repeat(64)
 const HIVE_NAME = 'JA Fairweather\'s hive'
 const HIVE_HANDLE = 'jaf@dequalsf.com'
 const TERMS = 'https://block.github.io/buzz/terms.html'
+const CONSENT_URL = 'https://jafairweather.github.io/nvoy/consent.html'
 const bridgeSk = generateSecretKey(), bridgePk = getPublicKey(bridgeSk)
 
 writeFileSync(join(tmp, 'config.json'), JSON.stringify({
@@ -30,6 +31,7 @@ writeFileSync(join(tmp, 'config.json'), JSON.stringify({
     mirror_consent_hive_name: HIVE_NAME,
     mirror_consent_hive_handle: HIVE_HANDLE,
     mirror_consent_terms_url: TERMS,
+    mirror_consent_url: CONSENT_URL,
     mirror_ask_per_hour: 2,
     muted_authors: [],
   },
@@ -65,7 +67,7 @@ const fresh = () => getPublicKey(generateSecretKey())
   t('prefill is an UNSIGNED 440', pre.kind === 440 && !pre.sig)
   t('  grantee is the bridge, cap is mirror', pre.tags.find(x => x[0] === 'p')[1] === bridgePk && pre.tags.find(x => x[0] === 'da-cap')[1] === 'mirror')
   t('  tos is the derived expected hash (matches the gate)', pre.tags.find(x => x[0] === 'tos')[1] === PUB.mirrorExpectedTosHash)
-  t('  the disclosure template accepts the prefill', typeof buildBody('consent_request', { hiveId: HIVE, hiveName: HIVE_NAME, hiveHandle: HIVE_HANDLE, termsUrl: TERMS, prefill: pre }) === 'string')
+  t('  the disclosure template accepts the prefill', typeof buildBody('consent_request', { consentUrl: CONSENT_URL, hiveId: HIVE, hiveName: HIVE_NAME, hiveHandle: HIVE_HANDLE, termsUrl: TERMS, prefill: pre }) === 'string')
   // a participant signs it unchanged → it verifies against the gate
   const psk = generateSecretKey()
   const signed = JSON.parse(JSON.stringify(finalizeEvent(pre, psk)))

--- a/tests/consent_request.mjs
+++ b/tests/consent_request.mjs
@@ -19,6 +19,7 @@ const HIVE = 'c'.repeat(64)
 const HIVE_NAME = 'JA Fairweather\'s hive'
 const HIVE_HANDLE = 'jaf@dequalsf.com'
 const TERMS = 'https://block.github.io/buzz/terms.html'
+const CONSENT_URL = 'https://jafairweather.github.io/nvoy/consent.html'
 const bridge = 'b'.repeat(64)
 
 // A well-formed UNSIGNED prefill 440 whose tos = hash of the canonical block (as the bridge builds it).
@@ -47,11 +48,10 @@ t('consent_request is a registered nostr template', NOSTR_TEMPLATE_NAMES.include
 
 // --- 3. the built DM carries cover line + block + the prefill, and binds the SAME hash -----------
 {
-  const body = buildBody('consent_request', { hiveId: HIVE, hiveName: HIVE_NAME, hiveHandle: HIVE_HANDLE, termsUrl: TERMS, prefill })
+  const body = buildBody('consent_request', { consentUrl: CONSENT_URL, hiveId: HIVE, hiveName: HIVE_NAME, hiveHandle: HIVE_HANDLE, termsUrl: TERMS, prefill })
   t('the DM opens with a warm but explicit consent invitation', /small invitation from waggle/.test(body))
-  t('the DM embeds the canonical block', body.includes(consentTosBlock({ hiveId: HIVE, hiveName: HIVE_NAME, hiveHandle: HIVE_HANDLE, termsUrl: TERMS })))
-  t('the DM embeds the prefilled 440 for the participant to sign', body.includes('"da-cap"') && body.includes('mirror'))
-  t('the prefill\'s tos hash equals the hash of the block shown (bound, not drifting)',
+  t('the DM contains a fragment-only Nvoy signing link, not raw event JSON', body.includes(`${CONSENT_URL}#request=`) && !body.includes('```json') && !body.includes('"da-scope"'))
+  t('the prefill\'s tos hash equals the canonical block shown by the signer (bound, not drifting)',
     prefill.tags.find(x => x[0] === 'tos')[1] === sha(consentTosBlock({ hiveId: HIVE, hiveName: HIVE_NAME, hiveHandle: HIVE_HANDLE, termsUrl: TERMS })))
 }
 
@@ -61,14 +61,14 @@ const mustThrow = (name, slots) => {
   try { buildBody('consent_request', slots); console.error(`FAIL - ${name} (did not throw)`) }
   catch { pass++; console.log(`ok - ${name}`) }
 }
-mustThrow('refuses a prefill that is not a 440', { hiveId: HIVE, hiveName: HIVE_NAME, hiveHandle: HIVE_HANDLE, termsUrl: TERMS, prefill: { ...prefill, kind: 1 } })
-mustThrow('refuses a non-mirror capability (e.g. admit)', { hiveId: HIVE, hiveName: HIVE_NAME, hiveHandle: HIVE_HANDLE, termsUrl: TERMS,
+mustThrow('refuses a prefill that is not a 440', { consentUrl: CONSENT_URL, hiveId: HIVE, hiveName: HIVE_NAME, hiveHandle: HIVE_HANDLE, termsUrl: TERMS, prefill: { ...prefill, kind: 1 } })
+mustThrow('refuses a non-mirror capability (e.g. admit)', { consentUrl: CONSENT_URL, hiveId: HIVE, hiveName: HIVE_NAME, hiveHandle: HIVE_HANDLE, termsUrl: TERMS,
   prefill: { ...prefill, tags: [['p', bridge], ['da-scope', 'a'.repeat(64), 'c'.repeat(32)], ['da-cap', 'admit'], ['tos', tosHash]] } })
-mustThrow('refuses a prefill that carries no tos hash', { hiveId: HIVE, hiveName: HIVE_NAME, hiveHandle: HIVE_HANDLE, termsUrl: TERMS,
+mustThrow('refuses a prefill that carries no tos hash', { consentUrl: CONSENT_URL, hiveId: HIVE, hiveName: HIVE_NAME, hiveHandle: HIVE_HANDLE, termsUrl: TERMS,
   prefill: { ...prefill, tags: [['p', bridge], ['da-scope', 'a'.repeat(64), 'c'.repeat(32)], ['da-cap', 'mirror']] } })
 mustThrow('refuses an ALREADY-SIGNED prefill (the participant must supply the signature)',
-  { hiveId: HIVE, hiveName: HIVE_NAME, hiveHandle: HIVE_HANDLE, termsUrl: TERMS, prefill: { ...prefill, sig: 'f'.repeat(128) } })
-mustThrow('refuses a non-https terms URL', { hiveId: HIVE, hiveName: HIVE_NAME, hiveHandle: HIVE_HANDLE, termsUrl: 'javascript:alert(1)', prefill })
+  { consentUrl: CONSENT_URL, hiveId: HIVE, hiveName: HIVE_NAME, hiveHandle: HIVE_HANDLE, termsUrl: TERMS, prefill: { ...prefill, sig: 'f'.repeat(128) } })
+mustThrow('refuses a non-https terms URL', { consentUrl: CONSENT_URL, hiveId: HIVE, hiveName: HIVE_NAME, hiveHandle: HIVE_HANDLE, termsUrl: 'javascript:alert(1)', prefill })
 
 console.log(`\n${pass}/${n} passed`)
 process.exit(pass === n ? 0 : 1)


### PR DESCRIPTION
## What changes

Replaces the raw kind:440 JSON block in waggle’s sealed consent DM with a light click-through invitation to Nvoy’s public review-and-sign page. The unsigned draft is carried only in the fragment. `mirror_consent_url` is now required to send an ask, so an unconfigured bridge fails closed rather than delivering an unusable workflow.

Supersedes closed #215 after its prerequisite #214 merged. Depends on Nvoy #39 (now merged).

## Safety

- The catalogue validates the draft is an unsigned `440`, for waggle, with only `mirror`, the hive scope, and the ToS hash.
- The URL fragment avoids routine HTTP logs and referrers.
- Existing once-per-target, mute, grandfather, and rate-cap rules are unchanged.

## Verification

- `npm run lint`
- `npm test` — all 28 suites

Drafted with assistance from [Claude Code](https://claude.com/claude-code)