### PR TITLE
relay: retire damus from active configuration

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -3,8 +3,7 @@
     "wss://relay.ditto.pub",
     "wss://relay.dreamith.to",
     "wss://jskitty.com/nostr",
-    "wss://asia.vectorapp.io/nostr",
-    "wss://relay.damus.io"
+    "wss://asia.vectorapp.io/nostr"
   ],
   "recipients": [
     { "name": "AGENT_A", "npub_hex": "<64-hex pubkey of agent A>", "inbox": "INBOX_UUID_AGENT_A" },
@@ -13,7 +12,7 @@
   ],
   "public": {
     "_comment": "Public kind:1 read lane. Phase-0 safety gates: quarantine + bounds + rate limits.",
-    "relays": ["wss://relay.damus.io", "wss://nos.lol", "wss://relay.primal.net"],
+    "relays": ["wss://nos.lol", "wss://relay.primal.net"],
     "inbox": "COMMUNITY_READ_LANE_UUID",
     "staging_inbox": "<channel name or UUID for pending posts; may EQUAL inbox for a single-channel lifecycle (pending and released together); omit => hold-and-log>",
     "watch_authors": ["<hex pubkey of a trusted author whose kind:1 posts publish straight to the community channel>"],

--- a/console/index.html
+++ b/console/index.html
@@ -242,7 +242,7 @@ import { verifyEvent, nip19 } from 'nostr-tools'
 const { decode } = nip19
 
 const $ = (id) => document.getElementById(id)
-const RELAYS = ['wss://relay.damus.io','wss://nos.lol','wss://relay.primal.net','wss://relay.ditto.pub','wss://jskitty.com/nostr']
+const RELAYS = ['wss://nos.lol','wss://relay.primal.net','wss://relay.ditto.pub','wss://jskitty.com/nostr']
 const KIND = { grant: 440, revocation: 441 }
 const TAG = { scope: 'da-scope', cap: 'da-cap' }
 

--- a/console/vendor/nave-connect.mjs
+++ b/console/vendor/nave-connect.mjs
@@ -167,7 +167,7 @@ export function nip46Signer(bunkerInput, {
 // the completed handshake — so a caller can persist it as an ordinary nip46
 // session and reconnect on reload without re-pairing.
 export const NOSTR_CONNECT_RELAYS = [
-  'wss://relay.nsec.app', 'wss://relay.damus.io', 'wss://nos.lol', 'wss://relay.primal.net',
+  'wss://relay.nsec.app', 'wss://nos.lol', 'wss://relay.primal.net',
 ]
 
 export async function nostrConnectSigner({

--- a/deploy/FEDERATION_RUNBOOK.md
+++ b/deploy/FEDERATION_RUNBOOK.md
@@ -75,8 +75,7 @@ Two systemd units (see `deploy/README.md` for the full split and why):
 ```jsonc
 {
   "relays": [ "wss://relay.ditto.pub", "wss://relay.dreamith.to",
-              "wss://jskitty.com/nostr", "wss://asia.vectorapp.io/nostr",
-              "wss://relay.damus.io" ],
+              "wss://jskitty.com/nostr", "wss://asia.vectorapp.io/nostr" ],
   "recipients": [
     { "name": "My Dude", "npub_hex": "0a8e0720…", "inbox": "906910e0-…" },
     { "name": "Dennis",  "npub_hex": "9a07300d…", "inbox": "d11ee480-…" },

--- a/deploy/nave-fw.nft
+++ b/deploy/nave-fw.nft
@@ -30,6 +30,6 @@ table inet nave_fw {
     tcp dport 80 accept                     # apt mirrors are commonly plain http
     tcp dport 443 accept                    # outbound wss: public trio + Armada relays + fleet relay
   }
-  # No per-IP relay pinning on purpose: damus/nos.lol/primal sit behind churning CDN IPs;
+  # No per-IP relay pinning on purpose: public relays sit behind churning CDN IPs;
   # a port-level allowlist is the honest design.
 }

--- a/src/bridge.mjs
+++ b/src/bridge.mjs
@@ -164,7 +164,7 @@ const PLANE_AUTHORS = Object.keys(PLANES)
 // --- Public kind:1 read lane (additive; absent => zero behavior change) -------
 // The INBOX DOOR for open-Nostr interop (POC, 2026-07-27). Unlike the two sealed
 // lanes above, public kind:1 notes are PLAINTEXT — there is nothing to unwrap and NO
-// key is ever held. We hold an open REQ to a set of PUBLIC relays (damus/nos.lol/
+// key is ever held. We hold an open REQ to the configured PUBLIC relays
 // primal) and repost each matching note into a Buzz channel as a human-readable
 // message. NON-CUSTODIAL by construction: read public data, repost its content.
 // This is the "outside world → us" half; the outbox half (federating a member's
@@ -172,7 +172,7 @@ const PLANE_AUTHORS = Object.keys(PLANES)
 // cfg.public: { relays:[...], inbox:"<uuid>", watch_authors:[hex...], watch_events:[id...], since_secs? }
 //   watch_authors — pull a chosen author's public kind:1 into Buzz.
 //   watch_events  — catch kind:1 REPLIES (#e) to one of our own published notes
-//                   (closes the round-trip: stranger's Damus reply lands back in Buzz).
+//                   (closes the round-trip: a stranger's reply lands back in Buzz).
 const PUB_SINCE_SECS = cfg.public && cfg.public.since_secs != null ? Number(cfg.public.since_secs) : 3600
 // A3: a persisted watermark lets a restart resume from the last delivered note instead of
 // re-reading the whole `since` window every boot. OVERLAP re-reads a small margin to absorb

--- a/tools/grant.mjs
+++ b/tools/grant.mjs
@@ -103,7 +103,7 @@ const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
 
 function relays() {
   try { const c = JSON.parse(readFileSync(CONFIG_PATH, 'utf8')); if (c.public?.relays?.length) return c.public.relays } catch { /* fall through */ }
-  return ['wss://relay.damus.io', 'wss://nos.lol', 'wss://relay.primal.net']
+  return ['wss://nos.lol', 'wss://relay.primal.net']
 }
 
 function publish(ev) {

--- a/tools/mint-consent.mjs
+++ b/tools/mint-consent.mjs
@@ -38,7 +38,7 @@ const HIVE = (flag('--hive', flag('--community-id', process.env.MIRROR_CONSENT_H
 if (!/^[0-9a-f]{64}$/.test(HIVE)) die('--hive must be the hive\'s 64-hex Concord community_id (consent never scopes to a channel)')
 const BRIDGE = (flag('--bridge', process.env.WAGGLE_BRIDGE_PUBKEY ||
   '84753207f2c6ae73af247da174e8e7c91a7d939a8eb0b4c2b98b54ea567786e6')).toLowerCase()
-const RELAYS = (process.env.RELAY_RELAYS || 'wss://relay.damus.io,wss://nos.lol,wss://relay.primal.net')
+const RELAYS = (process.env.RELAY_RELAYS || 'wss://nos.lol,wss://relay.primal.net')
   .split(',').map(s => s.trim()).filter(Boolean)
 const DRY = !!process.env.DRY_RUN
 

--- a/tools/participant-init.mjs
+++ b/tools/participant-init.mjs
@@ -33,7 +33,7 @@ const flag = (n, d) => { const i = args.indexOf(n); return i === -1 ? d : args[i
 const die = (m) => { console.error(`participant-init: ${m}`); process.exit(1) }
 const say = (s = '') => console.log(s)
 
-const RELAYS = (process.env.RELAYS?.split(',') || ['wss://relay.damus.io', 'wss://nos.lol', 'wss://relay.primal.net'])
+const RELAYS = (process.env.RELAYS?.split(',') || ['wss://nos.lol', 'wss://relay.primal.net'])
   .map(s => s.trim()).filter(Boolean)
 const toHex = (v) => {
   const s = String(v || '').trim()

--- a/tools/publish_relay_list.mjs
+++ b/tools/publish_relay_list.mjs
@@ -28,7 +28,7 @@ import WebSocket from 'ws'
 import { finalizeEvent, getPublicKey, nip19 } from 'nostr-tools'
 import { createHash } from 'node:crypto'
 
-const TRIO = ['wss://relay.damus.io', 'wss://nos.lol', 'wss://relay.primal.net']
+const TRIO = ['wss://nos.lol', 'wss://relay.primal.net']
 const now = () => Math.floor(Date.now() / 1000)
 const die = (m) => { console.error(`publish_relay_list: ${m}`); process.exit(1) }
 

--- a/tools/retract.mjs
+++ b/tools/retract.mjs
@@ -18,7 +18,7 @@ for (const line of readFileSync(homedir() + '/.nvoy/claude-identity.env', 'utf8'
 if (!nsec) { console.error('no NVOY_NSEC'); process.exit(1) }
 const sk = nsec.startsWith('nsec') ? nip19.decode(nsec).data : Uint8Array.from(nsec.match(/../g).map(b => parseInt(b, 16)))
 
-const RELAYS = ['wss://relay.damus.io', 'wss://nos.lol', 'wss://relay.primal.net',
+const RELAYS = ['wss://nos.lol', 'wss://relay.primal.net',
                 'wss://relay.ditto.pub', 'wss://jskitty.com/nostr', 'wss://asia.vectorapp.io',
                 'wss://relay.dreamith.to']
 const pool = new SimplePool()

--- a/tools/session-profile.mjs
+++ b/tools/session-profile.mjs
@@ -33,7 +33,7 @@ const flag = (n) => { const i = args.indexOf(n); return i === -1 ? null : args[i
 const has = (n) => args.includes(n)
 const die = (m) => { console.error(`session-profile: ${m}`); process.exit(1) }
 
-const RELAYS = (process.env.RELAY_RELAYS || 'wss://relay.damus.io,wss://nos.lol,wss://relay.primal.net')
+const RELAYS = (process.env.RELAY_RELAYS || 'wss://nos.lol,wss://relay.primal.net')
   .split(',').map(s => s.trim()).filter(Boolean)
 
 // The shared face. A URL, not embedded data: one asset, changed in one place for every session.

--- a/tools/tripwire.mjs
+++ b/tools/tripwire.mjs
@@ -77,7 +77,7 @@ function loadRelays() {
   const out = new Set()
   if (process.env.BUZZ_RELAY_URL) out.add(process.env.BUZZ_RELAY_URL)
   try { const c = JSON.parse(readFileSync(resolve(ROOT, 'config.json'), 'utf8')); for (const r of c.public?.relays || []) out.add(r) } catch { /* fall through */ }
-  if (!out.size) ['wss://relay.damus.io', 'wss://nos.lol', 'wss://relay.primal.net'].forEach(r => out.add(r))
+  if (!out.size) ['wss://nos.lol', 'wss://relay.primal.net'].forEach(r => out.add(r))
   return [...out]
 }
 


### PR DESCRIPTION
Closes #211.

Removes `relay.damus.io` from waggle’s active public-read defaults, sealed-lane/default publisher tools, participant/profile tools, console lookup defaults, the NIP-46 vendor relay set, maintained federation docs, and active source comments. Historical evidence remains intact.

Verification:

- `npm run lint`
- `CONFIG_PATH=/Users/fairwja/.buzz/REPOS/waggle/config.json npm test` — all 28 suites
- active-reference scan: no Damus URL remains

Drafted with assistance from [Claude Code](https://claude.com/claude-code)