### PR TITLE
consent: clarify the hive invitation

### DIFF
--- a/src/nostr_egress.mjs
+++ b/src/nostr_egress.mjs
@@ -195,10 +195,13 @@ const CATALOGUE = {
   consent_request: {
     build: ({ consentUrl, hiveId, hiveName, hiveHandle, termsUrl, prefill }) => {
       const link = consentLink({ consentUrl, hiveId, hiveName, hiveHandle, termsUrl, prefill })
-      return `A small invitation from waggle: ${handle(hiveName)}'s hive (${String(hiveHandle).replace(/[\r\n`]/g, '').trim()}) ` +
-        `would love to share your public wisdom in its meadow, with the bees already in the hive. ` +
-        `Nothing crosses until you give the nod.\n\n` +
-        `To see exactly what that means and choose your own Nostr signer, open this consent card:\n${link}\n\n` +
+      const hive = handle(hiveName)
+      const hiveHandleText = String(hiveHandle).replace(/[\r\n`]/g, '').trim()
+      return `Hello from ${hive} (${hiveHandleText}) on Buzz.xyz.\n\n` +
+        `The people and agents tending this hive have been enjoying your public writing and would love to bring it in from the meadow, ` +
+        `so the hive can read and discuss it together.\n\n` +
+        `May waggle mirror your public Nostr posts into this one hive? Nothing crosses unless you say yes.\n\n` +
+        `To review the exact terms and choose your own Nostr signer, open this consent card:\n${link}\n\n` +
         `If it is not for you, simply leave this note alone — silence is a no, and you will not be asked again.`
     },
   },

--- a/tests/consent_request.mjs
+++ b/tests/consent_request.mjs
@@ -49,7 +49,10 @@ t('consent_request is a registered nostr template', NOSTR_TEMPLATE_NAMES.include
 // --- 3. the built DM carries cover line + block + the prefill, and binds the SAME hash -----------
 {
   const body = buildBody('consent_request', { consentUrl: CONSENT_URL, hiveId: HIVE, hiveName: HIVE_NAME, hiveHandle: HIVE_HANDLE, termsUrl: TERMS, prefill })
-  t('the DM opens with a warm but explicit consent invitation', /small invitation from waggle/.test(body))
+  t('the DM opens with a warm but explicit consent invitation',
+    body.includes(`Hello from ${HIVE_NAME} (${HIVE_HANDLE}) on Buzz.xyz.`) &&
+    body.includes('May waggle mirror your public Nostr posts into this one hive? Nothing crosses unless you say yes.') &&
+    !body.includes("hive's hive"))
   t('the DM contains a fragment-only Nvoy signing link, not raw event JSON', body.includes(`${CONSENT_URL}#request=`) && !body.includes('```json') && !body.includes('"da-scope"'))
   t('the prefill\'s tos hash equals the canonical block shown by the signer (bound, not drifting)',
     prefill.tags.find(x => x[0] === 'tos')[1] === sha(consentTosBlock({ hiveId: HIVE, hiveName: HIVE_NAME, hiveHandle: HIVE_HANDLE, termsUrl: TERMS })))


### PR DESCRIPTION
## What changed

- replaces the ambiguous outer consent-DM copy with a clear invitation from the named Buzz hive
- keeps the meadow/hive voice while stating the people and agents want to read and discuss public posts
- plainly asks permission to mirror into this one hive and preserves the no-action-is-no explanation

The signed consent terms are unchanged, so existing consents remain valid.

## Verification

- `npm run lint`
- `npm test` (29 suites)

Drafted with assistance from [Claude Code](https://claude.com/claude-code)