### PR TITLE
fix: gate deploys on live routing policy

### DIFF
--- a/deploy/deploy-runner.sh
+++ b/deploy/deploy-runner.sh
@@ -64,6 +64,9 @@ SHIP='src tests tools package.json package-lock.json config.example.json'
 
 log() { echo "deploy-runner[$LANE] $*"; }
 alarm() { echo "deploy-runner[$LANE] ALARM: $*" >&2; }
+# The private routing policy is a deploy gate even when the new commit changes no shipped code.
+# A docs-only tick must never advance DEPLOYED_SHA past an incomplete live config.
+CONFIG_VERIFY_CMD="${WB_CONFIG_VERIFY_CMD:-sh \"$HUB/deploy/verify-config.sh\" \"$TREE/config.json\"}"
 
 # Default CI-state resolver: GitHub Actions records results as CHECK-RUNS (not legacy commit
 # statuses), so ask the check-runs API for this exact sha and aggregate. Unauthenticated for a
@@ -145,8 +148,12 @@ if [ "$DEPLOYED_SHA" != "none" ] && git -C "$HUB" cat-file -e "${DEPLOYED_SHA}^{
   CHANGED=$(git -C "$HUB" diff --name-only "$DEPLOYED_SHA" "$TARGET_SHA" -- $SHIP 2>/dev/null || echo '?')
   if [ -z "$CHANGED" ]; then
     log "no shipped files changed between $(git -C "$HUB" rev-parse --short "$DEPLOYED_SHA") and $SHORT — recording without restarting"
-    printf '%s\n' "$TARGET_SHA" > "$TREE/DEPLOYED_SHA.tmp" && mv "$TREE/DEPLOYED_SHA.tmp" "$TREE/DEPLOYED_SHA"
+    if ! sh -c "$CONFIG_VERIFY_CMD"; then
+      alarm "live routing policy is incomplete or unreadable — DEPLOYED_SHA left unchanged"
+      exit 1
+    fi
     if sh "$HUB/deploy/verify-deployed.sh" "$LANE" "$TREE" "$TARGET_SHA"; then
+      printf '%s\n' "$TARGET_SHA" > "$TREE/DEPLOYED_SHA.tmp" && mv "$TREE/DEPLOYED_SHA.tmp" "$TREE/DEPLOYED_SHA"
       log "no-op deploy OK — $TREE already matches $SHORT, verified, lane untouched"
       exit 0
     else
@@ -178,7 +185,6 @@ log "verifying deployed tree against $SHORT"
 if sh "$HUB/deploy/verify-deployed.sh" "$LANE" "$TREE" "$TARGET_SHA"; then
   # Code provenance alone is not a healthy bridge. config.json is deliberately never shipped,
   # so verify its live routing policy separately and fail closed if it is absent or incomplete.
-  CONFIG_VERIFY_CMD="${WB_CONFIG_VERIFY_CMD:-sh \"$HUB/deploy/verify-config.sh\" \"$TREE/config.json\"}"
   if ! sh -c "$CONFIG_VERIFY_CMD"; then
     alarm "live routing policy is incomplete or unreadable — DEPLOYED_SHA left unchanged"
     exit 1

--- a/deploy/deploy-runner.sh
+++ b/deploy/deploy-runner.sh
@@ -176,6 +176,13 @@ sh -c "$RESTART_CMD \"$UNIT\"" || { alarm "restart of $UNIT failed"; exit 1; }
 # --- post-deploy: what is on disk MUST equal git at the sha we shipped -------------------
 log "verifying deployed tree against $SHORT"
 if sh "$HUB/deploy/verify-deployed.sh" "$LANE" "$TREE" "$TARGET_SHA"; then
+  # Code provenance alone is not a healthy bridge. config.json is deliberately never shipped,
+  # so verify its live routing policy separately and fail closed if it is absent or incomplete.
+  CONFIG_VERIFY_CMD="${WB_CONFIG_VERIFY_CMD:-sh \"$HUB/deploy/verify-config.sh\" \"$TREE/config.json\"}"
+  if ! sh -c "$CONFIG_VERIFY_CMD"; then
+    alarm "live routing policy is incomplete or unreadable — DEPLOYED_SHA left unchanged"
+    exit 1
+  fi
   # DEPLOYED_SHA is written ONLY here — after verify passes (#136).
   #
   # It used to be written before the restart, reasoning that a crash mid-restart should still
@@ -192,7 +199,7 @@ if sh "$HUB/deploy/verify-deployed.sh" "$LANE" "$TREE" "$TARGET_SHA"; then
   # The trade, stated: provenance becomes "last VERIFIED sha" rather than "last shipped sha".
   # That is the more useful of the two — it is the question verify-deployed.sh asks anyway.
   printf '%s\n' "$TARGET_SHA" > "$TREE/DEPLOYED_SHA.tmp" && mv "$TREE/DEPLOYED_SHA.tmp" "$TREE/DEPLOYED_SHA"
-  log "deploy OK — $TREE now at $SHORT, verified"
+  log "deploy OK — $TREE now at $SHORT, code and live policy verified"
   exit 0
 else
   alarm "post-deploy drift at $SHORT — deployed tree does NOT match git; investigate now"

--- a/tests/deploy_runner.mjs
+++ b/tests/deploy_runner.mjs
@@ -24,6 +24,9 @@ import { fileURLToPath } from 'node:url'
 
 const REPO = join(dirname(fileURLToPath(import.meta.url)), '..')
 const SCRIPT = 'deploy/deploy-runner.sh'
+// Fixture trees intentionally omit the private live policy. Production uses the runner default;
+// individual tests may override this seam to prove that policy failure blocks DEPLOYED_SHA.
+process.env.WB_CONFIG_VERIFY_CMD = ':'
 let failed = 0
 const check = (cond, msg) => { if (!cond) { console.error('  ✗', msg); failed++ } else { console.log('  ✓', msg) } }
 

--- a/tests/deploy_runner.mjs
+++ b/tests/deploy_runner.mjs
@@ -248,6 +248,19 @@ try {
     'docs-only -> SHA still recorded, so the next tick is not re-evaluated')
   check(/verified/.test(docsTick.out), 'docs-only -> tree still VERIFIED, not merely assumed')
 
+  // #104: the no-op path is still a deploy decision. It must refuse an incomplete private
+  // routing policy and leave the old watermark so the next timer tick re-alarms.
+  const policyTree = join(work, 'tree-noop-policy')
+  mkdirSync(policyTree, { recursive: true })
+  const policyMarker = join(policyTree, '.restarted')
+  const policyBase = tick(policyTree, TARGET, policyMarker)
+  check(policyBase.code === 0, 'no-op policy gate: baseline deploy succeeds')
+  const policyDocs = tick(policyTree, DOCS_SHA, policyMarker, { WB_CONFIG_VERIFY_CMD: 'false' })
+  check(policyDocs.code === 1, 'docs-only with incomplete policy -> exit 1')
+  check(/policy is incomplete/.test(policyDocs.out), 'docs-only incomplete policy -> loud alarm')
+  check(readFileSync(join(policyTree, 'DEPLOYED_SHA'), 'utf8').trim() === TARGET,
+    'docs-only incomplete policy -> old DEPLOYED_SHA retained for retry')
+
   // NEGATIVE CONTROL. The checks above pass just as happily if the gate skipped everything
   // unconditionally — a runner that never restarts and one that restarts only when needed are
   // indistinguishable until a real code change is put through it.


### PR DESCRIPTION
Makes the existing live config verifier a mandatory post-deploy gate. A deployment records DEPLOYED_SHA only after both shipped-code provenance and the private routing policy verify. Tests use an explicit fixture seam because test trees intentionally contain no private config.