### PR TITLE
fix: run routing verifier with bash

### DIFF
--- a/deploy/deploy-runner.sh
+++ b/deploy/deploy-runner.sh
@@ -66,7 +66,10 @@ log() { echo "deploy-runner[$LANE] $*"; }
 alarm() { echo "deploy-runner[$LANE] ALARM: $*" >&2; }
 # The private routing policy is a deploy gate even when the new commit changes no shipped code.
 # A docs-only tick must never advance DEPLOYED_SHA past an incomplete live config.
-CONFIG_VERIFY_CMD="${WB_CONFIG_VERIFY_CMD:-sh \"$HUB/deploy/verify-config.sh\" \"$TREE/config.json\"}"
+# verify-config.sh deliberately uses bash (`pipefail` + BASH_SOURCE). Invoking it through `sh`
+# ignores its shebang on Debian/Ubuntu, where /bin/sh is dash, and makes every otherwise-good
+# deploy fail after shipping with `set: Illegal option -o pipefail`.
+CONFIG_VERIFY_CMD="${WB_CONFIG_VERIFY_CMD:-bash \"$HUB/deploy/verify-config.sh\" \"$TREE/config.json\"}"
 
 # Default CI-state resolver: GitHub Actions records results as CHECK-RUNS (not legacy commit
 # statuses), so ask the check-runs API for this exact sha and aggregate. Unauthenticated for a

--- a/tests/deploy_runner.mjs
+++ b/tests/deploy_runner.mjs
@@ -30,6 +30,13 @@ process.env.WB_CONFIG_VERIFY_CMD = ':'
 let failed = 0
 const check = (cond, msg) => { if (!cond) { console.error('  ✗', msg); failed++ } else { console.log('  ✓', msg) } }
 
+// Production uses the default command, not the seam below. verify-config is a bash script
+// (`pipefail` + BASH_SOURCE), so forcing it through `sh` fails on Ubuntu's dash after code has
+// already shipped and leaves DEPLOYED_SHA permanently stale.
+const runnerSource = readFileSync(join(REPO, SCRIPT), 'utf8')
+check(/CONFIG_VERIFY_CMD="\$\{WB_CONFIG_VERIFY_CMD:-bash /.test(runnerSource),
+  'production policy verifier honors its bash runtime instead of forcing /bin/sh')
+
 // The bridge persists signed operator decisions in config.json. ProtectSystem=strict remains
 // load-bearing, so the service may write that one policy file and data/, never its code tree.
 const readUnit = readFileSync(join(REPO, 'deploy', 'waggle-read.service'), 'utf8')


### PR DESCRIPTION
## Summary
- honor verify-config.sh's bash shebang requirements in the production deploy runner
- add a regression assertion for the production default verifier command

## Incident evidence
The sealed runner shipped and hash-verified main at 59542a8, then failed the routing-policy gate because it invoked the bash-only verifier through Ubuntu dash: set: Illegal option -o pipefail. DEPLOYED_SHA correctly remained unchanged.

## Verification
- npm run lint
- CONFIG_PATH=config.example.json npm test (31 suites)
- git diff --check

Originating Buzz channel: a8186b53-537d-46ad-a7e7-b6486c58970e