### PR TITLE
Fix lane-aware deployment policy verification

### DIFF
--- a/deploy/deploy-runner.sh
+++ b/deploy/deploy-runner.sh
@@ -69,7 +69,7 @@ alarm() { echo "deploy-runner[$LANE] ALARM: $*" >&2; }
 # verify-config.sh deliberately uses bash (`pipefail` + BASH_SOURCE). Invoking it through `sh`
 # ignores its shebang on Debian/Ubuntu, where /bin/sh is dash, and makes every otherwise-good
 # deploy fail after shipping with `set: Illegal option -o pipefail`.
-CONFIG_VERIFY_CMD="${WB_CONFIG_VERIFY_CMD:-bash \"$HUB/deploy/verify-config.sh\" \"$TREE/config.json\"}"
+CONFIG_VERIFY_CMD="${WB_CONFIG_VERIFY_CMD:-bash \"$HUB/deploy/verify-config.sh\" \"$TREE/config.json\" \"$LANE\"}"
 
 # Default CI-state resolver: GitHub Actions records results as CHECK-RUNS (not legacy commit
 # statuses), so ask the check-runs API for this exact sha and aggregate. Unauthenticated for a

--- a/deploy/verify-config.sh
+++ b/deploy/verify-config.sh
@@ -50,7 +50,7 @@ if lane == "sealed":
     channels = config.get("channels") or []
     names = {r.get("name") for r in recipients if isinstance(r, dict) and r.get("name")}
     print("live sealed routing policy: %s" % sys.argv[1])
-    valid_relay = lambda value: isinstance(value, str) and (lambda u: u.scheme == "wss" and bool(u.netloc) and not u.username and not u.password)(urlparse(value))
+    valid_relay = lambda value: isinstance(value, str) and (lambda u: u.scheme == "wss" and bool(u.netloc) and not u.username and not u.password and not u.query and not u.fragment)(urlparse(value))
     bad_relays = [r for r in relays if not valid_relay(r)]
     if not relays or bad_relays:
         print("  MISSING  relays         need wss:// relay URLs with hosts (%d invalid)" % len(bad_relays)); fail = 1

--- a/deploy/verify-config.sh
+++ b/deploy/verify-config.sh
@@ -14,7 +14,7 @@
 # So: check the SHAPE against config.example.json, and check the fields whose emptiness is
 # invisible at runtime. Report counts, never values.
 #
-#   sudo deploy/verify-config.sh [path-to-config.json]
+#   sudo deploy/verify-config.sh [path-to-config.json] [read|sealed]
 #
 #   0  complete
 #   2  a required field is missing or empty
@@ -23,7 +23,10 @@ set -uo pipefail
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CFG="${1:-/opt/waggle-read/config.json}"
+LANE="${2:-read}"
 EXAMPLE="$HERE/../config.example.json"
+
+case "$LANE" in read|sealed) ;; *) echo "verify-config: lane must be read or sealed"; exit 3 ;; esac
 
 if [ ! -r "$CFG" ]; then
   echo "verify-config: cannot read $CFG — re-run with sudo, or pass the path."
@@ -32,10 +35,42 @@ if [ ! -r "$CFG" ]; then
 fi
 [ -r "$EXAMPLE" ] || { echo "verify-config: missing $EXAMPLE"; exit 3; }
 
-python3 - "$CFG" "$EXAMPLE" <<'PY'
+python3 - "$CFG" "$EXAMPLE" "$LANE" <<'PY'
 import json, sys
 
-live = json.load(open(sys.argv[1])).get("public", {})
+config = json.load(open(sys.argv[1]))
+lane = sys.argv[3]
+
+if lane == "sealed":
+    import re
+    fail = 0
+    relays = config.get("relays") or []
+    recipients = config.get("recipients") or []
+    channels = config.get("channels") or []
+    names = {r.get("name") for r in recipients if isinstance(r, dict) and r.get("name")}
+    print("live sealed routing policy: %s" % sys.argv[1])
+    if not relays:
+        print("  MISSING  relays         no Armada relays — the sealed lane connects to nothing"); fail = 1
+    else: print("  ok       relays         %d entries" % len(relays))
+    bad_recipients = [r for r in recipients if not isinstance(r, dict) or not r.get("name") or not r.get("inbox") or str(r.get("inbox", "")).startswith("INBOX_UUID_") or not re.fullmatch(r"[0-9a-f]{64}", str(r.get("npub_hex", "")))]
+    if not recipients or bad_recipients:
+        print("  MISSING  recipients     need named seats with 64-hex pubkeys and real inboxes (%d invalid)" % len(bad_recipients)); fail = 1
+    else: print("  ok       recipients     %d entries" % len(recipients))
+    bad_channels = []
+    for c in channels:
+        refs = c.get("recipients") if isinstance(c, dict) else None
+        if not isinstance(c, dict) or not c.get("name") or not re.fullmatch(r"[0-9a-f]{64}", str(c.get("plane_pubkey", ""))) or not isinstance(refs, list) or not refs or any(n not in names for n in refs):
+            bad_channels.append(c)
+    if not channels or bad_channels:
+        print("  MISSING  channels       need named 64-hex planes fanning only to configured recipients (%d invalid)" % len(bad_channels)); fail = 1
+    else: print("  ok       channels       %d entries" % len(channels))
+    print()
+    if fail:
+        print("FAILED — the sealed bridge will start and route less than you think."); sys.exit(2)
+    print("complete — sealed relays, seats, inboxes, and channel fans are populated.")
+    sys.exit(0)
+
+live = config.get("public", {})
 example = json.load(open(sys.argv[2])).get("public", {})
 
 # Fields whose absence the bridge cannot complain about at runtime: it starts fine and simply

--- a/deploy/verify-config.sh
+++ b/deploy/verify-config.sh
@@ -43,18 +43,22 @@ lane = sys.argv[3]
 
 if lane == "sealed":
     import re
+    from urllib.parse import urlparse
     fail = 0
     relays = config.get("relays") or []
     recipients = config.get("recipients") or []
     channels = config.get("channels") or []
     names = {r.get("name") for r in recipients if isinstance(r, dict) and r.get("name")}
     print("live sealed routing policy: %s" % sys.argv[1])
-    if not relays:
-        print("  MISSING  relays         no Armada relays — the sealed lane connects to nothing"); fail = 1
+    valid_relay = lambda value: isinstance(value, str) and (lambda u: u.scheme == "wss" and bool(u.netloc) and not u.username and not u.password)(urlparse(value))
+    bad_relays = [r for r in relays if not valid_relay(r)]
+    if not relays or bad_relays:
+        print("  MISSING  relays         need wss:// relay URLs with hosts (%d invalid)" % len(bad_relays)); fail = 1
     else: print("  ok       relays         %d entries" % len(relays))
-    bad_recipients = [r for r in recipients if not isinstance(r, dict) or not r.get("name") or not r.get("inbox") or str(r.get("inbox", "")).startswith("INBOX_UUID_") or not re.fullmatch(r"[0-9a-f]{64}", str(r.get("npub_hex", "")))]
+    valid_inbox = lambda value: bool(re.fullmatch(r"[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}", str(value), re.I))
+    bad_recipients = [r for r in recipients if not isinstance(r, dict) or not r.get("name") or not valid_inbox(r.get("inbox")) or not re.fullmatch(r"[0-9a-f]{64}", str(r.get("npub_hex", "")))]
     if not recipients or bad_recipients:
-        print("  MISSING  recipients     need named seats with 64-hex pubkeys and real inboxes (%d invalid)" % len(bad_recipients)); fail = 1
+        print("  MISSING  recipients     need named seats with 64-hex pubkeys and canonical inbox UUIDs (%d invalid)" % len(bad_recipients)); fail = 1
     else: print("  ok       recipients     %d entries" % len(recipients))
     bad_channels = []
     for c in channels:

--- a/tests/deploy_runner.mjs
+++ b/tests/deploy_runner.mjs
@@ -48,7 +48,7 @@ const verifyPolicy = (body, lane) => {
   try { return { code: 0, out: execFileSync('bash', [join(REPO, 'deploy/verify-config.sh'), policyConfig, lane], { encoding: 'utf8' }) } }
   catch (e) { return { code: e.status ?? 1, out: (e.stdout || '') + (e.stderr || '') } }
 }
-const seat = { name: 'Agent', npub_hex: 'a'.repeat(64), inbox: 'real-inbox' }
+const seat = { name: 'Agent', npub_hex: 'a'.repeat(64), inbox: '11111111-1111-4111-8111-111111111111' }
 const sealedPolicy = { relays: ['wss://relay.example'], recipients: [seat], channels: [{ name: 'general', plane_pubkey: 'b'.repeat(64), recipients: ['Agent'] }] }
 const sealedGood = verifyPolicy(sealedPolicy, 'sealed')
 check(sealedGood.code === 0 && /complete — sealed/.test(sealedGood.out),
@@ -56,6 +56,12 @@ check(sealedGood.code === 0 && /complete — sealed/.test(sealedGood.out),
 const sealedBad = verifyPolicy({ ...sealedPolicy, channels: [{ ...sealedPolicy.channels[0], recipients: ['Missing'] }] }, 'sealed')
 check(sealedBad.code === 2 && /MISSING  channels/.test(sealedBad.out),
   'sealed policy fails closed when a channel fan names an unknown recipient')
+const sealedBadRelay = verifyPolicy({ ...sealedPolicy, relays: ['not-a-websocket'] }, 'sealed')
+check(sealedBadRelay.code === 2 && /MISSING  relays/.test(sealedBadRelay.out),
+  'sealed policy fails closed on a malformed relay URL')
+const sealedBadInbox = verifyPolicy({ ...sealedPolicy, recipients: [{ ...seat, inbox: 'not-an-inbox' }] }, 'sealed')
+check(sealedBadInbox.code === 2 && /MISSING  recipients/.test(sealedBadInbox.out),
+  'sealed policy fails closed on a malformed delivery inbox UUID')
 rmSync(policyFixture, { recursive: true, force: true })
 
 // The bridge persists signed operator decisions in config.json. ProtectSystem=strict remains

--- a/tests/deploy_runner.mjs
+++ b/tests/deploy_runner.mjs
@@ -36,6 +36,27 @@ const check = (cond, msg) => { if (!cond) { console.error('  ✗', msg); failed+
 const runnerSource = readFileSync(join(REPO, SCRIPT), 'utf8')
 check(/CONFIG_VERIFY_CMD="\$\{WB_CONFIG_VERIFY_CMD:-bash /.test(runnerSource),
   'production policy verifier honors its bash runtime instead of forcing /bin/sh')
+check(runnerSource.includes('\\"$TREE/config.json\\" \\"$LANE\\"'),
+  'production policy verifier receives the explicit deployment lane')
+
+// The two production lanes have different policy surfaces. A sealed Concord bridge must not be
+// rejected for intentionally lacking the public read lane, but its own seats and fans stay strict.
+const policyFixture = mkdtempSync(join(tmpdir(), 'wb-policy-'))
+const policyConfig = join(policyFixture, 'config.json')
+const verifyPolicy = (body, lane) => {
+  writeFileSync(policyConfig, JSON.stringify(body))
+  try { return { code: 0, out: execFileSync('bash', [join(REPO, 'deploy/verify-config.sh'), policyConfig, lane], { encoding: 'utf8' }) } }
+  catch (e) { return { code: e.status ?? 1, out: (e.stdout || '') + (e.stderr || '') } }
+}
+const seat = { name: 'Agent', npub_hex: 'a'.repeat(64), inbox: 'real-inbox' }
+const sealedPolicy = { relays: ['wss://relay.example'], recipients: [seat], channels: [{ name: 'general', plane_pubkey: 'b'.repeat(64), recipients: ['Agent'] }] }
+const sealedGood = verifyPolicy(sealedPolicy, 'sealed')
+check(sealedGood.code === 0 && /complete — sealed/.test(sealedGood.out),
+  'sealed policy accepts complete sealed routing without a public block')
+const sealedBad = verifyPolicy({ ...sealedPolicy, channels: [{ ...sealedPolicy.channels[0], recipients: ['Missing'] }] }, 'sealed')
+check(sealedBad.code === 2 && /MISSING  channels/.test(sealedBad.out),
+  'sealed policy fails closed when a channel fan names an unknown recipient')
+rmSync(policyFixture, { recursive: true, force: true })
 
 // The bridge persists signed operator decisions in config.json. ProtectSystem=strict remains
 // load-bearing, so the service may write that one policy file and data/, never its code tree.

--- a/tests/deploy_runner.mjs
+++ b/tests/deploy_runner.mjs
@@ -59,6 +59,9 @@ check(sealedBad.code === 2 && /MISSING  channels/.test(sealedBad.out),
 const sealedBadRelay = verifyPolicy({ ...sealedPolicy, relays: ['not-a-websocket'] }, 'sealed')
 check(sealedBadRelay.code === 2 && /MISSING  relays/.test(sealedBadRelay.out),
   'sealed policy fails closed on a malformed relay URL')
+const sealedCredentialRelay = verifyPolicy({ ...sealedPolicy, relays: ['wss://relay.example/?token=secret'] }, 'sealed')
+check(sealedCredentialRelay.code === 2 && /MISSING  relays/.test(sealedCredentialRelay.out),
+  'sealed policy fails closed on relay URL query credentials')
 const sealedBadInbox = verifyPolicy({ ...sealedPolicy, recipients: [{ ...seat, inbox: 'not-an-inbox' }] }, 'sealed')
 check(sealedBadInbox.code === 2 && /MISSING  recipients/.test(sealedBadInbox.out),
   'sealed policy fails closed on a malformed delivery inbox UUID')


### PR DESCRIPTION
## Summary
- pass the explicit deployment lane into the live-policy verifier
- retain the strict public read-lane contract
- validate sealed relays, seats, inboxes, channel planes, and fan references without requiring a public block
- add positive and fail-closed sealed policy coverage to the deploy-runner suite

## Production evidence
The sealed runner correctly invokes the verifier after PR #232, but current main rejects the healthy sealed config for missing public-only fields. The service remains active and DEPLOYED_SHA remains unchanged.

## Verification
- npm run lint
- CONFIG_PATH=config.example.json npm test (31 suites)
- node tests/deploy_runner.mjs
- git diff --check