### PR TITLE
fix: re-alarm live policy drift on already-current ticks

### DIFF
--- a/deploy/deploy-runner.sh
+++ b/deploy/deploy-runner.sh
@@ -112,7 +112,15 @@ DEPLOYED_SHA=$(cat "$TREE/DEPLOYED_SHA" 2>/dev/null || echo none)
 log "target $SHORT ($REF); deployed $DEPLOYED_SHA"
 
 if [ "$TARGET_SHA" = "$DEPLOYED_SHA" ]; then
-  log "already current — nothing to do"; exit 0
+  # A matching code watermark does not prove the mutable, deliberately-unshipped
+  # routing policy is still healthy. Check it on every timer tick: otherwise a
+  # config edited after the last deploy would remain invisible until some future
+  # code commit happened to enter the no-op/full-deploy paths below.
+  if ! sh -c "$CONFIG_VERIFY_CMD"; then
+    alarm "live routing policy is incomplete or unreadable — DEPLOYED_SHA retained; will re-alarm next tick"
+    exit 1
+  fi
+  log "already current — deployed code and live routing policy verified"; exit 0
 fi
 
 # --- green gate: merged is not enough, CI must have passed for THIS sha ------------------

--- a/tests/deploy_runner.mjs
+++ b/tests/deploy_runner.mjs
@@ -309,6 +309,24 @@ try {
   check(/\/\/ shipped change/.test(readFileSync(join(nt, 'src', 'log.mjs'), 'utf8')),
     'NEGATIVE CONTROL — the new code actually reached the tree')
 
+  // #104: "already current" is also a live health check. A box-side routing-policy
+  // edit can happen after a successful deploy, with no new git SHA to trigger the
+  // no-op gate. It must alarm on every tick and never restart the lane or mutate the
+  // last verified watermark.
+  rmSync(nm, { force: true })
+  const currentBadPolicy = tick(nt, CODE_SHA, nm, { WB_CONFIG_VERIFY_CMD: 'false' })
+  check(currentBadPolicy.code === 1, 'already-current with incomplete policy -> exit 1')
+  check(/policy is incomplete/.test(currentBadPolicy.out), 'already-current incomplete policy -> loud alarm')
+  check(!existsSync(nm), 'already-current incomplete policy -> lane NOT restarted')
+  check(readFileSync(join(nt, 'DEPLOYED_SHA'), 'utf8').trim() === CODE_SHA,
+    'already-current incomplete policy -> last verified SHA is retained')
+  const currentBadPolicyAgain = tick(nt, CODE_SHA, nm, { WB_CONFIG_VERIFY_CMD: 'false' })
+  check(currentBadPolicyAgain.code === 1 && /will re-alarm next tick/.test(currentBadPolicyAgain.out),
+    'already-current incomplete policy -> subsequent tick re-alarms')
+  const currentGoodPolicy = tick(nt, CODE_SHA, nm)
+  check(currentGoodPolicy.code === 0 && /already current/.test(currentGoodPolicy.out),
+    'already-current with healthy policy -> exits cleanly after verification')
+
   // Being unable to answer the question is not a reason to skip work: a recorded SHA the hub
   // does not have (force-push, rebase, a restored tree) must fall through to a full deploy.
   rmSync(nm, { force: true })


### PR DESCRIPTION
Completes the #104 live-policy gate: the deployment runner now verifies the mutable routing policy even when DEPLOYED_SHA already matches the target commit. A bad live policy leaves the watermark unchanged and re-alarms on every timer tick without restarting the lane. Includes regression coverage for the current-SHA path.