### PR TITLE
fix: bound latency telemetry and account fanout

### DIFF
--- a/src/bridge.mjs
+++ b/src/bridge.mjs
@@ -825,7 +825,7 @@ function forward(rec, ev, src) {
   emit(descriptor).then(({ stdout }) => {
     log(`FORWARD[buzz] ok -> ${rec.name} inbox: ${decrypted ? 'plaintext ' : ''}${src && src.channel ? `${src.channel} ` : 'DM '}1059 ${ev.id.slice(0, 12)}…`)
     journalSend(parseBuzzEventId(stdout), { kind: 9, dest: rec.inbox, lane: 'sealed' })
-    markLatency(ev.id, 'sealed.forwarded')
+    markLatency(ev.id, 'sealed.forwarded', Date.now(), src?.traceAttempt || 0)
   }).catch(e => {
     err(`FORWARD[buzz] ERR -> ${rec.name}: ${e.message}`)
     // The event was marked seen before this send (route()), and the mark is per EVENT, not per
@@ -837,8 +837,6 @@ function forward(rec, ev, src) {
 
 function route(ev) {
   if (!ev || !ev.id || seen.has(ev.id)) return
-  markLatency(ev.id, 'sealed.observed')
-
   // Channel-plane traffic: routed by AUTHOR (the derived plane pubkey), not by p-tag.
   // Every configured member of that channel gets a copy; each decrypts with the plane key.
   const plane = PLANES[ev.pubkey]
@@ -854,7 +852,10 @@ function route(ev) {
     // provisioned inbox, so a dryrun or a placeholder inbox never suppresses later backfill.
     const willDeliver = FORWARD_MODE === 'buzz' && recips.some(r => !r.inbox.startsWith('INBOX_UUID_'))
     if (willDeliver) markSeen(ev.id)
-    for (const r of recips) forward(r, ev, { channel: plane.name, planeKey: plane.planeKey })
+    for (const [attempt, r] of recips.entries()) {
+      markLatency(ev.id, 'sealed.observed', Date.now(), attempt)
+      forward(r, ev, { channel: plane.name, planeKey: plane.planeKey, traceAttempt: attempt })
+    }
     return
   }
 
@@ -872,7 +873,10 @@ function route(ev) {
   // second relay serving the same wrap can't double-send before the first records it.
   const willDeliver = FORWARD_MODE === 'buzz' && hits.some(p => !RECIPIENTS[p].inbox.startsWith('INBOX_UUID_'))
   if (willDeliver) markSeen(ev.id)
-  for (const p of hits) forward(RECIPIENTS[p], ev)
+  for (const [attempt, p] of hits.entries()) {
+    markLatency(ev.id, 'sealed.observed', Date.now(), attempt)
+    forward(RECIPIENTS[p], ev, { traceAttempt: attempt })
+  }
 }
 
 // --- public kind:1 delivery & routing ---------------------------------------

--- a/src/latency.mjs
+++ b/src/latency.mjs
@@ -7,8 +7,8 @@
 // turning that journal into another copy of private conversation metadata.
 
 import { createHmac } from 'node:crypto'
-import { existsSync, readFileSync } from 'node:fs'
-import { appendFile, mkdir } from 'node:fs/promises'
+import { closeSync, existsSync, openSync, readSync, statSync } from 'node:fs'
+import { appendFile, mkdir, stat } from 'node:fs/promises'
 import { dirname, resolve } from 'node:path'
 
 const validId = value => /^[0-9a-f]{64}$/i.test(String(value || ''))
@@ -37,6 +37,24 @@ export function latencyPath() {
 const chains = new Map()
 const pending = new Map()
 const maxPending = () => Math.max(1, Number(process.env.LATENCY_MAX_PENDING || 1000) || 1000)
+const maxFileBytes = () => Math.max(4096, Number(process.env.LATENCY_MAX_FILE_BYTES || 16 * 1024 * 1024) || 16 * 1024 * 1024)
+const health = new Map()
+const lastHealthLog = new Map()
+
+function noteHealth(path, reason) {
+  const row = health.get(path) || { queue_full: 0, file_full: 0, write_error: 0 }
+  row[reason]++
+  health.set(path, row)
+  const key = `${path}:${reason}`, now = Date.now()
+  if (now - (lastHealthLog.get(key) || 0) >= 60_000) {
+    lastHealthLog.set(key, now)
+    console.error(`latency trace health: ${reason}=${row[reason]} path=${path}`)
+  }
+}
+
+export function latencyHealth(path = latencyPath()) {
+  return { ...(health.get(path) || { queue_full: 0, file_full: 0, write_error: 0 }), pending: pending.get(path) || 0 }
+}
 
 export function flushLatency(path = latencyPath()) {
   return chains.get(path) || Promise.resolve()
@@ -44,36 +62,53 @@ export function flushLatency(path = latencyPath()) {
 
 // Stage is deliberately a closed-ish operational identifier, not a caller supplied sentence.
 // A later report can group it safely and no content can be smuggled into logs through a label.
-export function markLatency(sourceId, stage, at = Date.now()) {
+export function markLatency(sourceId, stage, at = Date.now(), attempt = 0) {
   if (!/^[a-z][a-z0-9_.-]{1,63}$/.test(String(stage || ''))) throw new Error('latency trace stage is invalid')
   if (!Number.isFinite(at) || at <= 0) throw new Error('latency trace timestamp is invalid')
   const key = traceKey()
   if (!key) return { ok: false, error: 'latency tracing disabled: LATENCY_TRACE_KEY unavailable' }
-  const record = { v: 1, trace: correlationId(sourceId, key), stage, at: Math.floor(at) }
+  if (!Number.isInteger(attempt) || attempt < 0 || attempt > 10_000) throw new Error('latency trace attempt is invalid')
+  const record = { v: 1, trace: correlationId(sourceId, key), attempt, stage, at: Math.floor(at) }
   const path = latencyPath()
   const count = pending.get(path) || 0
-  if (count >= maxPending()) return { ok: false, error: 'trace queue full', record }
+  if (count >= maxPending()) { noteHealth(path, 'queue_full'); return { ok: false, error: 'trace queue full', record } }
   pending.set(path, count + 1)
   const previous = chains.get(path) || Promise.resolve()
   const next = previous.catch(() => {}).then(async () => {
     try {
       await mkdir(dirname(path), { recursive: true, mode: 0o700 })
+      let bytes = 0
+      try { bytes = (await stat(path)).size } catch (e) { if (e?.code !== 'ENOENT') throw e }
+      if (bytes >= maxFileBytes()) { noteHealth(path, 'file_full'); return }
       await appendFile(path, JSON.stringify(record) + '\n', { mode: 0o600 })
-    } catch { /* telemetry is never a delivery dependency */ }
+    } catch { noteHealth(path, 'write_error') /* telemetry is never a delivery dependency */ }
     finally { pending.set(path, Math.max(0, (pending.get(path) || 1) - 1)) }
   })
   chains.set(path, next)
   return { ok: true, record }
 }
 
-export function readLatency(path = latencyPath()) {
-  if (!existsSync(path)) return []
-  return readFileSync(path, 'utf8').split('\n').flatMap(line => {
+export function readLatencyWindow(path = latencyPath(), limit = maxFileBytes()) {
+  if (!existsSync(path)) return { records: [], bytes: 0, total_bytes: 0, truncated: false }
+  const total = statSync(path).size
+  const bytes = Math.min(total, Math.max(4096, Number(limit) || maxFileBytes()))
+  const buffer = Buffer.alloc(bytes)
+  const fd = openSync(path, 'r')
+  try { readSync(fd, buffer, 0, bytes, total - bytes) } finally { closeSync(fd) }
+  let text = buffer.toString('utf8')
+  if (total > bytes) text = text.slice(text.indexOf('\n') + 1)
+  const records = text.split('\n').flatMap(line => {
     try {
       const x = JSON.parse(line)
-      return x?.v === 1 && /^[0-9a-f]{24}$/.test(x.trace || '') && /^[a-z][a-z0-9_.-]{1,63}$/.test(x.stage || '') && Number.isFinite(x.at) ? [x] : []
+      return x?.v === 1 && /^[0-9a-f]{24}$/.test(x.trace || '') && Number.isInteger(x.attempt ?? 0) && (x.attempt ?? 0) >= 0 && /^[a-z][a-z0-9_.-]{1,63}$/.test(x.stage || '') && Number.isFinite(x.at) ? [{ ...x, attempt: x.attempt ?? 0 }] : []
     } catch { return [] }
   })
+  return { records, bytes, total_bytes: total, truncated: total > bytes }
+}
+
+export function readLatency(path = latencyPath(), limit) {
+  const result = readLatencyWindow(path, limit)
+  return Array.isArray(result) ? result : result.records
 }
 
 const percentile = (xs, p) => {
@@ -88,16 +123,19 @@ export function summarizeLatency(records, pairs) {
   const byTrace = new Map()
   for (const r of records || []) {
     if (!r || !/^[0-9a-f]{24}$/.test(r.trace || '') || !Number.isFinite(r.at)) continue
-    const stages = byTrace.get(r.trace) || new Map()
+    const traceAttempt = `${r.trace}:${Number.isInteger(r.attempt) ? r.attempt : 0}`
+    const stages = byTrace.get(traceAttempt) || new Map()
     if (!stages.has(r.stage)) stages.set(r.stage, r.at)
-    byTrace.set(r.trace, stages)
+    byTrace.set(traceAttempt, stages)
   }
   return (pairs || []).map(([from, to]) => {
     const samples = []
+    let attempted = 0
     for (const stages of byTrace.values()) {
       const a = stages.get(from), b = stages.get(to)
+      if (Number.isFinite(a)) attempted++
       if (Number.isFinite(a) && Number.isFinite(b) && b >= a) samples.push(b - a)
     }
-    return { from, to, count: samples.length, p50_ms: percentile(samples, 0.5), p95_ms: percentile(samples, 0.95), max_ms: samples.length ? Math.max(...samples) : null }
+    return { from, to, attempted, count: samples.length, missing_to: attempted - samples.length, p50_ms: percentile(samples, 0.5), p95_ms: percentile(samples, 0.95), max_ms: samples.length ? Math.max(...samples) : null }
   })
 }

--- a/tests/latency_trace.mjs
+++ b/tests/latency_trace.mjs
@@ -1,8 +1,8 @@
 // #237: correlation is opaque and reports per-hop percentiles without payload/ids in the journal.
-import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { correlationId, markLatency, flushLatency, readLatency, summarizeLatency } from '../src/latency.mjs'
+import { correlationId, latencyHealth, markLatency, flushLatency, readLatency, readLatencyWindow, summarizeLatency } from '../src/latency.mjs'
 
 let failed = 0
 const ok = (name, yes) => { console.log(yes ? '  ok' : 'FAIL', name); if (!yes) failed++ }
@@ -20,12 +20,28 @@ try {
   ok('journal contains only opaque trace/stage/time records', !raw.includes(a) && !raw.includes(b) && !/content|body|recipient|secret|nsec/i.test(raw))
   const rows = summarizeLatency(readLatency(), [['relay.observed', 'relay.admitted'], ['relay.admitted', 'relay.posted'], ['relay.posted', 'return.published']])
   ok('report calculates repeatable p50/p95 hop timings', rows[0].count === 2 && rows[0].p50_ms === 25 && rows[0].p95_ms === 50 && rows[1].p50_ms === 75 && rows[1].p95_ms === 150 && rows[2].p50_ms === 50 && rows[2].p95_ms === 100)
+  markLatency(a, 'sealed.observed', 3000, 0); markLatency(a, 'sealed.forwarded', 3020, 0)
+  markLatency(a, 'sealed.observed', 3000, 1)
+  await flushLatency()
+  const fanout = summarizeLatency(readLatency(), [['sealed.observed', 'sealed.forwarded']])[0]
+  ok('fan-out reports every recipient attempt including a failed recipient', fanout.attempted === 2 && fanout.count === 1 && fanout.missing_to === 1 && fanout.p50_ms === 20)
   process.env.LATENCY_MAX_PENDING = '1'
-  const queued = markLatency(a, 'sealed.observed', 3000)
-  const dropped = markLatency(b, 'sealed.observed', 3000)
+  const queued = markLatency(a, 'sealed.observed', 4000)
+  const dropped = markLatency(b, 'sealed.observed', 4000)
   ok('a bounded telemetry queue drops measurement rather than extending a delivery backlog', queued.ok && !dropped.ok && dropped.error === 'trace queue full')
+  ok('dropped telemetry is surfaced through bounded health counters', latencyHealth().queue_full === 1)
   await flushLatency()
   delete process.env.LATENCY_MAX_PENDING
+  const bounded = readLatencyWindow(process.env.LATENCY_PATH, 4096)
+  ok('report reads a bounded tail window', bounded.bytes <= 4096 && Array.isArray(bounded.records))
+  const cappedPath = join(root, 'capped.jsonl')
+  writeFileSync(cappedPath, 'x'.repeat(4096))
+  process.env.LATENCY_PATH = cappedPath
+  process.env.LATENCY_MAX_FILE_BYTES = '4096'
+  markLatency(a, 'relay.observed', 5000)
+  await flushLatency(cappedPath)
+  ok('a full trace file drops new telemetry and surfaces the condition', latencyHealth(cappedPath).file_full === 1 && readFileSync(cappedPath).length === 4096)
+  delete process.env.LATENCY_MAX_FILE_BYTES
 } finally { delete process.env.LATENCY_TRACE_KEY; rmSync(root, { recursive: true, force: true }) }
 if (failed) process.exit(1)
 console.log('latency_trace: all checks passed')

--- a/tools/latency-report.mjs
+++ b/tools/latency-report.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 // Report the privacy-safe #237 trace.  It reads only opaque trace ids and stage times.
-import { readLatency, summarizeLatency } from '../src/latency.mjs'
+import { readLatencyWindow, summarizeLatency } from '../src/latency.mjs'
 
 const arg = flag => { const i = process.argv.indexOf(flag); return i < 0 ? '' : process.argv[i + 1] || '' }
 const file = arg('--file') || process.env.LATENCY_PATH
@@ -8,10 +8,11 @@ if (!file) {
   console.error('usage: node tools/latency-report.mjs --file <latency-trace.jsonl>')
   process.exit(2)
 }
-const rows = summarizeLatency(readLatency(file), [
+const window = readLatencyWindow(file)
+const rows = summarizeLatency(window.records || [], [
   ['relay.observed', 'relay.admitted'],
   ['relay.admitted', 'relay.posted'],
   ['relay.posted', 'return.published'],
   ['sealed.observed', 'sealed.forwarded'],
 ])
-console.log(JSON.stringify({ v: 1, file, samples: rows }, null, 2))
+console.log(JSON.stringify({ v: 1, file, window: { bytes: window.bytes || 0, total_bytes: window.total_bytes || 0, truncated: !!window.truncated }, samples: rows }, null, 2))


### PR DESCRIPTION
Follow-up to #239 for the three production review findings that missed its merge. Caps trace-file growth and report reads, rate-limits visible queue/file/write health signals, and records each sealed fan-out attempt independently so failed recipients appear as missing completions instead of disappearing.\n\nVerification: npm test; npm run lint; git diff --check.