### PR TITLE
fix: enforce hard latency trace cap

### DIFF
--- a/src/latency.mjs
+++ b/src/latency.mjs
@@ -69,6 +69,7 @@ export function markLatency(sourceId, stage, at = Date.now(), attempt = 0) {
   if (!key) return { ok: false, error: 'latency tracing disabled: LATENCY_TRACE_KEY unavailable' }
   if (!Number.isInteger(attempt) || attempt < 0 || attempt > 10_000) throw new Error('latency trace attempt is invalid')
   const record = { v: 1, trace: correlationId(sourceId, key), attempt, stage, at: Math.floor(at) }
+  const line = JSON.stringify(record) + '\n'
   const path = latencyPath()
   const count = pending.get(path) || 0
   if (count >= maxPending()) { noteHealth(path, 'queue_full'); return { ok: false, error: 'trace queue full', record } }
@@ -79,8 +80,10 @@ export function markLatency(sourceId, stage, at = Date.now(), attempt = 0) {
       await mkdir(dirname(path), { recursive: true, mode: 0o700 })
       let bytes = 0
       try { bytes = (await stat(path)).size } catch (e) { if (e?.code !== 'ENOENT') throw e }
-      if (bytes >= maxFileBytes()) { noteHealth(path, 'file_full'); return }
-      await appendFile(path, JSON.stringify(record) + '\n', { mode: 0o600 })
+      // The bound is on the resulting file, not merely its pre-append size. Checking only the
+      // latter permits the final telemetry record to cross the configured hard ceiling.
+      if (bytes + Buffer.byteLength(line) > maxFileBytes()) { noteHealth(path, 'file_full'); return }
+      await appendFile(path, line, { mode: 0o600 })
     } catch { noteHealth(path, 'write_error') /* telemetry is never a delivery dependency */ }
     finally { pending.set(path, Math.max(0, (pending.get(path) || 1) - 1)) }
   })

--- a/tests/latency_trace.mjs
+++ b/tests/latency_trace.mjs
@@ -35,12 +35,12 @@ try {
   const bounded = readLatencyWindow(process.env.LATENCY_PATH, 4096)
   ok('report reads a bounded tail window', bounded.bytes <= 4096 && Array.isArray(bounded.records))
   const cappedPath = join(root, 'capped.jsonl')
-  writeFileSync(cappedPath, 'x'.repeat(4096))
+  writeFileSync(cappedPath, 'x'.repeat(4095))
   process.env.LATENCY_PATH = cappedPath
   process.env.LATENCY_MAX_FILE_BYTES = '4096'
   markLatency(a, 'relay.observed', 5000)
   await flushLatency(cappedPath)
-  ok('a full trace file drops new telemetry and surfaces the condition', latencyHealth(cappedPath).file_full === 1 && readFileSync(cappedPath).length === 4096)
+  ok('a record that would cross the hard trace cap is dropped and surfaced', latencyHealth(cappedPath).file_full === 1 && readFileSync(cappedPath).length === 4095)
   delete process.env.LATENCY_MAX_FILE_BYTES
 } finally { delete process.env.LATENCY_TRACE_KEY; rmSync(root, { recursive: true, force: true }) }
 if (failed) process.exit(1)


### PR DESCRIPTION
## Fix

Counts the encoded telemetry line before append so `LATENCY_MAX_FILE_BYTES` is a hard resulting-file bound, not merely a pre-append threshold.

## Review finding

The private waggle-test review of #240 reproduced a 4095-byte file growing beyond a 4096-byte cap. This patch adds that exact regression case.

## Verification

- `npm run lint`
- `npm test` — 35/35 suites pass
- `git diff --check`
