### PR TITLE
docs: publish external review handoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 <p align="center">
   <a href="https://waggle.nave.pub">Website</a> ·
   <a href="docs/GETTING_STARTED.md">Set up a hive</a> ·
+  <a href="docs/REVIEW_PACKET.md">Review packet</a> ·
   <a href="docs/SPEC_EXTERNAL.md">Specification</a> ·
   <a href="SECURITY.md">Security</a> ·
   <a href="LICENSE">MIT</a>
@@ -126,6 +127,7 @@ boot · suite roster · Nostr remote signer · read resilience · egress catalog
 ## The details, when you want them
 
 - **[External specification](docs/SPEC_EXTERNAL.md)** — architecture, safety gates, moderation model, and roadmap.
+- **[External review packet](docs/REVIEW_PACKET.md)** — a short, sendable review path and the boundaries to challenge.
 - **[Getting started](docs/GETTING_STARTED.md)** — stand up a bridge end to end.
 - **[Concord consumer](docs/CONCORD_CONSUMER.md)** — derived-address group routing and its no-decrypt boundary.
 - **[DM trust allowlist](docs/DM_TRUST_ALLOWLIST.md)** — listening is not obeying.

--- a/docs/REVIEW_PACKET.md
+++ b/docs/REVIEW_PACKET.md
@@ -1,0 +1,70 @@
+# Waggle external review packet
+
+Waggle is a non-custodial, quarantine-gated bridge between a private Buzz community and
+the open Nostr network. It gives a community doors it can operate, rather than turning the
+community into a public room or asking one bridge account to impersonate everyone in it.
+
+This page is the handoff. It is intentionally public, short, and free of deployment paths,
+private channel names, credentials, or internal review history.
+
+## What to review
+
+Start with the [project overview](../README.md), then use these three documents for the
+load-bearing details:
+
+- [Getting started](GETTING_STARTED.md) — the guided owner path, readiness check, and
+  production topology.
+- [External specification](SPEC_EXTERNAL.md) — the protocol model, proof record, safety
+  gates, and known platform gaps. It is a dated design record; the README's “true today”
+  table is the current status surface.
+- [Key custody](KEY_CUSTODY.md) — the exact split between the local Buzz poster and the
+  Bunker-backed Nostr transport identity.
+
+The public home and owner console are at [waggle.nave.pub](https://waggle.nave.pub/).
+The implementation is [JAFairweather/waggle](https://github.com/JAFairweather/waggle).
+
+## What exists now
+
+- Member-signed public federation with relay read-back.
+- A default-closed inbound quarantine with human release.
+- Signed, scoped, revocable participant admission and task authority.
+- Consent-gated public-feed following.
+- Sealed return delivery to admitted external participants.
+- NIP-46 support for the bridge's Nostr transport identity, so that identity's nsec need
+  not live on the bridge host.
+- A guided setup flow and a separate, browser-based owner console.
+
+The automated suite exercises both the accepted paths and the default-closed failures.
+Where a claim depends on a relay, acceptance alone is not treated as proof; the operational
+standard is cold read-back.
+
+## The boundaries we want challenged
+
+1. **Authorship.** Outbound public notes retain their member's signature. Buzz cannot yet
+   render a verified foreign-signed event natively, so inbound public notes use an honest
+   bridge-authored carrier with source provenance. That limitation is tracked upstream.
+2. **Custody.** Sealed forwarding does not decrypt. Relay ingress opens only envelopes
+   addressed to the bridge. The return lane seals outbound traffic; it does not open an
+   inbound message. Buzz channel posting still uses a dedicated local CLI key.
+3. **Authority.** Network reachability is not permission. Participant admission, consent,
+   task authority, and carrier-only task relay are distinct signed capabilities. A task
+   relay can carry an original signed instruction but cannot become its author.
+4. **Failure direction.** Missing grants, stale policy, unreadable relay state, malformed
+   events, and unresolved routing all fail closed.
+5. **Operator experience.** The owner should be able to install, inspect, follow, consent,
+   grant, revoke, and diagnose without learning the bridge's internal storage layout.
+
+## Useful review questions
+
+- Is any carrier presented as the original speaker when it is not?
+- Can a relay, bridge host, or model turn transport access into instruction authority?
+- Does revocation stop the relevant capability without leaving a quiet cached permission?
+- Does any setup step move a private key across a boundary unnecessarily?
+- Can an owner tell what is live, what is held, and what failed from the supported surfaces?
+- Which remaining platform capability would remove the most bridge-specific machinery?
+
+Please report security-sensitive findings privately as described in
+[SECURITY.md](../SECURITY.md). Ordinary design and implementation findings can use the
+repository's issue tracker. A useful review names the exact document, source location, or
+event shape and distinguishes a demonstrated defect from a design preference.
+

--- a/docs/REVIEW_PACKET.md
+++ b/docs/REVIEW_PACKET.md
@@ -51,8 +51,9 @@ standard is cold read-back.
    relay can carry an original signed instruction but cannot become its author.
 4. **Failure direction.** Missing grants, stale policy, unreadable relay state, malformed
    events, and unresolved routing all fail closed.
-5. **Operator experience.** The owner should be able to install, inspect, follow, consent,
-   grant, revoke, and diagnose without learning the bridge's internal storage layout.
+5. **Operator experience.** The owner should be able to install, inspect, follow, inspect
+   consent state, request consent, grant, revoke, and diagnose without learning the
+   bridge's internal storage layout. Consent itself remains the participant's decision.
 
 ## Useful review questions
 

--- a/docs/REVIEW_PACKET.md
+++ b/docs/REVIEW_PACKET.md
@@ -67,4 +67,3 @@ Please report security-sensitive findings privately as described in
 [SECURITY.md](../SECURITY.md). Ordinary design and implementation findings can use the
 repository's issue tracker. A useful review names the exact document, source location, or
 event shape and distinguishes a demonstrated defect from a design preference.
-


### PR DESCRIPTION
Closes #50.\n\nCreates a public, sendable review packet now that the installer, console, spec fold, and status correction blockers are closed. It strips private paths and internal review history, points reviewers to the current owner and custody surfaces, and asks concrete boundary questions.\n\nVerification: git diff --check; npm run lint; all 37 test suites.