### PR TITLE
fix: recover prepared policy events without re-signing

### DIFF
--- a/src/policy_journal.mjs
+++ b/src/policy_journal.mjs
@@ -2,12 +2,15 @@
 // service (#54). One immutable file per policy-derived key is the claim. O_EXCL makes the
 // first claim atomic across forced-command processes; an atomic rename makes completion
 // terminal. Nothing here signs or interprets evidence.
-import { closeSync, constants, fstatSync, fsyncSync, lstatSync, mkdirSync, openSync, readFileSync, renameSync, unlinkSync, writeFileSync } from 'node:fs'
+import { closeSync, constants, fstatSync, fsyncSync, linkSync, lstatSync, mkdirSync, openSync, readFileSync, renameSync, unlinkSync, writeFileSync } from 'node:fs'
 import { createHash, randomBytes, timingSafeEqual } from 'node:crypto'
 import { resolve } from 'node:path'
+import { verifyEvent } from 'nostr-tools/pure'
 
 const HEX64 = /^[0-9a-f]{64}$/
-const MAX_RECORD_BYTES = 96 * 1024
+// A prepared event or receipt may itself be 64 KiB. Stored as a JSON string in the
+// outer canonical record, worst-case escaping can roughly double those bytes.
+const MAX_RECORD_BYTES = 160 * 1024
 const fail = message => { throw new Error(`policy-journal: ${message}`) }
 const hex = (value, label) => {
   const text = String(value || '').toLowerCase()
@@ -32,17 +35,39 @@ const canonical = value => {
   return `{${Object.keys(value).sort().map(key => `${JSON.stringify(key)}:${canonical(value[key])}`).join(',')}}`
 }
 
+function verifiedBuzzEvent(eventText) {
+  if (typeof eventText !== 'string' || !eventText || Buffer.byteLength(eventText) > 64 * 1024) fail('buzz_event must be 1..65536 bytes')
+  let event
+  try { event = JSON.parse(eventText) } catch { fail('buzz_event is not JSON') }
+  if (!event || typeof event !== 'object' || Array.isArray(event) ||
+      Object.keys(event).sort().join(',') !== 'content,created_at,id,kind,pubkey,sig,tags') fail('buzz_event is not an exact wire event')
+  if (canonical(event) !== eventText) fail('buzz_event is not canonical')
+  if (event.kind !== 9) fail('buzz_event must be kind 9')
+  let valid = false
+  try { valid = verifyEvent(JSON.parse(JSON.stringify(event))) } catch { valid = false }
+  if (!valid) fail('buzz_event signature or id is invalid')
+  return event
+}
+
 const INFLIGHT = new Set(['version', 'status', 'key', 'request_digest', 'claimed_at'])
+const PREPARED = new Set(['version', 'status', 'key', 'request_digest', 'buzz_event', 'buzz_event_digest', 'buzz_event_id', 'prepared_at'])
 const TERMINAL = new Set(['version', 'status', 'key', 'request_digest', 'receipt', 'receipt_digest', 'buzz_event_id', 'result', 'completed_at'])
 
 function validate(record, expectedKey = '') {
-  if (record?.version !== 1 || !['in-flight', 'terminal'].includes(record?.status)) fail('record has an invalid version or status')
-  exactKeys(record, record.status === 'in-flight' ? INFLIGHT : TERMINAL, 'record')
+  if (record?.version !== 1 || !['in-flight', 'prepared', 'terminal'].includes(record?.status)) fail('record has an invalid version or status')
+  exactKeys(record, record.status === 'in-flight' ? INFLIGHT : record.status === 'prepared' ? PREPARED : TERMINAL, 'record')
   record.key = hex(record.key, 'record key')
   record.request_digest = hex(record.request_digest, 'request_digest')
   if (expectedKey && record.key !== expectedKey) fail('record key does not match its filename')
   if (record.status === 'in-flight') integer(record.claimed_at, 'claimed_at')
-  else {
+  else if (record.status === 'prepared') {
+    const event = verifiedBuzzEvent(record.buzz_event)
+    record.buzz_event_digest = hex(record.buzz_event_digest, 'buzz_event_digest')
+    if (createHash('sha256').update(record.buzz_event).digest('hex') !== record.buzz_event_digest) fail('buzz_event_digest does not match buzz_event bytes')
+    record.buzz_event_id = hex(record.buzz_event_id, 'buzz_event_id')
+    if (record.buzz_event_id !== event.id) fail('buzz_event_id does not match the signed event')
+    integer(record.prepared_at, 'prepared_at')
+  } else {
     if (typeof record.receipt !== 'string' || !record.receipt || Buffer.byteLength(record.receipt) > 64 * 1024) fail('receipt must be 1..65536 bytes')
     record.receipt_digest = hex(record.receipt_digest, 'receipt_digest')
     if (createHash('sha256').update(record.receipt).digest('hex') !== record.receipt_digest) fail('receipt_digest does not match receipt bytes')
@@ -94,13 +119,21 @@ export class PolicyJournal {
   }
 
   path(key) { return resolve(this.directory, `${hex(key, 'key')}.json`) }
+  terminalPath(key) { return resolve(this.directory, `${hex(key, 'key')}.done.json`) }
 
-  get(key) { const k = hex(key, 'key'); return readRecord(this.path(k), k) }
+  get(key) {
+    const k = hex(key, 'key')
+    return readRecord(this.terminalPath(k), k) || readRecord(this.path(k), k)
+  }
 
   claim(key, requestDigest, claimedAt = Math.floor(Date.now() / 1000)) {
     const k = hex(key, 'key'), digest = hex(requestDigest, 'request_digest')
     const record = validate({ version: 1, status: 'in-flight', key: k, request_digest: digest, claimed_at: integer(claimedAt, 'claimed_at') }, k)
-    const path = this.path(k)
+    const path = this.path(k), existingTerminal = readRecord(this.terminalPath(k), k)
+    if (existingTerminal) {
+      if (existingTerminal.request_digest !== digest) fail('idempotency key already belongs to another request digest')
+      return Object.freeze({ claimed: false, record: existingTerminal })
+    }
     let fd, created = false
     try {
       fd = openSync(path, constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL | constants.O_NOFOLLOW, 0o600)
@@ -119,23 +152,50 @@ export class PolicyJournal {
         }
       }
       if (e.code !== 'EEXIST') throw e
-      const existing = readRecord(path, k)
+      const existing = this.get(k)
       if (!existing || existing.request_digest !== digest) fail('idempotency key already belongs to another request digest')
       return Object.freeze({ claimed: false, record: existing })
     }
   }
 
+  prepare(key, requestDigest, { buzzEvent, preparedAt = Math.floor(Date.now() / 1000) } = {}) {
+    const k = hex(key, 'key'), digest = hex(requestDigest, 'request_digest')
+    const current = this.get(k)
+    if (!current) fail('cannot prepare an unclaimed key')
+    if (current.request_digest !== digest) fail('request digest does not own this claim')
+    if (current.status === 'terminal' || current.status === 'prepared') return current
+    if (!this.owned.has(k)) fail('this process does not own the in-flight claim')
+    const eventText = typeof buzzEvent === 'string' ? buzzEvent : ''
+    const event = verifiedBuzzEvent(eventText)
+    const prepared = validate({ version: 1, status: 'prepared', key: k, request_digest: digest,
+      buzz_event: eventText, buzz_event_digest: createHash('sha256').update(eventText).digest('hex'),
+      buzz_event_id: event.id, prepared_at: integer(preparedAt, 'prepared_at') }, k)
+    const tmp = resolve(this.directory, `.${k}.${randomBytes(8).toString('hex')}.prepare.tmp`)
+    let fd
+    try {
+      fd = openSync(tmp, constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL | constants.O_NOFOLLOW, 0o600)
+      writeFileSync(fd, `${canonical(prepared)}\n`); fsyncSync(fd); closeSync(fd); fd = undefined
+      renameSync(tmp, this.path(k)); fsyncDirectory(this.directory); this.owned.delete(k)
+      return prepared
+    } finally {
+      if (fd !== undefined) { try { closeSync(fd) } catch { /* best effort */ } }
+      try { unlinkSync(tmp) } catch (e) { if (e.code !== 'ENOENT') throw e }
+    }
+  }
+
   commit(key, requestDigest, { receipt, buzzEventId = null, result, completedAt = Math.floor(Date.now() / 1000) } = {}) {
     const k = hex(key, 'key'), digest = hex(requestDigest, 'request_digest')
-    const path = this.path(k), existing = readRecord(path, k)
+    const existing = this.get(k)
     if (!existing) fail('cannot commit an unclaimed key')
     if (existing.request_digest !== digest) fail('request digest does not own this claim')
     if (existing.status === 'terminal') return existing
-    if (!this.owned.has(k)) fail('this process does not own the in-flight claim')
+    if (existing.status === 'in-flight' && !this.owned.has(k)) fail('this process does not own the in-flight claim')
     const receiptText = typeof receipt === 'string' ? receipt : ''
     const terminal = validate({ version: 1, status: 'terminal', key: k, request_digest: digest, receipt: receiptText,
       receipt_digest: createHash('sha256').update(receiptText).digest('hex'), buzz_event_id: buzzEventId === null ? null : hex(buzzEventId, 'buzz_event_id'),
       result, completed_at: integer(completedAt, 'completed_at') }, k)
+    if (result === 'accepted' && existing.status !== 'prepared') fail('an accepted result requires a durably prepared event')
+    if (existing.status === 'prepared' && result === 'accepted' && terminal.buzz_event_id !== existing.buzz_event_id) fail('terminal Buzz id does not match the prepared event')
     const tmp = resolve(this.directory, `.${k}.${randomBytes(8).toString('hex')}.tmp`)
     let fd
     try {
@@ -143,7 +203,12 @@ export class PolicyJournal {
       writeFileSync(fd, `${canonical(terminal)}\n`)
       fsyncSync(fd)
       closeSync(fd); fd = undefined
-      renameSync(tmp, path)
+      try { linkSync(tmp, this.terminalPath(k)) } catch (e) {
+        if (e.code !== 'EEXIST') throw e
+        const winner = readRecord(this.terminalPath(k), k)
+        if (!winner || winner.request_digest !== digest) fail('terminal winner does not belong to this request')
+        return winner
+      }
       fsyncDirectory(this.directory)
       this.owned.delete(k)
       return terminal
@@ -167,6 +232,7 @@ export class PolicyJournal {
     if (!existing) fail('cannot resolve an unclaimed key')
     if (existing.request_digest !== digest) fail('request digest does not own this claim')
     if (existing.status === 'terminal') return existing
+    if (existing.status === 'prepared') fail('a prepared event is recoverable and must not be orphan-resolved')
     if (existing.claimed_at !== integer(expectedClaimedAt, 'expectedClaimedAt')) fail('in-flight claim changed since operator inspection')
     this.owned.add(k)
     try { return this.commit(k, digest, { receipt, result: 'ambiguous', completedAt }) }

--- a/tests/policy_journal.mjs
+++ b/tests/policy_journal.mjs
@@ -2,13 +2,17 @@ import { mkdtempSync, chmodSync, symlinkSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { resolve } from 'node:path'
 import { PolicyJournal } from '../src/policy_journal.mjs'
+import { finalizeEvent } from 'nostr-tools/pure'
 
 let fails = 0
 const t = (name, ok) => { console.log(`${ok ? 'ok  ' : 'FAIL'} — ${name}`); if (!ok) fails++ }
 const rejects = (name, fn, pattern) => { try { fn(); t(name, false) } catch (e) { t(name, pattern.test(e.message)) } }
 const dir = mkdtempSync(resolve(tmpdir(), 'waggle-policy-journal-'))
 chmodSync(dir, 0o700)
-const key = 'a'.repeat(64), request = 'b'.repeat(64), receipt = '{"signed":"receipt-one"}', event = 'd'.repeat(64)
+const key = 'a'.repeat(64), request = 'b'.repeat(64), receipt = '{"signed":"receipt-one"}'
+const signedEvent = JSON.parse(JSON.stringify(finalizeEvent({ kind: 9, created_at: 105, content: 'fixed signed event', tags: [['h', 'a8186b53-537d-46ad-a7e7-b6486c58970e']] }, new Uint8Array(32).fill(7))))
+const preparedBytes = JSON.stringify(signedEvent, Object.keys(signedEvent).sort())
+const event = signedEvent.id
 const first = new PolicyJournal(dir)
 
 const claim = first.claim(key, request, 100)
@@ -21,14 +25,30 @@ rejects('a duplicate process cannot complete the first process claim', () => sec
 rejects('the same key cannot be reused for different request bytes', () => second.claim(key, 'e'.repeat(64)), /another request digest/)
 rejects('an unclaimed key cannot be committed', () => first.commit('f'.repeat(64), request, { receipt, result: 'refused' }), /unclaimed/)
 
-const done = first.commit(key, request, { receipt, buzzEventId: event, result: 'accepted', completedAt: 110 })
-t('completion atomically replaces the in-flight claim', done.status === 'terminal' && done.buzz_event_id === event)
+const prepared = first.prepare(key, request, { buzzEvent: preparedBytes, preparedAt: 105 })
+t('the exact signed event is durable before submission', prepared.status === 'prepared' && prepared.buzz_event === preparedBytes)
+t('the Buzz id is derived from the verified signed event', prepared.buzz_event_id === event)
+const recovering = new PolicyJournal(dir).claim(key, request, 106)
+t('a restarted process recovers the same prepared event without re-signing', !recovering.claimed && recovering.record.buzz_event === preparedBytes)
+rejects('a prepared event cannot commit a substituted Buzz id', () => second.commit(key, request, { receipt, buzzEventId: '9'.repeat(64), result: 'accepted' }), /does not match/)
+const done = second.commit(key, request, { receipt, buzzEventId: event, result: 'accepted', completedAt: 110 })
+t('completion atomically publishes first-winner terminal state', done.status === 'terminal' && done.buzz_event_id === event)
 const afterRestart = new PolicyJournal(dir).claim(key, request, 120)
 t('a restarted process receives the terminal result and never reclaims', !afterRestart.claimed && afterRestart.record.status === 'terminal')
-t('a duplicate commit returns the exact prior receipt bytes', second.commit(key, request, { receipt: '{"different":true}', result: 'refused' }).receipt === receipt)
+t('a competing terminal commit returns the exact first-winner receipt', first.commit(key, request, { receipt: '{"different":true}', result: 'refused' }).receipt === receipt)
 rejects('an accepted result requires the policy-derived Buzz id', () => {
   const k = '1'.repeat(64); first.claim(k, '2'.repeat(64)); first.commit(k, '2'.repeat(64), { receipt, result: 'accepted' })
 }, /requires buzz_event_id/)
+rejects('even a named Buzz id cannot be accepted before durable preparation', () => {
+  const k = '3'.repeat(64); first.claim(k, '2'.repeat(64)); first.commit(k, '2'.repeat(64), { receipt, buzzEventId: event, result: 'accepted' })
+}, /durably prepared/)
+rejects('arbitrary bytes cannot become a prepared event', () => {
+  const k = '0'.repeat(64); first.claim(k, '2'.repeat(64)); first.prepare(k, '2'.repeat(64), { buzzEvent: '{"not":"an event"}' })
+}, /exact wire event/)
+rejects('a caller cannot smuggle an id independent of the signed bytes', () => {
+  const k = 'c'.repeat(64); first.claim(k, '2'.repeat(64)); first.prepare(k, '2'.repeat(64), { buzzEvent: preparedBytes, buzzEventId: '9'.repeat(64) })
+  first.commit(k, '2'.repeat(64), { receipt, buzzEventId: '9'.repeat(64), result: 'accepted' })
+}, /does not match/)
 rejects('an empty receipt cannot become terminal state', () => {
   const k = '6'.repeat(64); first.claim(k, '7'.repeat(64)); first.commit(k, '7'.repeat(64), { receipt: '', result: 'refused' })
 }, /receipt must/)
@@ -40,7 +60,7 @@ const linkKey = '5'.repeat(64)
 symlinkSync(resolve(dir, `${key}.json`), resolve(dir, `${linkKey}.json`))
 rejects('a symlinked record is refused', () => first.get(linkKey), /private regular file/)
 const hugeKey = '8'.repeat(64)
-writeFileSync(resolve(dir, `${hugeKey}.json`), 'x'.repeat(96 * 1024 + 1), { mode: 0o600 })
+writeFileSync(resolve(dir, `${hugeKey}.json`), 'x'.repeat(160 * 1024 + 1), { mode: 0o600 })
 rejects('an oversized record is refused before parsing', () => first.get(hugeKey), /record size/)
 
 const orphanKey = '9'.repeat(64), orphanRequest = '3'.repeat(64), recoverySecret = 'recovery_secret_0123456789abcdef'
@@ -50,6 +70,7 @@ rejects('a bridge process cannot resolve an orphan without the policy-host secre
 rejects('an operator cannot resolve a stale observation of the claim', () => recovery.resolveOrphan(orphanKey, orphanRequest, 499, { recoverySecret, receipt }), /changed since operator inspection/)
 const resolved = recovery.resolveOrphan(orphanKey, orphanRequest, 500, { recoverySecret, receipt, completedAt: 510 })
 t('an operator can terminalize a proven-dead orphan without claiming the post failed', resolved.status === 'terminal' && resolved.result === 'ambiguous' && resolved.buzz_event_id === null)
+t('the signing-to-prepare crash window therefore fails closed as ambiguous', resolved.result === 'ambiguous')
 t('restart converges on the signed ambiguous receipt', new PolicyJournal(dir).claim(orphanKey, orphanRequest, 520).record.receipt === receipt)
 
 console.log(fails ? `\npolicy_journal: ${fails} FAILED` : '\npolicy_journal: all checks passed')


### PR DESCRIPTION
## What this closes

Hardens the merged policy journal so a crash after Bunker signing can never force the service to author a replacement event:

- persists the exact bounded signed Buzz event in a durable `prepared` state before submission;
- a restarted process recovers those identical bytes and event ID;
- accepted terminal state is structurally impossible before preparation;
- a substituted event ID cannot be committed;
- terminal publication uses an atomic no-overwrite hard link, so concurrent recovery converges on the first exact signed receipt rather than overwriting it;
- the record cap safely includes worst-case JSON escaping while remaining bounded.

This is independent of the artifact/submission stack and advances #54's restart and ambiguity migration gate.

## Verification

- `npm run lint`
- `CONFIG_PATH="$PWD/config.example.json" npm test` — all 39 mainline suites green
- restart, competing commit, pre-prepare acceptance, substituted-ID, corruption, symlink, and oversize negative controls
