### PR TITLE
fix: resolve orphaned policy claims safely

### DIFF
--- a/src/policy_journal.mjs
+++ b/src/policy_journal.mjs
@@ -3,7 +3,7 @@
 // first claim atomic across forced-command processes; an atomic rename makes completion
 // terminal. Nothing here signs or interprets evidence.
 import { closeSync, constants, fstatSync, fsyncSync, lstatSync, mkdirSync, openSync, readFileSync, renameSync, unlinkSync, writeFileSync } from 'node:fs'
-import { createHash, randomBytes } from 'node:crypto'
+import { createHash, randomBytes, timingSafeEqual } from 'node:crypto'
 import { resolve } from 'node:path'
 
 const HEX64 = /^[0-9a-f]{64}$/
@@ -47,9 +47,9 @@ function validate(record, expectedKey = '') {
     record.receipt_digest = hex(record.receipt_digest, 'receipt_digest')
     if (createHash('sha256').update(record.receipt).digest('hex') !== record.receipt_digest) fail('receipt_digest does not match receipt bytes')
     if (record.buzz_event_id !== null) record.buzz_event_id = hex(record.buzz_event_id, 'buzz_event_id')
-    if (!['accepted', 'refused'].includes(record.result)) fail('terminal result is invalid')
+    if (!['accepted', 'refused', 'ambiguous'].includes(record.result)) fail('terminal result is invalid')
     if (record.result === 'accepted' && !record.buzz_event_id) fail('an accepted record requires buzz_event_id')
-    if (record.result === 'refused' && record.buzz_event_id !== null) fail('a refused record cannot name a Buzz event')
+    if (record.result !== 'accepted' && record.buzz_event_id !== null) fail('a non-accepted record cannot name a Buzz event')
     integer(record.completed_at, 'completed_at')
   }
   return Object.freeze(record)
@@ -82,13 +82,15 @@ function fsyncDirectory(directory) {
 }
 
 export class PolicyJournal {
-  constructor(directory) {
+  constructor(directory, { recoverySecret = '' } = {}) {
     if (!directory || typeof directory !== 'string') fail('directory is required')
     this.directory = resolve(directory)
     mkdirSync(this.directory, { recursive: true, mode: 0o700 })
     const st = lstatSync(this.directory)
     if (!st.isDirectory() || st.isSymbolicLink() || (st.mode & 0o777) !== 0o700) fail('directory must be private, real, and mode 0700')
     this.owned = new Set()
+    this.recoverySecret = String(recoverySecret || '')
+    if (this.recoverySecret && !/^[A-Za-z0-9_-]{32,128}$/.test(this.recoverySecret)) fail('recoverySecret must be 32..128 URL-safe characters')
   }
 
   path(key) { return resolve(this.directory, `${hex(key, 'key')}.json`) }
@@ -149,5 +151,25 @@ export class PolicyJournal {
       if (fd !== undefined) { try { closeSync(fd) } catch { /* best effort */ } }
       try { unlinkSync(tmp) } catch (e) { if (e.code !== 'ENOENT') throw e }
     }
+  }
+
+  // Explicit crash resolution. The recovery secret belongs only to the policy host;
+  // the untrusted bridge never receives it. An operator uses this after proving the
+  // former worker is dead. The exact claimed_at comparison prevents resolving a stale
+  // observation, and `ambiguous` burns the key without claiming the external post failed.
+  resolveOrphan(key, requestDigest, expectedClaimedAt, { recoverySecret, receipt, completedAt = Math.floor(Date.now() / 1000) } = {}) {
+    const k = hex(key, 'key'), digest = hex(requestDigest, 'request_digest')
+    if (!this.recoverySecret) fail('orphan recovery is disabled')
+    const supplied = String(recoverySecret || '')
+    const left = Buffer.from(this.recoverySecret), right = Buffer.from(supplied)
+    if (left.length !== right.length || !timingSafeEqual(left, right)) fail('orphan recovery authorization failed')
+    const existing = readRecord(this.path(k), k)
+    if (!existing) fail('cannot resolve an unclaimed key')
+    if (existing.request_digest !== digest) fail('request digest does not own this claim')
+    if (existing.status === 'terminal') return existing
+    if (existing.claimed_at !== integer(expectedClaimedAt, 'expectedClaimedAt')) fail('in-flight claim changed since operator inspection')
+    this.owned.add(k)
+    try { return this.commit(k, digest, { receipt, result: 'ambiguous', completedAt }) }
+    finally { this.owned.delete(k) }
   }
 }

--- a/tests/policy_journal.mjs
+++ b/tests/policy_journal.mjs
@@ -43,5 +43,14 @@ const hugeKey = '8'.repeat(64)
 writeFileSync(resolve(dir, `${hugeKey}.json`), 'x'.repeat(96 * 1024 + 1), { mode: 0o600 })
 rejects('an oversized record is refused before parsing', () => first.get(hugeKey), /record size/)
 
+const orphanKey = '9'.repeat(64), orphanRequest = '3'.repeat(64), recoverySecret = 'recovery_secret_0123456789abcdef'
+new PolicyJournal(dir).claim(orphanKey, orphanRequest, 500)
+const recovery = new PolicyJournal(dir, { recoverySecret })
+rejects('a bridge process cannot resolve an orphan without the policy-host secret', () => recovery.resolveOrphan(orphanKey, orphanRequest, 500, { recoverySecret: 'wrong_secret_0123456789abcdefgh', receipt }), /authorization failed/)
+rejects('an operator cannot resolve a stale observation of the claim', () => recovery.resolveOrphan(orphanKey, orphanRequest, 499, { recoverySecret, receipt }), /changed since operator inspection/)
+const resolved = recovery.resolveOrphan(orphanKey, orphanRequest, 500, { recoverySecret, receipt, completedAt: 510 })
+t('an operator can terminalize a proven-dead orphan without claiming the post failed', resolved.status === 'terminal' && resolved.result === 'ambiguous' && resolved.buzz_event_id === null)
+t('restart converges on the signed ambiguous receipt', new PolicyJournal(dir).claim(orphanKey, orphanRequest, 520).record.receipt === receipt)
+
 console.log(fails ? `\npolicy_journal: ${fails} FAILED` : '\npolicy_journal: all checks passed')
 process.exit(fails ? 1 : 0)


### PR DESCRIPTION
## Fix

Closes the crash-orphan gap identified in private review of #249.

- adds an explicit policy-host-only orphan resolution path;
- requires a 32–128 character recovery secret that is never persisted in the journal or exposed to the bridge;
- requires the operator's exact observed `claimed_at`, preventing stale resolution;
- terminalizes the request as `ambiguous`, never falsely claiming that an externally submitted event failed;
- preserves the signed receipt and burns the idempotency key across restart.

This is deliberately operator resolution, not a time lease: a slow but live signer must never lose ownership merely because a wall-clock threshold elapsed.

## Verification

- `git diff --check`
- `npm run lint`
- full 40-suite `npm test`
- hostile tests for missing/wrong recovery authority and stale claim observation
