### PR TITLE
feat: submit verified policy artifacts directly to Buzz

### DIFF
--- a/src/buzz_policy_artifacts.mjs
+++ b/src/buzz_policy_artifacts.mjs
@@ -36,7 +36,7 @@ const exactWireEvent = (event, label) => {
 const same = (left, right) => canonicalJson(left) === canonicalJson(right)
 const ARTIFACT_POLICIES = new WeakSet()
 
-export function createArtifactPolicy({ posterPubkey, authTag, endpoint } = {}) {
+export function createArtifactPolicy({ posterPubkey, authTag, endpoint, timeoutMs = 15_000, maxResponseBytes = 64 * 1024, nip98MaxAgeSec = 60 } = {}) {
   const poster = hex(posterPubkey, 'posterPubkey')
   if (!Array.isArray(authTag) || authTag.length !== 4 || authTag[0] !== 'auth' || !authTag.every(value => typeof value === 'string')) fail('authTag must be the fixed four-field NIP-OA tag')
   const owner = hex(authTag[1], 'authTag owner'), signature = hex(authTag[3], 'authTag signature', HEX128)
@@ -44,7 +44,11 @@ export function createArtifactPolicy({ posterPubkey, authTag, endpoint } = {}) {
   if (!schnorr.verify(hexToBytes(signature), attestation, hexToBytes(owner))) fail('authTag owner signature is invalid for this poster')
   let url; try { url = new URL(String(endpoint || '')) } catch { fail('endpoint is invalid') }
   if (url.protocol !== 'https:' || url.username || url.password || url.hash || url.search || url.pathname !== '/events') fail('endpoint must be the fixed HTTPS origin /events URL')
-  const policy = Object.freeze({ posterPubkey: poster, authTag: Object.freeze([...authTag]), endpoint: url.toString(), endpointAuthority: url.host })
+  if (!Number.isSafeInteger(timeoutMs) || timeoutMs < 1_000 || timeoutMs > 30_000) fail('timeoutMs is outside the policy bounds')
+  if (!Number.isSafeInteger(maxResponseBytes) || maxResponseBytes < 1_024 || maxResponseBytes > 256 * 1024) fail('maxResponseBytes is outside the policy bounds')
+  if (!Number.isSafeInteger(nip98MaxAgeSec) || nip98MaxAgeSec < 5 || nip98MaxAgeSec > 300) fail('nip98MaxAgeSec is outside the policy bounds')
+  const policy = Object.freeze({ posterPubkey: poster, authTag: Object.freeze([...authTag]), endpoint: url.toString(), endpointAuthority: url.host,
+    timeoutMs, maxResponseBytes, nip98MaxAgeSec })
   ARTIFACT_POLICIES.add(policy)
   return policy
 }
@@ -86,12 +90,77 @@ export function buildNip98Authorization(signedBuzzEvent, policy, { nonce, now = 
 
 export const signExactNip98 = (unsigned, signer) => signExact(unsigned, signer, 'signed NIP-98 event')
 
+const tagValue = (event, name) => {
+  const matches = event.tags.filter(tag => tag[0] === name)
+  if (matches.length !== 1 || matches[0].length !== 2) fail(`signed NIP-98 event has invalid ${name} binding`)
+  return matches[0][1]
+}
+
+async function boundedResponseBody(response, maxBytes) {
+  const declared = Number(response.headers?.get?.('content-length'))
+  if (Number.isFinite(declared) && declared > maxBytes) fail('Buzz response exceeds the policy limit')
+  if (!response.body?.getReader) {
+    const bytes = new Uint8Array(await response.arrayBuffer())
+    if (bytes.byteLength > maxBytes) fail('Buzz response exceeds the policy limit')
+    return bytes
+  }
+  const reader = response.body.getReader(), chunks = []; let size = 0
+  try {
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+      size += value.byteLength
+      if (size > maxBytes) { await reader.cancel(); fail('Buzz response exceeds the policy limit') }
+      chunks.push(value)
+    }
+  } finally { reader.releaseLock() }
+  const bytes = new Uint8Array(size); let offset = 0
+  for (const chunk of chunks) { bytes.set(chunk, offset); offset += chunk.byteLength }
+  return bytes
+}
+
+// The reusable credentials never cross this call boundary. The policy service verifies
+// their exact bindings, submits them itself, and returns only a bounded outcome digest.
+export async function submitBuzzEvent(signedBuzzEvent, signedNip98, policy, {
+  fetchImpl = globalThis.fetch, now = Math.floor(Date.now() / 1000),
+} = {}) {
+  exactWireEvent(signedBuzzEvent, 'signed Buzz event'); exactWireEvent(signedNip98, 'signed NIP-98 event'); artifactPolicy(policy)
+  if (signedBuzzEvent.pubkey !== policy.posterPubkey || signedNip98.pubkey !== policy.posterPubkey || signedNip98.kind !== 27235 || signedNip98.content !== '') fail('signed submission identity is invalid')
+  timestamp(now)
+  if (Math.abs(now - signedNip98.created_at) > policy.nip98MaxAgeSec) fail('signed NIP-98 event is outside the freshness window')
+  const eventAuth = signedBuzzEvent.tags.filter(tag => tag[0] === 'auth')
+  if (eventAuth.length !== 1 || !same(eventAuth[0], policy.authTag)) fail('signed Buzz event does not carry the configured owner attestation')
+  const body = canonicalJson(signedBuzzEvent), payload = createHash('sha256').update(body).digest('hex')
+  if (signedNip98.tags.length !== 4 || tagValue(signedNip98, 'u') !== policy.endpoint ||
+      tagValue(signedNip98, 'method') !== 'POST' || tagValue(signedNip98, 'payload') !== payload ||
+      !/^[A-Za-z0-9_-]{16,128}$/.test(tagValue(signedNip98, 'nonce'))) fail('signed NIP-98 event does not authorize this exact submission')
+  if (typeof fetchImpl !== 'function') fail('HTTPS submitter is unavailable')
+  let response
+  try {
+    response = await fetchImpl(policy.endpoint, { method: 'POST', redirect: 'manual', signal: globalThis.AbortSignal.timeout(policy.timeoutMs),
+      headers: { authorization: `Nostr ${Buffer.from(JSON.stringify(signedNip98)).toString('base64')}`,
+        'content-type': 'application/json', 'x-auth-tag': JSON.stringify(policy.authTag) }, body })
+  } catch (error) { fail(`Buzz submission did not reach an authoritative response: ${error?.name || 'network error'}`) }
+  const bytes = await boundedResponseBody(response, policy.maxResponseBytes)
+  const responseDigest = createHash('sha256').update(bytes).digest('hex')
+  if (response.status === 429 || response.status >= 500 || response.status < 200 || (response.status >= 300 && response.status < 400)) fail(`Buzz submission is retryable (HTTP ${response.status})`)
+  if (response.status >= 400) fail(`Buzz response is not an authoritative exact-event outcome (HTTP ${response.status})`)
+  let parsed
+  try { parsed = JSON.parse(new TextDecoder().decode(bytes)) } catch { fail('Buzz success response is not JSON') }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed) ||
+      Object.keys(parsed).some(key => !['event_id', 'accepted', 'message'].includes(key)) ||
+      parsed.event_id !== signedBuzzEvent.id || typeof parsed.accepted !== 'boolean' || typeof parsed.message !== 'string') fail('Buzz success response has an invalid shape or event binding')
+  return Object.freeze({ result: parsed.accepted ? 'accepted' : 'rejected', reasonCode: parsed.accepted ? 'accepted' : 'relay_refused', responseDigest, status: response.status })
+}
+
 export async function buildSignedReceipt(fields, signer, policy, { now = Math.floor(Date.now() / 1000) } = {}) {
   artifactPolicy(policy)
   const required = ['version', 'policy_instance', 'operation', 'catalogue_version', 'request_digest', 'idempotency_key',
     'source_ids', 'buzz_channel', 'endpoint_authority', 'buzz_event_id', 'result', 'reason_code', 'response_digest', 'completed_at']
   if (!fields || Object.keys(fields).sort().join(',') !== [...required].sort().join(',')) fail('receipt has an invalid shape')
-  if (fields.version !== 1 || fields.operation !== 'quarantine_header' || fields.result !== 'accepted' || fields.reason_code !== 'accepted') fail('receipt outcome is invalid')
+  if (fields.version !== 1 || fields.operation !== 'quarantine_header' || !['accepted', 'rejected'].includes(fields.result) ||
+      !['accepted', 'relay_refused'].includes(fields.reason_code) ||
+      (fields.result === 'accepted') !== (fields.reason_code === 'accepted')) fail('receipt outcome is invalid')
   if (!/^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/.test(String(fields.policy_instance || ''))) fail('policy_instance is invalid')
   for (const name of ['catalogue_version', 'request_digest', 'idempotency_key', 'buzz_event_id', 'response_digest']) hex(fields[name], name)
   if (!Array.isArray(fields.source_ids) || !fields.source_ids.length || !fields.source_ids.every(id => HEX64.test(String(id)))) fail('source_ids are invalid')

--- a/tests/buzz_policy_artifacts.mjs
+++ b/tests/buzz_policy_artifacts.mjs
@@ -4,7 +4,7 @@ import { schnorr } from '@noble/curves/secp256k1'
 import { sha256 } from '@noble/hashes/sha256'
 import { bytesToHex, utf8ToBytes } from '@noble/hashes/utils'
 import { decodePolicyRequest, decideQuarantineHeader, canonicalJson, policyIdempotencyKey } from '../src/buzz_policy_core.mjs'
-import { createArtifactPolicy, buildBuzzEvent, signExactBuzzEvent, buildNip98Authorization, signExactNip98, buildSignedReceipt } from '../src/buzz_policy_artifacts.mjs'
+import { createArtifactPolicy, buildBuzzEvent, signExactBuzzEvent, buildNip98Authorization, signExactNip98, submitBuzzEvent, buildSignedReceipt } from '../src/buzz_policy_artifacts.mjs'
 
 let fails = 0
 const t = (name, ok) => { console.log(`${ok ? 'ok  ' : 'FAIL'} — ${name}`); if (!ok) fails++ }
@@ -37,6 +37,28 @@ const evilPolicy = createArtifactPolicy({ posterPubkey: poster, authTag: ['auth'
 await rejects('a caller cannot swap a different policy object into NIP-98 construction', () => buildNip98Authorization(signed, { ...evilPolicy }, { nonce: 'nonce_0123456789', now }), /internally configured artifact policy/)
 const key = policyIdempotencyKey(request, decision)
 await rejects('a host-fabricated request cannot choose idempotency', () => policyIdempotencyKey({ ...request }, decision), /not bound to this verified request/)
+let submitted
+const acceptedOutcome = await submitBuzzEvent(signed, signedAuth, policy, { now, fetchImpl: async (url, init) => {
+  submitted = { url, init }
+  return new globalThis.Response(JSON.stringify({ event_id: signed.id, accepted: true, message: '' }), { status: 200 })
+} })
+t('the policy service submits exact bytes and keeps authorization inside the call', submitted.url === policy.endpoint && submitted.init.body === canonicalJson(signed) && submitted.init.headers.authorization.startsWith('Nostr ') && submitted.init.headers['x-auth-tag'] === JSON.stringify(policy.authTag) && acceptedOutcome.result === 'accepted')
+await rejects('NIP-98 for another payload cannot be submitted', () => submitBuzzEvent({ ...signed, content: 'changed' }, signedAuth, policy, { now, fetchImpl: async () => new globalThis.Response() }), /signature or id|exact submission/)
+await rejects('a stale but valid NIP-98 event is refused before network I/O', () => submitBuzzEvent(signed, signedAuth, policy, { now: now + 61, fetchImpl: async () => new globalThis.Response() }), /freshness window/)
+await rejects('a redirect is never followed as authority', () => submitBuzzEvent(signed, signedAuth, policy, { now, fetchImpl: async () => new globalThis.Response('', { status: 302 }) }), /retryable/)
+await rejects('a transient relay response stays retryable', () => submitBuzzEvent(signed, signedAuth, policy, { now, fetchImpl: async () => new globalThis.Response('', { status: 503 }) }), /retryable/)
+await rejects('a proxy or WAF 403 cannot mint a terminal refusal', () => submitBuzzEvent(signed, signedAuth, policy, { now, fetchImpl: async () => new globalThis.Response('{"error":"denied"}', { status: 403, headers: { 'content-type': 'application/json' } }) }), /not an authoritative exact-event outcome/)
+const boundedPolicy = createArtifactPolicy({ posterPubkey: poster, authTag: ['auth', owner, conditions, authSig], endpoint: 'https://nave.example/events', maxResponseBytes: 1024 })
+await rejects('an oversized response is refused before interpretation', () => submitBuzzEvent(signed, signedAuth, boundedPolicy, { now, fetchImpl: async () => new globalThis.Response('x'.repeat(1025)) }), /exceeds the policy limit/)
+await rejects('a success response for another event is refused', () => submitBuzzEvent(signed, signedAuth, policy, { now, fetchImpl: async () => new globalThis.Response(JSON.stringify({ event_id: 'f'.repeat(64), accepted: true, message: '' }), { status: 200 }) }), /event binding/)
+const refusedOutcome = await submitBuzzEvent(signed, signedAuth, policy, { now, fetchImpl: async () => new globalThis.Response(JSON.stringify({ event_id: signed.id, accepted: false, message: 'policy refusal' }), { status: 200 }) })
+t('an authoritative accepted:false is a terminal refusal', refusedOutcome.result === 'rejected' && refusedOutcome.reasonCode === 'relay_refused')
+const foreignOwnerSk = generateSecretKey(), foreignOwner = getPublicKey(foreignOwnerSk)
+const foreignSig = bytesToHex(schnorr.sign(sha256(utf8ToBytes(`nostr:agent-auth:${poster}:${conditions}`)), foreignOwnerSk))
+const foreignPolicy = createArtifactPolicy({ posterPubkey: poster, authTag: ['auth', foreignOwner, conditions, foreignSig], endpoint: 'https://nave.example/events' })
+let foreignFetches = 0
+await rejects('a valid foreign owner policy cannot submit this event', () => submitBuzzEvent(signed, signedAuth, foreignPolicy, { now, fetchImpl: async () => { foreignFetches++; return new globalThis.Response() } }), /configured owner attestation/)
+t('owner-policy mismatch is refused before network I/O', foreignFetches === 0)
 const receiptFields = { version: 1, policy_instance: packet.policy_instance, operation: packet.operation, catalogue_version: packet.catalogue_version,
   request_digest: createHash('sha256').update(raw).digest('hex'), idempotency_key: key, source_ids: [source.id], buzz_channel: decision.dest,
   endpoint_authority: 'nave.example', buzz_event_id: signed.id, result: 'accepted', reason_code: 'accepted', response_digest: 'e'.repeat(64), completed_at: now }
@@ -45,6 +67,9 @@ t('the return is a signed canonical receipt, not the signed Buzz event', receipt
 await rejects('a signer cannot substitute the receipt identity', () => buildSignedReceipt(receiptFields, { signEvent: event => finalizeEvent(event, bad) }, policy, { now }), /changed policy-owned/)
 await rejects('receipt fields cannot be widened', () => buildSignedReceipt({ ...receiptFields, authorization: 'reusable' }, sign, policy, { now }), /invalid shape/)
 await rejects('a receipt cannot name a caller-selected endpoint', () => buildSignedReceipt({ ...receiptFields, endpoint_authority: 'evil.example' }, sign, policy, { now }), /endpoint_authority is not policy-owned/)
+const rejectedFields = { ...receiptFields, result: refusedOutcome.result, reason_code: refusedOutcome.reasonCode, response_digest: refusedOutcome.responseDigest }
+const rejectedReceipt = await buildSignedReceipt(rejectedFields, sign, policy, { now })
+t('an authoritative refusal becomes a signed terminal receipt', JSON.parse(rejectedReceipt.content).reason_code === 'relay_refused')
 
 console.log(fails ? `\nbuzz_policy_artifacts: ${fails} FAILED` : '\nbuzz_policy_artifacts: all checks passed')
 process.exit(fails ? 1 : 0)


### PR DESCRIPTION
## What

Replaces #254 with a policy-owned direct Buzz submitter for the off-box writer.

- accepts only branded artifact policy objects created from a verified NIP-OA owner attestation
- fixes the HTTPS `/events` endpoint, poster identity, exact auth tag, timeout, response cap, and NIP-98 freshness policy
- verifies the signed kind:9 and signed NIP-98 events, including exact URL/method/payload/nonce bindings, before network I/O
- sends canonical event bytes itself with redirects disabled
- bounds and hashes the authoritative response, distinguishes retryable transport outcomes from terminal refusal, and supports signed accepted/refused receipts
- refuses a valid but foreign owner policy before any fetch

## Why this supersedes #254

#254 trusted a caller-selected endpoint and only checked for an auth tag by name. This version fixes both at the artifact-policy boundary and uses a real cryptographically valid NIP-OA fixture.

## Verification

- `npm run lint`
- all 40 test suites
- negative controls for payload substitution, stale NIP-98, redirect, 5xx, oversized response, response/event mismatch, and foreign owner policy

Review is being requested privately in the Buzz `waggle-test` channel.
