### PR TITLE
fix: expose safe policy orphan resolution

### DIFF
--- a/docs/DESIGN_OFFBOX_BUZZ_POLICY.md
+++ b/docs/DESIGN_OFFBOX_BUZZ_POLICY.md
@@ -191,6 +191,12 @@ The durable policy journal claims this key before signing. Concurrent and restar
 either receive the same terminal receipt or the current in-flight status; they never author a
 second Buzz event.
 
+The signer-returned/preparation-not-yet-durable crash interval is operator-resolved, never
+automatically reclaimed. The policy host binds the exact original canonical request and
+`claimed_at` under a separate private recovery secret, then signs an `ambiguous` receipt with no
+Buzz event id. The bridge cannot invoke this transition. See
+[OFFBOX_POLICY_RUNBOOK.md](OFFBOX_POLICY_RUNBOOK.md#resolving-a-pre-prepare-orphan).
+
 A terminal receipt is a signed, canonical record binding:
 
 - request digest and idempotency key;

--- a/docs/OFFBOX_POLICY_RUNBOOK.md
+++ b/docs/OFFBOX_POLICY_RUNBOOK.md
@@ -1,0 +1,74 @@
+# Off-box policy service operator runbook
+
+This is the policy-host side of the remote Buzz writer. It does **not** belong on the
+Waggle bridge host. The bridge receives a forced-command SSH key that can invoke only
+`tools/buzz-policy-service.mjs`; the policy host alone holds the Bunker pairing, private
+policy configuration, journal, and recovery secret.
+
+The service is not yet a replacement for every Buzz write family. Follow the migration
+gates in [DESIGN_OFFBOX_BUZZ_POLICY.md](DESIGN_OFFBOX_BUZZ_POLICY.md#10--migration-gates)
+before removing the bridge's existing local poster path.
+
+## Private files
+
+Create both files as the dedicated policy-service Unix user, outside the checkout. They
+must be real regular files, owned privately, and mode `0600`; their parent directory and
+the journal directory must not be writable by the bridge account.
+
+`policy.json` has exactly this shape:
+
+```json
+{
+  "version": 1,
+  "policy_instance": "jaf-hive",
+  "catalogue_version": "<64-hex reviewed catalogue digest>",
+  "staging_channel": "<fixed Buzz channel UUID>",
+  "watched_event_ids": ["<64-hex Nostr event id>"],
+  "approver_mention": "James",
+  "poster_pubkey": "<64-hex Buzz poster pubkey>",
+  "auth_tag": ["auth", "<owner pubkey>", "<NIP-OA conditions>", "<owner signature>"],
+  "endpoint": "https://<fixed Buzz host>/events",
+  "journal_path": "/var/lib/waggle-policy/journal",
+  "recovery_secret_file": "/etc/waggle-policy/recovery.secret"
+}
+```
+
+`recovery.secret` contains one 32–128 character URL-safe random value. It is never an
+argument, environment value, receipt field, log field, bridge credential, or Bunker
+credential. The ordinary request path loads it only so the same journal can enforce the
+operator-only orphan transition; untrusted requests cannot select that transition.
+
+Set `WAGGLE_POLICY_CONFIG_FILE` to the absolute `policy.json` path in the policy-host
+service environment. Configure `src/nostr_signer.mjs` there with the policy service's
+NIP-46/Bunker pairing, and verify its reported pubkey equals `poster_pubkey`.
+
+## Forced command
+
+The bridge's SSH public key must be restricted server-side to the zero-argument runner.
+Disable shell, PTY, forwarding, agent forwarding, X11, and user-selected commands. The
+runner accepts one bounded canonical JSON request on stdin and emits only canonical
+status plus a signed receipt. It never returns a signed Buzz event, NIP-98 authorization,
+auth tag, recovery secret, or Bunker credential.
+
+Exercise the negative control before enabling the key: adding any argument must exit 2
+with `arguments are not accepted`.
+
+## Resolving a pre-prepare orphan
+
+Do this only after proving the old policy worker is dead. Inspect the journal record and
+record its exact `claimed_at`, then provide the **same canonical request bytes** locally:
+
+```sh
+WAGGLE_POLICY_CONFIG_FILE=/etc/waggle-policy/policy.json \
+  node tools/buzz-policy-resolve-orphan.mjs --claimed-at 1234567890 \
+  < canonical-request.json
+```
+
+This command is deliberately not the SSH forced command. It requires the private recovery
+file, exact request digest, policy-derived idempotency key, and exact observed `claimed_at`.
+It signs and commits only an `ambiguous` receipt with no Buzz event id. It cannot claim
+that Buzz accepted or refused a post, and a prepared event is recoverable instead of
+eligible for orphan resolution.
+
+Archive the signed receipt and retain the original request alongside the journal backup.
+Never delete or manually rewrite an in-flight, prepared, or terminal journal record.

--- a/src/buzz_policy_artifacts.mjs
+++ b/src/buzz_policy_artifacts.mjs
@@ -157,17 +157,19 @@ export async function submitBuzzEvent(signedBuzzEvent, signedNip98, policy, {
     throw submitFailure(`Buzz submission did not reach an authoritative response: ${error?.name || 'network error'}`,
       'ambiguous', createHash('sha256').update(String(error?.name || 'network-error')).digest('hex'))
   }
-  const bytes = await boundedResponseBody(response, policy.maxResponseBytes)
+  let bytes
+  try { bytes = await boundedResponseBody(response, policy.maxResponseBytes) }
+  catch (error) { throw submitFailure(String(error?.message || 'Buzz response could not be bounded'), 'ambiguous') }
   const responseDigest = createHash('sha256').update(bytes).digest('hex')
   if (response.status === 429 || response.status >= 500 || response.status < 200 || (response.status >= 300 && response.status < 400)) {
     throw submitFailure(`Buzz submission is retryable (HTTP ${response.status})`, 'held', responseDigest)
   }
-  if (response.status >= 400) fail(`Buzz response is not an authoritative exact-event outcome (HTTP ${response.status})`)
+  if (response.status >= 400) throw submitFailure(`Buzz response is not an authoritative exact-event outcome (HTTP ${response.status})`, 'ambiguous', responseDigest)
   let parsed
-  try { parsed = JSON.parse(new TextDecoder().decode(bytes)) } catch { fail('Buzz success response is not JSON') }
+  try { parsed = JSON.parse(new TextDecoder().decode(bytes)) } catch { throw submitFailure('Buzz success response is not JSON', 'ambiguous', responseDigest) }
   if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed) ||
       Object.keys(parsed).some(key => !['event_id', 'accepted', 'message'].includes(key)) ||
-      parsed.event_id !== signedBuzzEvent.id || typeof parsed.accepted !== 'boolean' || typeof parsed.message !== 'string') fail('Buzz success response has an invalid shape or event binding')
+      parsed.event_id !== signedBuzzEvent.id || typeof parsed.accepted !== 'boolean' || typeof parsed.message !== 'string') throw submitFailure('Buzz success response has an invalid shape or event binding', 'ambiguous', responseDigest)
   return Object.freeze({ result: parsed.accepted ? 'accepted' : 'rejected', reasonCode: parsed.accepted ? 'accepted' : 'relay_refused', responseDigest, status: response.status })
 }
 
@@ -176,11 +178,13 @@ export async function buildSignedReceipt(fields, signer, policy, { now = Math.fl
   const required = ['version', 'policy_instance', 'operation', 'catalogue_version', 'request_digest', 'idempotency_key',
     'source_ids', 'buzz_channel', 'endpoint_authority', 'buzz_event_id', 'result', 'reason_code', 'response_digest', 'completed_at']
   if (!fields || Object.keys(fields).sort().join(',') !== [...required].sort().join(',')) fail('receipt has an invalid shape')
-  if (fields.version !== 1 || fields.operation !== 'quarantine_header' || !['accepted', 'rejected'].includes(fields.result) ||
-      !['accepted', 'relay_refused'].includes(fields.reason_code) ||
-      (fields.result === 'accepted') !== (fields.reason_code === 'accepted')) fail('receipt outcome is invalid')
+  const outcomes = Object.freeze({ accepted: 'accepted', rejected: 'relay_refused', ambiguous: 'signing_outcome_unknown' })
+  if (fields.version !== 1 || fields.operation !== 'quarantine_header' || outcomes[fields.result] !== fields.reason_code) fail('receipt outcome is invalid')
   if (!/^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/.test(String(fields.policy_instance || ''))) fail('policy_instance is invalid')
-  for (const name of ['catalogue_version', 'request_digest', 'idempotency_key', 'buzz_event_id', 'response_digest']) hex(fields[name], name)
+  for (const name of ['catalogue_version', 'request_digest', 'idempotency_key', 'response_digest']) hex(fields[name], name)
+  if (fields.result === 'ambiguous') {
+    if (fields.buzz_event_id !== null) fail('an ambiguous receipt cannot claim a Buzz event id')
+  } else hex(fields.buzz_event_id, 'buzz_event_id')
   if (!Array.isArray(fields.source_ids) || !fields.source_ids.length || !fields.source_ids.every(id => HEX64.test(String(id)))) fail('source_ids are invalid')
   if (!UUID.test(String(fields.buzz_channel || ''))) fail('buzz_channel is invalid')
   if (fields.endpoint_authority !== policy.endpointAuthority) fail('endpoint_authority is not policy-owned')

--- a/src/buzz_policy_runner.mjs
+++ b/src/buzz_policy_runner.mjs
@@ -6,7 +6,7 @@ import { TextDecoder } from 'node:util'
 import { createArtifactPolicy } from './buzz_policy_artifacts.mjs'
 import { canonicalJson } from './buzz_policy_core.mjs'
 import { PolicyJournal } from './policy_journal.mjs'
-import { processBuzzPolicyRequest } from './buzz_policy_service.mjs'
+import { processBuzzPolicyRequest, resolveBuzzPolicyOrphan } from './buzz_policy_service.mjs'
 
 const HEX64 = /^[0-9a-f]{64}$/, UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
 const fail = message => { throw new Error(`buzz-policy-runner: ${message}`) }
@@ -14,12 +14,12 @@ const exactKeys = (value, keys) => {
   if (!value || typeof value !== 'object' || Array.isArray(value) || Object.keys(value).sort().join(',') !== [...keys].sort().join(',')) fail('config has an invalid shape')
 }
 
-function privateText(path) {
+function privateText(path, maxBytes = 64 * 1024) {
   let fd
   try { fd = openSync(path, constants.O_RDONLY | constants.O_NOFOLLOW) } catch { fail('config cannot be read as a regular non-symlink file') }
   try {
     const st = fstatSync(fd)
-    if (!st.isFile() || (st.mode & 0o077) || st.size < 2 || st.size > 64 * 1024) fail('config must be a private regular file of at most 65536 bytes')
+    if (!st.isFile() || (st.mode & 0o077) || st.size < 2 || st.size > maxBytes) fail('private input must be a bounded private regular file')
     return readFileSync(fd)
   } finally { closeSync(fd) }
 }
@@ -31,14 +31,16 @@ export function loadBuzzPolicyConfig(path) {
     fail('config is not valid UTF-8 JSON')
   }
   exactKeys(config, ['version', 'policy_instance', 'catalogue_version', 'staging_channel', 'watched_event_ids',
-    'approver_mention', 'poster_pubkey', 'auth_tag', 'endpoint', 'journal_path'])
+    'approver_mention', 'poster_pubkey', 'auth_tag', 'endpoint', 'journal_path', 'recovery_secret_file'])
   if (config.version !== 1 || !/^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/.test(config.policy_instance)) fail('config version or policy_instance is invalid')
   if (!HEX64.test(config.catalogue_version) || !UUID.test(config.staging_channel)) fail('config catalogue or channel is invalid')
   if (!Array.isArray(config.watched_event_ids) || !config.watched_event_ids.every(id => HEX64.test(id)) || new Set(config.watched_event_ids).size !== config.watched_event_ids.length) fail('watched_event_ids are invalid')
   if (typeof config.approver_mention !== 'string' || Buffer.byteLength(config.approver_mention) > 128) fail('approver_mention is invalid')
-  if (!isAbsolute(config.journal_path)) fail('journal_path must be absolute')
+  if (!isAbsolute(config.journal_path) || !isAbsolute(config.recovery_secret_file)) fail('journal and recovery-secret paths must be absolute')
+  const recoverySecret = new TextDecoder('utf-8', { fatal: true }).decode(privateText(config.recovery_secret_file, 256)).trim()
+  if (!/^[A-Za-z0-9_-]{32,128}$/.test(recoverySecret)) fail('recovery secret is invalid')
   const artifactPolicy = createArtifactPolicy({ posterPubkey: config.poster_pubkey, authTag: config.auth_tag, endpoint: config.endpoint })
-  return Object.freeze({ ...config, watched_event_ids: Object.freeze([...config.watched_event_ids]), artifactPolicy })
+  return Object.freeze({ ...config, watched_event_ids: Object.freeze([...config.watched_event_ids]), artifactPolicy, recoverySecret })
 }
 
 export async function readBoundedPolicyRequest(stream, maxBytes = 128 * 1024) {
@@ -56,11 +58,22 @@ export async function readBoundedPolicyRequest(stream, maxBytes = 128 * 1024) {
 export async function runBuzzPolicyRequest(raw, config, signer, deps = {}) {
   if (!config?.artifactPolicy) fail('verified config is required')
   if (!signer || signer.pubkey !== config.poster_pubkey) fail('Bunker signer identity does not match poster_pubkey')
-  const journal = deps.journal || new PolicyJournal(config.journal_path)
+  const journal = deps.journal || new PolicyJournal(config.journal_path, { recoverySecret: config.recoverySecret })
   const result = await processBuzzPolicyRequest(raw, { policyInstance: config.policy_instance,
     catalogueVersion: config.catalogue_version, stagingChannel: config.staging_channel,
     watchedEventIds: config.watched_event_ids, approverMention: config.approver_mention,
     artifactPolicy: config.artifactPolicy, journal, signer, fetchImpl: deps.fetchImpl,
-    now: deps.now, nonce: deps.nonce, timeoutMs: deps.timeoutMs })
+    now: deps.now, nonce: deps.nonce })
+  return `${canonicalJson(result)}\n`
+}
+
+export async function runBuzzPolicyOrphanResolution(raw, expectedClaimedAt, config, signer, deps = {}) {
+  if (!config?.artifactPolicy || !config.recoverySecret) fail('verified recovery config is required')
+  if (!signer || signer.pubkey !== config.poster_pubkey) fail('Bunker signer identity does not match poster_pubkey')
+  const journal = deps.journal || new PolicyJournal(config.journal_path, { recoverySecret: config.recoverySecret })
+  const result = await resolveBuzzPolicyOrphan(raw, expectedClaimedAt, { policyInstance: config.policy_instance,
+    catalogueVersion: config.catalogue_version, stagingChannel: config.staging_channel,
+    watchedEventIds: config.watched_event_ids, approverMention: config.approver_mention,
+    artifactPolicy: config.artifactPolicy, journal, signer, recoverySecret: config.recoverySecret, now: deps.now })
   return `${canonicalJson(result)}\n`
 }

--- a/src/buzz_policy_service.mjs
+++ b/src/buzz_policy_service.mjs
@@ -21,6 +21,13 @@ function replay(record) {
   return frozen({ status: record.status === 'prepared' ? 'recoverable' : 'held', result: null, receipt: null })
 }
 
+function derive(raw, { policyInstance, catalogueVersion, stagingChannel, watchedEventIds, approverMention = '', now }) {
+  const request = decodePolicyRequest(raw, { policyInstance, catalogueVersion, now })
+  const decision = decideQuarantineHeader(request, { stagingChannel, watchedEventIds, approverMention })
+  const requestDigest = createHash('sha256').update(raw).digest('hex')
+  return { request, decision, requestDigest, key: policyIdempotencyKey(request, decision) }
+}
+
 export async function processBuzzPolicyRequest(raw, {
   policyInstance, catalogueVersion, stagingChannel, watchedEventIds, approverMention = '',
   artifactPolicy, journal, signer, fetchImpl = fetch, now = Math.floor(Date.now() / 1000),
@@ -28,10 +35,7 @@ export async function processBuzzPolicyRequest(raw, {
 } = {}) {
   if (!journal || typeof journal.claim !== 'function' || typeof journal.prepare !== 'function' || typeof journal.commit !== 'function') fail('journal is unavailable')
   if (!signer || typeof signer.signEvent !== 'function') fail('signer is unavailable')
-  const request = decodePolicyRequest(raw, { policyInstance, catalogueVersion, now })
-  const decision = decideQuarantineHeader(request, { stagingChannel, watchedEventIds, approverMention })
-  const requestDigest = createHash('sha256').update(raw).digest('hex')
-  const key = policyIdempotencyKey(request, decision)
+  const { request, decision, requestDigest, key } = derive(raw, { policyInstance, catalogueVersion, stagingChannel, watchedEventIds, approverMention, now })
   const claim = journal.claim(key, requestDigest, now)
   if (!claim.claimed && claim.record.status !== 'prepared') return replay(claim.record)
 
@@ -41,7 +45,7 @@ export async function processBuzzPolicyRequest(raw, {
     const unsigned = buildBuzzEvent(decision, artifactPolicy, { now })
     event = await signExactBuzzEvent(unsigned, signer)
     const eventText = canonicalJson(event)
-    const durable = journal.prepare(key, requestDigest, { buzzEvent: eventText, buzzEventId: event.id, preparedAt: now })
+    const durable = journal.prepare(key, requestDigest, { buzzEvent: eventText, preparedAt: now })
     event = preparedEvent(durable, decision, artifactPolicy)
   }
 
@@ -49,7 +53,10 @@ export async function processBuzzPolicyRequest(raw, {
   const signedAuthorization = await signExactNip98(authorization.event, signer)
   let outcome
   try { outcome = await submitBuzzEvent(event, signedAuthorization, artifactPolicy, { fetchImpl, now }) }
-  catch (error) { return frozen({ status: error?.outcome === 'held' ? 'held' : 'ambiguous', result: null, receipt: null }) }
+  catch (error) {
+    if (error?.outcome === 'held' || error?.outcome === 'ambiguous') return frozen({ status: error.outcome, result: null, receipt: null })
+    throw error
+  }
 
   const accepted = outcome.result === 'accepted'
   const receiptFields = {
@@ -63,4 +70,32 @@ export async function processBuzzPolicyRequest(raw, {
   const terminal = journal.commit(key, requestDigest, { receipt: canonicalJson(receiptEvent),
     buzzEventId: event.id, result: accepted ? 'accepted' : 'refused', completedAt: now })
   return frozen({ status: 'terminal', result: terminal.result === 'refused' ? 'rejected' : terminal.result, receipt: terminal.receipt })
+}
+
+// Local policy-host operator path for the only unrecoverable interval: the signer
+// returned but the exact event was not yet durably prepared. The forced-command
+// request runner never calls this. Exact request bytes + claimed_at + the private
+// recovery secret are all required, and the receipt states only "ambiguous".
+export async function resolveBuzzPolicyOrphan(raw, expectedClaimedAt, {
+  policyInstance, catalogueVersion, stagingChannel, watchedEventIds, approverMention = '',
+  artifactPolicy, journal, signer, recoverySecret, now = Math.floor(Date.now() / 1000),
+} = {}) {
+  if (!journal || typeof journal.get !== 'function' || typeof journal.resolveOrphan !== 'function') fail('recovery journal is unavailable')
+  if (!signer || typeof signer.signEvent !== 'function') fail('signer is unavailable')
+  if (!Number.isSafeInteger(expectedClaimedAt) || expectedClaimedAt < 0) fail('expectedClaimedAt is invalid')
+  const { request, decision, requestDigest, key } = derive(raw, { policyInstance, catalogueVersion, stagingChannel, watchedEventIds, approverMention, now: expectedClaimedAt })
+  const record = journal.get(key)
+  if (!record || record.status !== 'in-flight' || record.claimed_at !== expectedClaimedAt) fail('the exact inspected in-flight claim is no longer present')
+  const fields = {
+    version: 1, policy_instance: policyInstance, operation: request.operation, catalogue_version: catalogueVersion,
+    request_digest: requestDigest, idempotency_key: key, source_ids: [request.evidence.source_event.id],
+    buzz_channel: decision.dest, endpoint_authority: artifactPolicy.endpointAuthority,
+    buzz_event_id: null, result: 'ambiguous', reason_code: 'signing_outcome_unknown',
+    response_digest: createHash('sha256').update('no-submission-evidence').digest('hex'), completed_at: now,
+  }
+  const receiptEvent = await buildSignedReceipt(fields, signer, artifactPolicy, { now })
+  const terminal = journal.resolveOrphan(key, requestDigest, expectedClaimedAt, {
+    recoverySecret, receipt: canonicalJson(receiptEvent), completedAt: now,
+  })
+  return frozen({ status: 'terminal', result: terminal.result, receipt: terminal.receipt })
 }

--- a/tests/buzz_policy_runner.mjs
+++ b/tests/buzz_policy_runner.mjs
@@ -5,8 +5,11 @@ import { generateSecretKey, finalizeEvent, getPublicKey } from 'nostr-tools/pure
 import { schnorr } from '@noble/curves/secp256k1'
 import { sha256 } from '@noble/hashes/sha256'
 import { bytesToHex, utf8ToBytes } from '@noble/hashes/utils'
+import { spawnSync } from 'node:child_process'
+import { createHash } from 'node:crypto'
 import { canonicalJson } from '../src/buzz_policy_core.mjs'
-import { loadBuzzPolicyConfig, readBoundedPolicyRequest, runBuzzPolicyRequest } from '../src/buzz_policy_runner.mjs'
+import { PolicyJournal } from '../src/policy_journal.mjs'
+import { loadBuzzPolicyConfig, readBoundedPolicyRequest, runBuzzPolicyOrphanResolution, runBuzzPolicyRequest } from '../src/buzz_policy_runner.mjs'
 
 let fails = 0
 const t = (name, ok) => { console.log(`${ok ? 'ok  ' : 'FAIL'} — ${name}`); if (!ok) fails++ }
@@ -14,13 +17,17 @@ const rejects = async (name, fn, pattern) => { try { await fn(); t(name, false) 
 const root = mkdtempSync(join(tmpdir(), 'waggle-policy-runner-')), now = 2_000_000_000
 const posterSk = generateSecretKey(), poster = getPublicKey(posterSk), ownerSk = generateSecretKey(), owner = getPublicKey(ownerSk)
 const signature = bytesToHex(schnorr.sign(sha256(utf8ToBytes(`nostr:agent-auth:${poster}:`)), ownerSk))
+const recoveryPath = join(root, 'recovery.secret')
+writeFileSync(recoveryPath, 'recovery_secret_0123456789abcdef\n', { mode: 0o600 })
 const configValue = { version: 1, policy_instance: 'jaf-hive', catalogue_version: 'c'.repeat(64),
   staging_channel: 'a8186b53-537d-46ad-a7e7-b6486c58970e', watched_event_ids: ['d'.repeat(64)], approver_mention: '',
-  poster_pubkey: poster, auth_tag: ['auth', owner, '', signature], endpoint: 'https://hive.example/events', journal_path: join(root, 'journal') }
+  poster_pubkey: poster, auth_tag: ['auth', owner, '', signature], endpoint: 'https://hive.example/events',
+  journal_path: join(root, 'journal'), recovery_secret_file: recoveryPath }
 const configPath = join(root, 'policy.json')
 writeFileSync(configPath, `${JSON.stringify(configValue)}\n`, { mode: 0o600 })
 const config = loadBuzzPolicyConfig(configPath)
 t('a mode-0600 fixed config creates an internal artifact policy', config.policy_instance === 'jaf-hive' && config.artifactPolicy.posterPubkey === poster)
+t('the policy-host recovery secret is loaded only from its private file', config.recoverySecret === 'recovery_secret_0123456789abcdef')
 
 const source = JSON.parse(JSON.stringify(finalizeEvent({ kind: 1, created_at: now - 1, tags: [['e', 'd'.repeat(64)]], content: 'wisdom' }, generateSecretKey())))
 const raw = canonicalJson({ version: 1, policy_instance: 'jaf-hive', operation: 'quarantine_header', catalogue_version: 'c'.repeat(64), observed_at: now, evidence: { source_event: source } })
@@ -32,13 +39,25 @@ const output = await runBuzzPolicyRequest(raw, config, signer, { now, nonce: () 
   } } })
 const result = JSON.parse(output)
 t('the forced-command adapter emits one canonical receipt result', output === `${canonicalJson(result)}\n` && result.status === 'terminal' && JSON.parse(result.receipt).kind === 30078)
+t('the forced-command result never exposes the recovery secret', !output.includes(config.recoverySecret))
 await rejects('the configured poster cannot differ from the Bunker identity', () => runBuzzPolicyRequest(raw, config, { ...signer, pubkey: 'f'.repeat(64) }), /does not match/)
+
+const orphanSource = JSON.parse(JSON.stringify(finalizeEvent({ kind: 1, created_at: now - 2, tags: [['e', 'd'.repeat(64)]], content: 'other wisdom' }, generateSecretKey())))
+const orphanRaw = canonicalJson({ version: 1, policy_instance: 'jaf-hive', operation: 'quarantine_header', catalogue_version: 'c'.repeat(64), observed_at: now, evidence: { source_event: orphanSource } })
+const orphanKey = createHash('sha256').update(canonicalJson([1, 'jaf-hive', 'c'.repeat(64), 'quarantine_header', [orphanSource.id], config.staging_channel])).digest('hex')
+const orphanJournal = new PolicyJournal(join(root, 'orphan-journal'), { recoverySecret: config.recoverySecret })
+orphanJournal.claim(orphanKey, createHash('sha256').update(orphanRaw).digest('hex'), now)
+const orphanOutput = await runBuzzPolicyOrphanResolution(orphanRaw, now, config, signer, { journal: orphanJournal, now: now + 3600 })
+const orphanResult = JSON.parse(orphanOutput)
+t('the local operator adapter emits only a signed ambiguous receipt', orphanResult.result === 'ambiguous' && JSON.parse(orphanResult.receipt).kind === 30078 && !orphanOutput.includes(config.recoverySecret))
 
 const world = join(root, 'world.json'); writeFileSync(world, '{}\n', { mode: 0o600 }); chmodSync(world, 0o644)
 await rejects('group/world-readable config is refused', () => loadBuzzPolicyConfig(world), /private regular file/)
 const link = join(root, 'link.json'); symlinkSync(configPath, link)
 await rejects('a symlinked config is refused', () => loadBuzzPolicyConfig(link), /non-symlink/)
 await rejects('unknown config fields are refused', () => { const p = join(root, 'wide.json'); writeFileSync(p, JSON.stringify({ ...configValue, command: 'anything' }), { mode: 0o600 }); return loadBuzzPolicyConfig(p) }, /invalid shape/)
+const openSecret = join(root, 'open.secret'); writeFileSync(openSecret, 'recovery_secret_0123456789abcdef\n', { mode: 0o644 })
+await rejects('a world-readable recovery secret is refused', () => { const p = join(root, 'open-secret.json'); writeFileSync(p, JSON.stringify({ ...configValue, recovery_secret_file: openSecret }), { mode: 0o600 }); return loadBuzzPolicyConfig(p) }, /bounded private regular file/)
 
 const stream = async function * () { yield Buffer.from(raw.slice(0, 20)); yield Buffer.from(raw.slice(20)) }
 t('bounded stdin preserves exact canonical bytes', await readBoundedPolicyRequest(stream()) === raw)
@@ -46,6 +65,8 @@ const tooLarge = async function * () { yield Buffer.alloc(128 * 1024); yield Buf
 await rejects('stdin is refused immediately above the hard cap', () => readBoundedPolicyRequest(tooLarge()), /exceeds/)
 const invalidUtf8 = async function * () { yield Buffer.from([0xc3, 0x28]) }
 await rejects('invalid UTF-8 cannot cross the canonical boundary', () => readBoundedPolicyRequest(invalidUtf8()), /UTF-8/)
+const widened = spawnSync(process.execPath, ['tools/buzz-policy-service.mjs', '--endpoint', 'https://evil.example/events'], { cwd: process.cwd(), encoding: 'utf8' })
+t('the forced command rejects every caller-selected argument before configuration', widened.status === 2 && /arguments are not accepted/.test(widened.stderr))
 
 rmSync(root, { recursive: true, force: true })
 console.log(fails ? `\nbuzz_policy_runner: ${fails} FAILED` : '\nbuzz_policy_runner: all checks passed')

--- a/tests/buzz_policy_service.mjs
+++ b/tests/buzz_policy_service.mjs
@@ -9,7 +9,7 @@ import { bytesToHex, utf8ToBytes } from '@noble/hashes/utils'
 import { canonicalJson } from '../src/buzz_policy_core.mjs'
 import { createArtifactPolicy } from '../src/buzz_policy_artifacts.mjs'
 import { PolicyJournal } from '../src/policy_journal.mjs'
-import { processBuzzPolicyRequest } from '../src/buzz_policy_service.mjs'
+import { processBuzzPolicyRequest, resolveBuzzPolicyOrphan } from '../src/buzz_policy_service.mjs'
 
 let fails = 0
 const t = (name, ok) => { console.log(`${ok ? 'ok  ' : 'FAIL'} — ${name}`); if (!ok) fails++ }
@@ -37,6 +37,19 @@ const makeSigner = () => {
 const options = (journal, signer, extra = {}) => ({ policyInstance, catalogueVersion, stagingChannel: channel,
   watchedEventIds: [watchedId], artifactPolicy, journal, signer, now, nonce: () => 'nonce_0123456789', ...extra })
 
+{
+  const path = directory(), recoverySecret = 'recovery_secret_0123456789abcdef'
+  const journal = new PolicyJournal(path, { recoverySecret }), { signer } = makeSigner()
+  const key = createHash('sha256').update(canonicalJson([1, policyInstance, catalogueVersion, 'quarantine_header', [source.id], channel])).digest('hex')
+  const requestDigest = createHash('sha256').update(raw).digest('hex')
+  journal.claim(key, requestDigest, now)
+  await rejects('orphan resolution is bound to the exact inspected claimed_at', () => resolveBuzzPolicyOrphan(raw, now - 1,
+    { ...options(journal, signer), recoverySecret }), /no longer present/)
+  const resolved = await resolveBuzzPolicyOrphan(raw, now, { ...options(journal, signer), recoverySecret, now: now + 3600 })
+  const fields = JSON.parse(JSON.parse(resolved.receipt).content)
+  t('a pre-prepare orphan becomes only a signed ambiguous terminal receipt', resolved.result === 'ambiguous' && fields.result === 'ambiguous' && fields.buzz_event_id === null && fields.reason_code === 'signing_outcome_unknown')
+  t('operator recovery remains possible after the request freshness window', fields.completed_at === now + 3600)
+}
 {
   const journal = new PolicyJournal(directory()), { signer, signed } = makeSigner(); let calls = 0
   const first = await processBuzzPolicyRequest(raw, options(journal, signer, { fetchImpl: async (_url, request) => {
@@ -85,6 +98,13 @@ const options = (journal, signer, extra = {}) => ({ policyInstance, catalogueVer
 {
   const journal = new PolicyJournal(directory()), badSigner = { signEvent: event => finalizeEvent(event, generateSecretKey()) }
   await rejects('a substituted signing identity cannot create a durable prepared event', () => processBuzzPolicyRequest(raw, options(journal, badSigner, { fetchImpl: async () => response(500, {}) })), /changed policy-owned/)
+}
+
+{
+  const journal = new PolicyJournal(directory()), { signer } = makeSigner()
+  const invalidFetch = async () => { throw new Error('must not fetch') }
+  await rejects('an internal submit-validation failure is not disguised as network ambiguity', () => processBuzzPolicyRequest(raw,
+    { ...options(journal, signer, { fetchImpl: invalidFetch }), artifactPolicy: { ...artifactPolicy } }), /internally configured artifact policy/)
 }
 
 for (const path of dirs) rmSync(path, { recursive: true, force: true })

--- a/tools/buzz-policy-resolve-orphan.mjs
+++ b/tools/buzz-policy-resolve-orphan.mjs
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+// Policy-host operator command, deliberately separate from the sshd forced command.
+// It burns an exact inspected pre-prepare orphan as signed `ambiguous`; it can never
+// claim that Buzz accepted or refused an event.
+import { loadNostrSigner } from '../src/nostr_signer.mjs'
+import { loadBuzzPolicyConfig, readBoundedPolicyRequest, runBuzzPolicyOrphanResolution } from '../src/buzz_policy_runner.mjs'
+
+let signer
+try {
+  if (process.argv.length !== 4 || process.argv[2] !== '--claimed-at') throw new Error('usage: buzz-policy-resolve-orphan --claimed-at <exact unix seconds> < canonical-request.json')
+  const claimedAt = Number(process.argv[3])
+  if (!Number.isSafeInteger(claimedAt) || claimedAt < 0) throw new Error('--claimed-at must be exact non-negative unix seconds')
+  const configPath = String(process.env.WAGGLE_POLICY_CONFIG_FILE || '')
+  if (!configPath) throw new Error('WAGGLE_POLICY_CONFIG_FILE is required')
+  const config = loadBuzzPolicyConfig(configPath)
+  signer = loadNostrSigner()
+  const raw = await readBoundedPolicyRequest(process.stdin)
+  process.stdout.write(await runBuzzPolicyOrphanResolution(raw, claimedAt, config, signer))
+} catch (error) {
+  process.stderr.write(`${String(error?.message || 'buzz-policy orphan resolution refused').slice(0, 512)}\n`)
+  process.exitCode = 2
+} finally { try { signer?.close() } catch {} }


### PR DESCRIPTION
## What

Closes the remaining signer-returned → durable-prepare crash boundary in the merged off-box policy service.

- loads a separate mode-0600 policy-host recovery secret file; it is never an argument, request field, receipt field, log field, or bridge credential
- adds a local-only operator resolver, deliberately separate from the SSH forced command
- binds recovery to the same canonical request, policy-derived key, request digest, and exact inspected `claimed_at`
- revalidates request freshness at the original claim time, so a legitimate old orphan can still be burned
- signs and commits only `ambiguous` with no Buzz event id; prepared events remain recoverable and cannot take this path
- lets the transaction wrapper catch only explicitly classified submission outcomes; internal validation failures are no longer disguised as network ambiguity
- classifies bounded generic 4xx/malformed/oversized success responses as non-terminal ambiguity while preserving exact-event refusal IDs
- documents private files, forced-command restrictions, and the operator procedure

## Verification

- `npm run lint`
- all 42 suites
- exact-`claimed_at`, delayed-recovery, private-file, no-secret-output, zero-argv, generic-4xx, and internal-validation negative controls

Review is requested privately in Buzz `waggle-test` only.
