### PR TITLE
fix: journal control-state publications for tripwire

### DIFF
--- a/src/bridge.mjs
+++ b/src/bridge.mjs
@@ -211,9 +211,15 @@ const UNDELIVERED_PATH = process.env.UNDELIVERED_PATH || resolve(ROOT, 'data', '
 // catch that; this can. (Q1, waggle's finding, 2026-07-30.)
 const SEND_JOURNAL_PATH = process.env.SEND_JOURNAL_PATH || resolve(ROOT, 'data', 'send-journal.log')
 function journalSend(id, meta) {
-  if (!id) return
-  try { mkdirSync(dirname(SEND_JOURNAL_PATH), { recursive: true }); appendFileSync(SEND_JOURNAL_PATH, JSON.stringify({ id, ...meta, ts: Math.floor(Date.now() / 1000) }) + '\n') }
-  catch (e) { err(`tripwire: journal append failed for ${String(id).slice(0, 12)}…: ${e.message}`) }
+  if (!id) return false
+  try {
+    mkdirSync(dirname(SEND_JOURNAL_PATH), { recursive: true })
+    appendFileSync(SEND_JOURNAL_PATH, JSON.stringify({ id, ...meta, ts: Math.floor(Date.now() / 1000) }) + '\n')
+    return true
+  } catch (e) {
+    err(`tripwire: journal append failed for ${String(id).slice(0, 12)}…: ${e.message}`)
+    return false
+  }
 }
 // The bridge's own identity, used to SEAL outbound return-lane mail. A NIP-17 seal names its
 // real sender, so this has to be the bridge's key — the wrap around it is signed by a throwaway,
@@ -1611,18 +1617,19 @@ function publishControlStateToRelays(event, relays = PUB?.relays || [], mkSocket
   })
 }
 
-async function publishControlState(publish = publishControlStateToRelays, force = false) {
+async function publishControlState(publish = publishControlStateToRelays, force = false, sign = signControlState) {
   const state = buildControlState()
   if ((!PUB?.controlStatePublish && !force) || !state || !hasBridgeKey()) return 0
   let event
-  try { event = await signControlState(state) }
+  try { event = await sign(state) }
   catch (e) { err(`control state: refused to sign: ${e?.message || '?'}`); return 0 }
+  // Journal the exact immutable event before the first network write. A relay may persist EVENT
+  // and lose its positive OK frame; waiting for that acknowledgement would make this legitimate
+  // process-authored event indistinguishable from key theft. If durable intent cannot be recorded,
+  // fail closed and do not create an event the tripwire can later observe without its journal row.
+  if (!journalSend(event.id, { kind: event.kind, operation: 'control_state' })) return 0
   const accepted = await publish(event).catch(() => 0)
   if (accepted >= 1) {
-    // This is authored by the same poster identity the tripwire watches.  Every other landed
-    // poster event is journaled at its send boundary; omitting this periodic NIP-78 snapshot
-    // made each legitimate refresh look exactly like out-of-process key theft.
-    journalSend(event.id, { kind: event.kind, operation: 'control_state' })
     log(`control state -> ${accepted}/${PUB.relays.length} relay(s): ${state.follows.length} followed author(s) (${event.id.slice(0, 12)}…)`)
   }
   else err('control state: reached no relay — console will correctly show state unavailable')

--- a/src/bridge.mjs
+++ b/src/bridge.mjs
@@ -212,13 +212,29 @@ const UNDELIVERED_PATH = process.env.UNDELIVERED_PATH || resolve(ROOT, 'data', '
 const SEND_JOURNAL_PATH = process.env.SEND_JOURNAL_PATH || resolve(ROOT, 'data', 'send-journal.log')
 function journalSend(id, meta) {
   if (!id) return false
+  let fileFd = null
+  let dirFd = null
   try {
-    mkdirSync(dirname(SEND_JOURNAL_PATH), { recursive: true })
-    appendFileSync(SEND_JOURNAL_PATH, JSON.stringify({ id, ...meta, ts: Math.floor(Date.now() / 1000) }) + '\n')
+    const directory = dirname(SEND_JOURNAL_PATH)
+    mkdirSync(directory, { recursive: true })
+    fileFd = openSync(SEND_JOURNAL_PATH, 'a', 0o600)
+    writeFileSync(fileFd, JSON.stringify({ id, ...meta, ts: Math.floor(Date.now() / 1000) }) + '\n')
+    fsyncSync(fileFd)
+    closeSync(fileFd)
+    fileFd = null
+    // Syncing the parent unconditionally also closes the first-create crash window; doing it for
+    // an existing journal is cheap and avoids a pre-check race around file creation/replacement.
+    dirFd = openSync(directory, 'r')
+    fsyncSync(dirFd)
+    closeSync(dirFd)
+    dirFd = null
     return true
   } catch (e) {
     err(`tripwire: journal append failed for ${String(id).slice(0, 12)}…: ${e.message}`)
     return false
+  } finally {
+    if (fileFd !== null) { try { closeSync(fileFd) } catch { /* failure already means false */ } }
+    if (dirFd !== null) { try { closeSync(dirFd) } catch { /* failure already means false */ } }
   }
 }
 // The bridge's own identity, used to SEAL outbound return-lane mail. A NIP-17 seal names its

--- a/src/bridge.mjs
+++ b/src/bridge.mjs
@@ -1618,7 +1618,13 @@ async function publishControlState(publish = publishControlStateToRelays, force 
   try { event = await signControlState(state) }
   catch (e) { err(`control state: refused to sign: ${e?.message || '?'}`); return 0 }
   const accepted = await publish(event).catch(() => 0)
-  if (accepted >= 1) log(`control state -> ${accepted}/${PUB.relays.length} relay(s): ${state.follows.length} followed author(s) (${event.id.slice(0, 12)}…)`)
+  if (accepted >= 1) {
+    // This is authored by the same poster identity the tripwire watches.  Every other landed
+    // poster event is journaled at its send boundary; omitting this periodic NIP-78 snapshot
+    // made each legitimate refresh look exactly like out-of-process key theft.
+    journalSend(event.id, { kind: event.kind, operation: 'control_state' })
+    log(`control state -> ${accepted}/${PUB.relays.length} relay(s): ${state.follows.length} followed author(s) (${event.id.slice(0, 12)}…)`)
+  }
   else err('control state: reached no relay — console will correctly show state unavailable')
   return accepted
 }

--- a/src/bridge.mjs
+++ b/src/bridge.mjs
@@ -210,15 +210,23 @@ const UNDELIVERED_PATH = process.env.UNDELIVERED_PATH || resolve(ROOT, 'data', '
 // the key signed something we did not (theft / a second signer). Process rate-limits cannot
 // catch that; this can. (Q1, waggle's finding, 2026-07-30.)
 const SEND_JOURNAL_PATH = process.env.SEND_JOURNAL_PATH || resolve(ROOT, 'data', 'send-journal.log')
-function journalSend(id, meta) {
+function journalSend(id, meta, durable = false) {
   if (!id) return false
+  const row = JSON.stringify({ id, ...meta, ts: Math.floor(Date.now() / 1000) }) + '\n'
+  // Existing data-plane senders retain the append-only boundary they already use. The periodic
+  // control snapshot opts into the stronger crash-consistent pre-send commit below; forcing two
+  // fsyncs onto every public/relay/return message would turn the tripwire fix into lane latency.
+  if (!durable) {
+    try { mkdirSync(dirname(SEND_JOURNAL_PATH), { recursive: true }); appendFileSync(SEND_JOURNAL_PATH, row); return true }
+    catch (e) { err(`tripwire: journal append failed for ${String(id).slice(0, 12)}…: ${e.message}`); return false }
+  }
   let fileFd = null
   let dirFd = null
   try {
     const directory = dirname(SEND_JOURNAL_PATH)
     mkdirSync(directory, { recursive: true })
     fileFd = openSync(SEND_JOURNAL_PATH, 'a', 0o600)
-    writeFileSync(fileFd, JSON.stringify({ id, ...meta, ts: Math.floor(Date.now() / 1000) }) + '\n')
+    writeFileSync(fileFd, row)
     fsyncSync(fileFd)
     closeSync(fileFd)
     fileFd = null
@@ -1643,7 +1651,7 @@ async function publishControlState(publish = publishControlStateToRelays, force 
   // and lose its positive OK frame; waiting for that acknowledgement would make this legitimate
   // process-authored event indistinguishable from key theft. If durable intent cannot be recorded,
   // fail closed and do not create an event the tripwire can later observe without its journal row.
-  if (!journalSend(event.id, { kind: event.kind, operation: 'control_state' })) return 0
+  if (!journalSend(event.id, { kind: event.kind, operation: 'control_state' }, true)) return 0
   const accepted = await publish(event).catch(() => 0)
   if (accepted >= 1) {
     log(`control state -> ${accepted}/${PUB.relays.length} relay(s): ${state.follows.length} followed author(s) (${event.id.slice(0, 12)}…)`)

--- a/tests/control_state.mjs
+++ b/tests/control_state.mjs
@@ -10,6 +10,7 @@ import { generateSecretKey, getPublicKey, finalizeEvent, verifyEvent } from 'nos
 
 const tmp = mkdtempSync(join(tmpdir(), 'wb-control-state-'))
 const CFG = join(tmp, 'config.json')
+const SEND_JOURNAL = join(tmp, 'send-journal.log')
 const HIVE = 'a'.repeat(64)
 const CHANNEL = '77777777-7777-7777-7777-777777777777'
 const bridgeSk = generateSecretKey()
@@ -22,6 +23,7 @@ process.env.SEEN_PATH = join(tmp, 'seen.log')
 process.env.PUB_WATERMARK_PATH = join(tmp, 'watermark')
 process.env.POSTED_MAP_PATH = join(tmp, 'posted.log')
 process.env.MIRRORASKED_PATH = join(tmp, 'asked.log')
+process.env.SEND_JOURNAL_PATH = SEND_JOURNAL
 writeFileSync(CFG, JSON.stringify({
   relays: [], recipients: [],
   public: {
@@ -32,7 +34,7 @@ writeFileSync(CFG, JSON.stringify({
   },
 }))
 
-const { buildControlState, processConsentEvent, mirrorAsked, mirrorRevoked, PUB, handleControlStateCommand, handleWatchlistControlCommand, CONTROL_COMMAND_KIND, CONTROL_COMMAND_D, WATCHLIST_COMMAND_D } = await import('../src/bridge.mjs')
+const { buildControlState, publishControlState, processConsentEvent, mirrorAsked, mirrorRevoked, PUB, handleControlStateCommand, handleWatchlistControlCommand, CONTROL_COMMAND_KIND, CONTROL_COMMAND_D, WATCHLIST_COMMAND_D } = await import('../src/bridge.mjs')
 const { signControlState, CONTROL_STATE_KIND } = await import('../src/nostr_egress.mjs')
 const { scopeHash } = await import('../src/consent.mjs')
 
@@ -69,6 +71,12 @@ t('state contains only the declared owner-visible fields',
   Object.keys(body.follows[0]).sort().join(',') === 'consent,pubkey' &&
   Object.keys(body.operations).sort().join(',') === 'drops,gates,lanes,trust' &&
   Object.keys(body.operations.drops).sort().join(',') === 'relay_not_relay,relay_preauth')
+
+let publishedControlId = ''
+const acceptedControl = await publishControlState(async (event) => { publishedControlId = event.id; return 1 }, true)
+const controlJournal = readFileSync(SEND_JOURNAL, 'utf8').trim().split('\n').map(line => JSON.parse(line))
+t('an accepted control-state publication is recorded for the out-of-process tripwire',
+  acceptedControl === 1 && controlJournal.some(row => row.id === publishedControlId && row.kind === CONTROL_STATE_KIND && row.operation === 'control_state'))
 
 const currentState = buildControlState()
 const { v: legacyV, observed_at: legacyObservedAt, hive: legacyHive, bridge: legacyBridge, publishing: legacyPublishing, follows: legacyFollows } = currentState

--- a/tests/control_state.mjs
+++ b/tests/control_state.mjs
@@ -3,7 +3,7 @@
 // The console must never read config.json. This drives the real bridge-derived payload through
 // the bridge-key signer, checks its wire signature, and proves the consent lifecycle is rendered
 // as owner-observable state without creating a free-form public publishing capability.
-import { mkdtempSync, writeFileSync, readFileSync } from 'node:fs'
+import { mkdtempSync, writeFileSync, readFileSync, unlinkSync, mkdirSync, rmdirSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { generateSecretKey, getPublicKey, finalizeEvent, verifyEvent } from 'nostr-tools/pure'
@@ -91,6 +91,16 @@ const refusedControl = await publishControlState(async () => { publishAfterSignF
 const afterSignFailure = readFileSync(SEND_JOURNAL, 'utf8').trim().split('\n').map(line => JSON.parse(line))
 t('a signing refusal creates no journal row and performs no network write',
   refusedControl === 0 && publishAfterSignFailure === 0 && afterSignFailure.length === beforeSignFailure)
+
+// Replace the expected journal file with a directory: open-for-append must fail on every platform.
+// The publication boundary must fail closed rather than create an on-relay event with no durable row.
+unlinkSync(SEND_JOURNAL)
+mkdirSync(SEND_JOURNAL)
+let publishAfterJournalFailure = 0
+const unjournaled = await publishControlState(async () => { publishAfterJournalFailure++; return 1 }, true)
+t('a journal open/write/fsync failure suppresses the network write', unjournaled === 0 && publishAfterJournalFailure === 0)
+rmdirSync(SEND_JOURNAL)
+writeFileSync(SEND_JOURNAL, afterSignFailure.map(row => JSON.stringify(row)).join('\n') + '\n')
 
 const currentState = buildControlState()
 const { v: legacyV, observed_at: legacyObservedAt, hive: legacyHive, bridge: legacyBridge, publishing: legacyPublishing, follows: legacyFollows } = currentState

--- a/tests/control_state.mjs
+++ b/tests/control_state.mjs
@@ -78,6 +78,20 @@ const controlJournal = readFileSync(SEND_JOURNAL, 'utf8').trim().split('\n').map
 t('an accepted control-state publication is recorded for the out-of-process tripwire',
   acceptedControl === 1 && controlJournal.some(row => row.id === publishedControlId && row.kind === CONTROL_STATE_KIND && row.operation === 'control_state'))
 
+let unacknowledgedControlId = ''
+const unacknowledged = await publishControlState(async (event) => { unacknowledgedControlId = event.id; return 0 }, true)
+const afterUnacknowledged = readFileSync(SEND_JOURNAL, 'utf8').trim().split('\n').map(line => JSON.parse(line))
+t('an attempted control-state publication is journaled even when every relay acknowledgement is lost',
+  unacknowledged === 0 && afterUnacknowledged.some(row => row.id === unacknowledgedControlId && row.operation === 'control_state'))
+
+const beforeSignFailure = afterUnacknowledged.length
+let publishAfterSignFailure = 0
+const refusedControl = await publishControlState(async () => { publishAfterSignFailure++; return 1 }, true,
+  async () => { throw new Error('fixture signing refusal') })
+const afterSignFailure = readFileSync(SEND_JOURNAL, 'utf8').trim().split('\n').map(line => JSON.parse(line))
+t('a signing refusal creates no journal row and performs no network write',
+  refusedControl === 0 && publishAfterSignFailure === 0 && afterSignFailure.length === beforeSignFailure)
+
 const currentState = buildControlState()
 const { v: legacyV, observed_at: legacyObservedAt, hive: legacyHive, bridge: legacyBridge, publishing: legacyPublishing, follows: legacyFollows } = currentState
 const legacy = await signControlState({ v: legacyV, observed_at: legacyObservedAt, hive: legacyHive, bridge: legacyBridge, publishing: legacyPublishing, follows: legacyFollows })


### PR DESCRIPTION
The live tripwire currently reports every legitimate periodic kind-30078 owner-control snapshot as unauthorized because that accepted publication bypasses the poster send journal. This journals the exact accepted event at the publication boundary and adds a regression proving the landed control-state id/kind/operation appears in the tripwire journal.\n\nEvidence: targeted control-state suite 24/24; npm run lint; all 43 suites green.\n\nNo GitHub review mentions; private review is routed only through Buzz waggle-test.