### PR TITLE
fix: provision independent tripwire alarm credentials

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -304,9 +304,18 @@ detection a property of the **install**, not of anyone remembering to run a scri
 
 1. **The alarm is signed by a SEPARATE key, never the poster key.** An alarm signed by the
    identity under suspicion is worthless — a thief holding the poster nsec could forge the
-   all-clear too. Set `ALARM_NSEC` to a **dedicated** key with zero authority (its only
-   power is sending a DM), so it is safe to hold on the watcher and disposable if the
-   watcher is lost. Never set it to `BUZZ_PRIVATE_KEY`.
+   all-clear too. Mint a **dedicated** key with zero authority directly into systemd credential
+   files (its only power is sending a DM). The initializer never accepts or prints an nsec:
+
+   ```
+   sudo node tools/tripwire-alarm-init.mjs \
+     --recipient <operator-npub> \
+     --poster <bridge-poster-npub> \
+     --directory /etc/waggle-tripwire
+   ```
+
+   The resulting `alarm.nsec` and `alarm.to` are mode 0600. Never set it to
+   `BUZZ_PRIVATE_KEY`, and do not copy it into `tripwire.env`.
 2. **Off-host is stronger.** A compromised box can silence an on-box watcher before it
    fires. The recommended posture runs the tripwire on a **separate host** (your Mac, a
    second droplet) against a synced copy of the journal — a box compromise then cannot kill
@@ -327,13 +336,30 @@ never opens a gap.
 On a **watcher host** that is not the box — clone this repo, `npm ci`, then:
 
 ```
-# tripwire.env (0600, owner-only, NEVER committed):
+# tripwire.env (0600, owner-only, NEVER committed; PUBLIC values only):
 POSTER=<npub of the bridge poster key>          # PUBLIC key only — the watcher never signs as poster
 SEND_JOURNAL_PATH=/opt/waggle/data/journal-sealed.log:/opt/waggle/data/journal-read.log  # BOTH lanes, :-separated (below)
-ALARM_NSEC=<dedicated alarm key nsec>           # rule 1 — a fresh, zero-authority key
-ALARM_TO=<npub to DM on alarm>
 BUZZ_RELAY_URL=<relay>                          # extra public relays come from config.json
 ```
+
+`deploy/tripwire.service` loads `/etc/waggle-tripwire/alarm.nsec` and `alarm.to` with
+systemd `LoadCredential=`. The secret therefore stays out of the unit environment, command
+line, repo, and logs.
+
+For an existing watcher—especially the live on-box unit that first merges read- and sealed-lane
+journals—do **not** replace its `ExecStart` with the generic off-host template. Install only the
+credential drop-in, preserving the already-verified detector command:
+
+```
+sudo install -d -m 0755 /etc/systemd/system/waggle-tripwire.service.d
+sudo install -m 0644 deploy/tripwire-alarm.conf \
+  /etc/systemd/system/waggle-tripwire.service.d/alarm.conf
+sudo systemctl daemon-reload
+sudo systemctl restart waggle-tripwire.service
+```
+
+The last command is the negative control and may report `QUIET` or `OK`; it must no longer report
+`no alarm delivery path configured`. The positive drill below must then produce a sealed DM.
 
 The watcher **pulls** the journals (so the box needs no credentials to the watcher — a journal
 is only public event ids, nothing sensitive), on its own timer just ahead of the tripwire tick.
@@ -364,6 +390,12 @@ sudo systemctl enable --now tripwire.timer
 systemctl list-timers tripwire.timer
 ```
 
+Run the positive drill and confirm the sealed DM arrives at the operator identity before
+accepting a clean timer tick. For rotation, initialize a fresh directory, switch both
+`LoadCredential=` source paths together, daemon-reload, rerun the delivery drill, and only then
+retire the old directory. If no relay accepts the DM, preserve the alarm log, repair relay
+reachability, and rerun the drill; a logged alarm does not prove anyone was notified.
+
 On macOS (no systemd) run the same script from a `launchd` job or `cron` on the same
 30-min cadence — the units are a convenience, `tools/tripwire.mjs` is the whole detector.
 
@@ -385,7 +417,7 @@ mistakes and crude theft; only off-host catches an adversary who owns the host.
   process.`
 - **Positive control (must fire):** temporarily point `--journal` at an empty file (or sign
   one test event off-process) so a real on-relay post is unaccounted — the run must print
-  `🚨 TRIPWIRE`, append `data/tripwire-alarms.log`, exit 2, and (if `ALARM_*` are set) DM the
+  `🚨 TRIPWIRE`, append `data/tripwire-alarms.log`, exit 2, and (if alarm credentials are loaded) DM the
   alarm. Restore the real journal path after.
 
 Alert on **exit 2 / unit failure** (`systemctl --failed`, or an `OnFailure=` handler) as the

--- a/deploy/tripwire-alarm.conf
+++ b/deploy/tripwire-alarm.conf
@@ -1,0 +1,10 @@
+# Alarm credential drop-in for an existing waggle-tripwire.service.
+# Install as /etc/systemd/system/waggle-tripwire.service.d/alarm.conf.
+# It deliberately does not replace ExecStart: the live on-box unit merges both lane journals,
+# while an off-host watcher has different paths. This adds only the independent delivery identity.
+[Service]
+LoadCredential=alarm.nsec:/etc/waggle-tripwire/alarm.nsec
+LoadCredential=alarm.to:/etc/waggle-tripwire/alarm.to
+Environment=ALARM_NSEC_FILE=%d/alarm.nsec
+Environment=ALARM_TO_FILE=%d/alarm.to
+UMask=0077

--- a/deploy/tripwire.service
+++ b/deploy/tripwire.service
@@ -17,12 +17,13 @@
 #
 # WorkingDirectory is a checkout of THIS repo on the watcher host (off-host: your Mac / a
 # second box — recommended; on-box fallback: point it at the sealed tree). Adjust the paths
-# and User below to that host. tripwire.env (0600, owner-only, NEVER committed) sets:
+# and User below to that host. tripwire.env (0600, owner-only, NEVER committed) sets only:
 #   POSTER=<npub|hex of the bridge poster key>   # the PUBLIC key — this watcher never signs as poster
 #   SEND_JOURNAL_PATH=<path to the (synced) send-journal.log>
-#   ALARM_NSEC=<dedicated alarm key nsec>        # rule 1 — separate identity
-#   ALARM_TO=<npub to DM on alarm>
 #   BUZZ_RELAY_URL=<relay>                       # extra public relays are read from config.json
+# The alarm identity and recipient are root-owned files loaded through systemd credentials:
+#   /etc/waggle-tripwire/alarm.nsec              # dedicated zero-authority key, mode 0600
+#   /etc/waggle-tripwire/alarm.to                # operator-owned recipient npub, mode 0600
 [Unit]
 Description=waggle tripwire — detect out-of-process signing by the bridge poster key
 After=network-online.target
@@ -37,7 +38,12 @@ WorkingDirectory=/opt/waggle
 # mean a single missed run never opens a detection gap (see tripwire.timer).
 ExecStart=/usr/bin/node tools/tripwire.mjs --since-min 60
 EnvironmentFile=/opt/waggle/tripwire.env
+LoadCredential=alarm.nsec:/etc/waggle-tripwire/alarm.nsec
+LoadCredential=alarm.to:/etc/waggle-tripwire/alarm.to
+Environment=ALARM_NSEC_FILE=%d/alarm.nsec
+Environment=ALARM_TO_FILE=%d/alarm.to
 Environment=PATH=/usr/local/bin:/usr/bin:/bin
+UMask=0077
 NoNewPrivileges=yes
 ProtectSystem=strict
 ProtectHome=yes

--- a/tests/tripwire_detection.mjs
+++ b/tests/tripwire_detection.mjs
@@ -14,14 +14,18 @@
 // a parallel path would prove nothing about the path that matters.
 
 import { spawnSync } from 'node:child_process'
-import { mkdtempSync, writeFileSync, readFileSync, existsSync, rmSync } from 'node:fs'
+import { mkdtempSync, writeFileSync, readFileSync, existsSync, rmSync, chmodSync, lstatSync, symlinkSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { resolve, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { getPublicKey } from 'nostr-tools/pure'
+import * as nip19 from 'nostr-tools/nip19'
 
 const HERE = dirname(fileURLToPath(import.meta.url))
 const ROOT = resolve(HERE, '..')
 const TOOL = resolve(ROOT, 'tools', 'tripwire.mjs')
+const INIT = resolve(ROOT, 'tools', 'tripwire-alarm-init.mjs')
+const DROP_IN = resolve(ROOT, 'deploy', 'tripwire-alarm.conf')
 const POSTER = 'npub1s36nypljc6h88tey0kshf688eyd8myu636ctfs4e3d2w54nhsmnqfhaent'
 // Written per-run into the temp dir. The real log at data/tripwire-alarms.log is evidence an
 // operator is meant to trust; a test must not leave fake alarms in it.
@@ -129,6 +133,56 @@ try {
     /no alarm delivery path configured/.test(neg.out))
   check('a firing alarm with no delivery path says nobody was told',
     /ALARM NOT DELIVERED/.test(pos.out))
+
+  console.log('\nalarm credential files')
+  const credentials = resolve(dir, 'credentials')
+  const init = spawnSync('node', [INIT, '--directory', credentials, '--recipient', POSTER], { encoding: 'utf8' })
+  check('initializer succeeds without accepting a secret', init.status === 0, init.stderr)
+  check('initializer output never prints an nsec', !/nsec1/i.test((init.stdout || '') + (init.stderr || '')))
+  const alarmNsecPath = resolve(credentials, 'alarm.nsec')
+  const alarmToPath = resolve(credentials, 'alarm.to')
+  check('alarm nsec is written mode 0600', (lstatSync(alarmNsecPath).mode & 0o777) === 0o600)
+  check('recipient is written mode 0600', (lstatSync(alarmToPath).mode & 0o777) === 0o600)
+  const alarmSecret = nip19.decode(readFileSync(alarmNsecPath, 'utf8').trim()).data
+  check('initializer mints a separate identity', getPublicKey(alarmSecret) !== nip19.decode(POSTER).data)
+  check('initializer refuses to overwrite a live credential directory',
+    spawnSync('node', [INIT, '--directory', credentials, '--recipient', POSTER], { encoding: 'utf8' }).status === 1)
+
+  const credentialRun = spawnSync('node', [TOOL, '--since-min', '60', '--journal', full, '--events-from', eventsFile], {
+    env: { ...process.env, POSTER, ALARM_NSEC: '', ALARM_TO: '', ALARM_NSEC_FILE: alarmNsecPath, ALARM_TO_FILE: alarmToPath, ALARM_LOG_PATH: ALARMS },
+    encoding: 'utf8',
+  })
+  const credentialOut = (credentialRun.stdout || '') + (credentialRun.stderr || '')
+  check('credential-file configuration is accepted on a clean run', credentialRun.status === 0, `exit ${credentialRun.status}`)
+  check('configured credential files remove the no-delivery warning', !/no alarm delivery path configured/.test(credentialOut))
+
+  chmodSync(alarmNsecPath, 0o644)
+  const loose = spawnSync('node', [TOOL, '--journal', full, '--events-from', eventsFile], {
+    env: { ...process.env, POSTER, ALARM_NSEC: '', ALARM_TO: '', ALARM_NSEC_FILE: alarmNsecPath, ALARM_TO_FILE: alarmToPath, ALARM_LOG_PATH: ALARMS },
+    encoding: 'utf8',
+  })
+  check('group/world-readable secret is rejected', loose.status === 1 && /must not be group\/world accessible/.test((loose.stderr || '') + (loose.stdout || '')))
+  chmodSync(alarmNsecPath, 0o600)
+
+  const symlink = resolve(dir, 'alarm-link.nsec')
+  symlinkSync(alarmNsecPath, symlink)
+  const linked = spawnSync('node', [TOOL, '--journal', full, '--events-from', eventsFile], {
+    env: { ...process.env, POSTER, ALARM_NSEC: '', ALARM_TO: '', ALARM_NSEC_FILE: symlink, ALARM_TO_FILE: alarmToPath, ALARM_LOG_PATH: ALARMS },
+    encoding: 'utf8',
+  })
+  check('symlinked secret is rejected', linked.status === 1 && /non-symlink/.test((linked.stderr || '') + (linked.stdout || '')))
+
+  const publicHex = nip19.decode(POSTER).data
+  const hexInit = spawnSync('node', [INIT, '--directory', resolve(dir, 'hex-recipient'), '--recipient', publicHex], { encoding: 'utf8' })
+  check('a public 64-hex recipient is not mistaken for an nsec', hexInit.status === 0, hexInit.stderr)
+
+  const dropIn = readFileSync(DROP_IN, 'utf8')
+  check('the live-safe drop-in loads both systemd credentials',
+    dropIn.includes('LoadCredential=alarm.nsec:/etc/waggle-tripwire/alarm.nsec') &&
+    dropIn.includes('LoadCredential=alarm.to:/etc/waggle-tripwire/alarm.to'))
+  check('the drop-in maps systemd credential paths without replacing the detector command',
+    dropIn.includes('Environment=ALARM_NSEC_FILE=%d/alarm.nsec') &&
+    dropIn.includes('Environment=ALARM_TO_FILE=%d/alarm.to') && !dropIn.includes('ExecStart='))
 } finally {
   rmSync(dir, { recursive: true, force: true })
 }

--- a/tools/tripwire-alarm-init.mjs
+++ b/tools/tripwire-alarm-init.mjs
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+// Mint the independent, zero-authority tripwire alarm identity directly into root-owned files.
+// The secret is never printed or accepted on argv. Refuses an existing directory: rotation uses
+// a fresh staging directory so the current working alarm remains recoverable until the drill passes.
+import { mkdirSync, openSync, writeFileSync, closeSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { generateSecretKey, getPublicKey } from 'nostr-tools/pure'
+import * as nip19 from 'nostr-tools/nip19'
+
+const fail = message => { console.error(`tripwire-alarm-init: ${message}`); process.exit(1) }
+const allowed = new Set(['--directory', '--recipient', '--poster'])
+const parsed = new Map()
+for (let i = 2; i < process.argv.length; i += 2) {
+  const name = process.argv[i]
+  const value = process.argv[i + 1]
+  if (!allowed.has(name) || value == null || value.startsWith('--')) fail(`unknown or incomplete argument: ${name}`)
+  if (parsed.has(name)) fail(`${name} may be supplied only once`)
+  parsed.set(name, String(value).trim())
+}
+const arg = name => parsed.get(name) || ''
+// There is deliberately no import path. Public 64-hex values remain valid in the two public-key
+// slots, but an nsec anywhere on argv is always an operator mistake.
+if (process.argv.some(value => /^nsec1/i.test(value))) fail('never pass a secret key on argv')
+
+const directory = resolve(arg('--directory') || '/etc/waggle-tripwire')
+const recipientInput = arg('--recipient')
+const posterInput = arg('--poster')
+if (!recipientInput) fail('--recipient <operator npub> is required')
+let recipient
+try { recipient = recipientInput.startsWith('npub1') ? nip19.decode(recipientInput).data : recipientInput.toLowerCase() } catch { fail('recipient is not a valid npub') }
+if (!/^[0-9a-f]{64}$/.test(recipient)) fail('recipient must be an npub or 64-hex public key')
+let poster = ''
+if (posterInput) {
+  try { poster = posterInput.startsWith('npub1') ? nip19.decode(posterInput).data : posterInput.toLowerCase() } catch { fail('poster is not a valid npub') }
+  if (!/^[0-9a-f]{64}$/.test(poster)) fail('poster must be an npub or 64-hex public key')
+}
+
+try { mkdirSync(dirname(directory), { recursive: true, mode: 0o700 }); mkdirSync(directory, { mode: 0o700 }) }
+catch (e) { fail(`refusing existing/unwritable directory ${directory}: ${e.message}`) }
+const sk = generateSecretKey(), alarmPub = getPublicKey(sk)
+if (poster && alarmPub === poster) fail('generated alarm identity unexpectedly equals poster; run again in a fresh directory')
+const writePrivate = (path, value) => {
+  const fd = openSync(path, 'wx', 0o600)
+  try { writeFileSync(fd, value + '\n') } finally { closeSync(fd) }
+}
+try {
+  writePrivate(resolve(directory, 'alarm.nsec'), nip19.nsecEncode(sk))
+  writePrivate(resolve(directory, 'alarm.to'), nip19.npubEncode(recipient))
+} catch (e) { fail(`credential write failed: ${e.message}`) }
+
+console.log(`tripwire alarm identity: ${nip19.npubEncode(alarmPub)}`)
+console.log(`recipient: ${nip19.npubEncode(recipient)}`)
+console.log(`credentials: ${directory}/alarm.nsec + alarm.to (0600; secret not printed)`)
+console.log('Next: install/reload the unit, run the positive sealed-delivery drill, then a clean timer tick.')

--- a/tools/tripwire.mjs
+++ b/tools/tripwire.mjs
@@ -20,7 +20,7 @@
 // poster key (which may be the compromised one). Wire it to a systemd timer; alert on exit 2.
 
 import WebSocket from 'ws'
-import { readFileSync, appendFileSync, mkdirSync, existsSync } from 'node:fs'
+import { readFileSync, appendFileSync, mkdirSync, existsSync, lstatSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { getPublicKey, finalizeEvent, generateSecretKey } from 'nostr-tools/pure'
@@ -30,6 +30,24 @@ import * as nip44 from 'nostr-tools/nip44'
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..')
 const arg = (n, d) => { const i = process.argv.indexOf(n); return i === -1 ? d : process.argv[i + 1] }
 const die = (m) => { console.error(`tripwire: ${m}`); process.exit(1) }
+
+// systemd credentials keep the alarm nsec out of EnvironmentFile, process listings, the repo,
+// and logs. Direct env remains for local drills/backward compatibility, but a unit that supplies
+// BOTH is a migration error: silently preferring one could leave an old secret live indefinitely.
+function credential(name) {
+  const direct = String(process.env[name] || '').trim()
+  const path = String(process.env[`${name}_FILE`] || '').trim()
+  if (direct && path) die(`${name} and ${name}_FILE are both set — remove the legacy environment secret`)
+  if (!path) return direct
+  let st
+  try { st = lstatSync(path) } catch (e) { die(`${name}_FILE cannot be read: ${e.message}`) }
+  if (!st.isFile() || st.isSymbolicLink()) die(`${name}_FILE must be a regular non-symlink file`)
+  if ((st.mode & 0o077) !== 0) die(`${name}_FILE must not be group/world accessible`)
+  if (st.size < 1 || st.size > 512) die(`${name}_FILE has an invalid size`)
+  try { return readFileSync(path, 'utf8').trim() } catch (e) { die(`${name}_FILE cannot be read: ${e.message}`) }
+}
+const ALARM_NSEC = credential('ALARM_NSEC')
+const ALARM_TO = credential('ALARM_TO')
 
 // Poster identity — the key whose signing we are policing.
 let poster = arg('--poster', process.env.POSTER)
@@ -44,8 +62,8 @@ const posterHex = poster.startsWith('npub1') ? nip19.decode(poster).data : poste
 // Rule 1 as a property of the code, not just the docs: the alarm must be signed by a SEPARATE
 // key, never the poster. If ALARM_NSEC derives to the poster, a thief holding that nsec could
 // forge the all-clear too — so refuse to run rather than offer that false assurance.
-if (process.env.ALARM_NSEC) {
-  const alarmSk = process.env.ALARM_NSEC.startsWith('nsec1') ? nip19.decode(process.env.ALARM_NSEC).data : Uint8Array.from(Buffer.from(process.env.ALARM_NSEC, 'hex'))
+if (ALARM_NSEC) {
+  const alarmSk = ALARM_NSEC.startsWith('nsec1') ? nip19.decode(ALARM_NSEC).data : Uint8Array.from(Buffer.from(ALARM_NSEC, 'hex'))
   if (getPublicKey(alarmSk) === posterHex) die('ALARM_NSEC derives to the POSTER key — the alarm must be signed by a SEPARATE, zero-authority key (rule 1). An alarm signed by the identity under suspicion proves nothing.')
 }
 
@@ -120,7 +138,7 @@ function fetchPosterEvents() {
 // the absence of a delivery path is exactly the kind of thing discovered during an incident rather
 // than before one. Reported on every run, clean or not — a 30-minute timer saying so is cheap
 // compared to finding out when it matters.
-const alarmConfigured = () => !!(process.env.ALARM_NSEC && process.env.ALARM_TO)
+const alarmConfigured = () => !!(ALARM_NSEC && ALARM_TO)
 
 async function alarmDM(text) {
   if (!alarmConfigured()) {
@@ -128,8 +146,8 @@ async function alarmDM(text) {
     return
   }
   try {
-    const ask = process.env.ALARM_NSEC.startsWith('nsec1') ? nip19.decode(process.env.ALARM_NSEC).data : Uint8Array.from(Buffer.from(process.env.ALARM_NSEC, 'hex'))
-    const to = process.env.ALARM_TO.startsWith('npub1') ? nip19.decode(process.env.ALARM_TO).data : process.env.ALARM_TO.toLowerCase()
+    const ask = ALARM_NSEC.startsWith('nsec1') ? nip19.decode(ALARM_NSEC).data : Uint8Array.from(Buffer.from(ALARM_NSEC, 'hex'))
+    const to = ALARM_TO.startsWith('npub1') ? nip19.decode(ALARM_TO).data : ALARM_TO.toLowerCase()
     // NIP-17 seal+wrap (signer = the ALARM key, NOT the poster key).
     const now = () => Math.floor(Date.now() / 1000 - Math.random() * 172800)
     const rumor = { kind: 14, pubkey: getPublicKey(ask), created_at: Math.floor(Date.now() / 1000), tags: [['p', to]], content: text }


### PR DESCRIPTION
Closes the implementation portion of #263.\n\n- loads the independent alarm signer and recipient through systemd credentials instead of EnvironmentFile\n- adds a secret-safe initializer that mints directly into mode-0600 files and never accepts or prints an nsec\n- rejects symlinks, loose modes, duplicate legacy/file configuration, and reuse of the poster identity\n- documents rotation and requires a positive sealed-delivery drill before treating the detector as operational\n- extends the real tripwire drill with positive and negative credential custody controls\n\nVerification: npm test (44 suites); npm run lint.\n\nLive issue closure still requires the operator-recipient delivery drill after merge; this PR does not claim that drill has happened.