### PR TITLE
Fix task-route signing with the saved Console identity

### DIFF
--- a/console/signer-session.mjs
+++ b/console/signer-session.mjs
@@ -1,0 +1,26 @@
+// Reuse the Access tab's persisted Nave signer on every owner-control surface. A page must not
+// silently replace an established Bunker session with whichever window.nostr provider happens to
+// be injected into that tab; that can sign as a different identity or return no event at all.
+import { nip07Signer, parseSession, signerFromSession } from './vendor/nave-connect.mjs'
+
+export const CONSOLE_SESSION_KEY = 'waggle-console-session'
+
+export async function consoleSigner({
+  storage = globalThis.localStorage,
+  win = globalThis.window,
+  parse = parseSession,
+  restore = signerFromSession,
+  browserSigner = nip07Signer,
+} = {}) {
+  let saved = null
+  try { saved = storage?.getItem(CONSOLE_SESSION_KEY) || null } catch { /* private mode */ }
+  if (saved) {
+    try {
+      const signer = restore(parse(saved), { win })
+      if (signer) return signer
+    } catch {
+      try { storage?.removeItem(CONSOLE_SESSION_KEY) } catch { /* private mode */ }
+    }
+  }
+  return browserSigner(win)
+}

--- a/console/task-route-envelope.mjs
+++ b/console/task-route-envelope.mjs
@@ -14,7 +14,7 @@ export async function sealedTaskRouteCommand(signer, bridge, body, now = Math.fl
   const encrypted = await signer.nip44Encrypt(bridge, JSON.stringify(rumor))
   const sealDraft = { kind:13, created_at:fuzzed(), tags:[], content:encrypted }
   const seal = await signer.signEvent(sealDraft)
-  if (!verifyEvent(seal) || seal.pubkey !== owner || seal.kind !== sealDraft.kind ||
+  if (!seal || typeof seal !== 'object' || Array.isArray(seal) || !verifyEvent(seal) || seal.pubkey !== owner || seal.kind !== sealDraft.kind ||
       seal.created_at !== sealDraft.created_at || seal.content !== sealDraft.content ||
       JSON.stringify(seal.tags) !== JSON.stringify(sealDraft.tags)) throw new Error('The signer returned an invalid or altered route seal.')
   const wrapKey = generateSecretKey()

--- a/console/task-routes.mjs
+++ b/console/task-routes.mjs
@@ -2,8 +2,8 @@
 // public state, asks the owner's signer for an encrypted NIP-17 seal, then publishes an ephemeral
 // NIP-59 wrap. Relays never learn the channel, participant, sender, or mention inside the command.
 import { nip19, verifyEvent } from 'nostr-tools'
-import { nip07Signer } from './vendor/nave-connect.mjs'
 import { sealedTaskRouteCommand } from './task-route-envelope.mjs'
+import { consoleSigner } from './signer-session.mjs'
 
 const RELAYS = ['wss://nos.lol', 'wss://relay.primal.net', 'wss://relay.ditto.pub', 'wss://jskitty.com/nostr']
 const $ = id => document.getElementById(id)
@@ -79,7 +79,7 @@ async function manage(action) {
     if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(channel)) throw new Error('Use the Buzz channel UUID, not its display name.')
     const mention = String($('route-mention').value || '').trim().replace(/^@/, '').toLowerCase()
     if (!/^[a-z0-9][a-z0-9_-]{0,31}$/.test(mention)) throw new Error('Mention must be 1–32 letters, numbers, underscores, or hyphens.')
-    const signer = nip07Signer(), signingIdentity = (await signer.getPublicKey()).toLowerCase()
+    const signer = await consoleSigner(), signingIdentity = (await signer.getPublicKey()).toLowerCase()
     const sender = $('route-sender').value.trim() ? hex($('route-sender').value) : signingIdentity
     const verb = action === 'upsert' ? 'activate' : 'remove'
     if (!confirm(`${verb[0].toUpperCase() + verb.slice(1)} @${mention} for ${npub(participant)} in channel ${channel}?\n\nOnly messages signed by ${npub(sender)} can use this route.`)) return

--- a/tests/control_state.mjs
+++ b/tests/control_state.mjs
@@ -9,6 +9,7 @@ import { join } from 'node:path'
 import { generateSecretKey, getEventHash, getPublicKey, finalizeEvent, verifyEvent } from 'nostr-tools/pure'
 import * as nip44 from 'nostr-tools/nip44'
 import { sealedTaskRouteCommand } from '../console/task-route-envelope.mjs'
+import { consoleSigner, CONSOLE_SESSION_KEY } from '../console/signer-session.mjs'
 
 const tmp = mkdtempSync(join(tmpdir(), 'wb-control-state-'))
 const CFG = join(tmp, 'config.json')
@@ -182,6 +183,18 @@ const ownerSigner = {
   signEvent: async event => wire(finalizeEvent(event, watchedSk)),
   nip44Encrypt: async (recipient, plaintext) => nip44.encrypt(plaintext, nip44.getConversationKey(watchedSk, recipient)),
 }
+const restoredSigner = { marker: 'saved-bunker' }
+const fakeStorage = { value: 'nip46:saved', getItem(key) { return key === CONSOLE_SESSION_KEY ? this.value : null }, removeItem() { this.value = null } }
+const selectedSigner = await consoleSigner({ storage: fakeStorage, parse: value => ({ kind: value.slice(0, 5) }),
+  restore: session => session.kind === 'nip46' ? restoredSigner : null,
+  browserSigner: () => ({ marker: 'ambient-window-nostr' }) })
+t('the route Console reuses the Access tab Bunker session instead of ambient window.nostr', selectedSigner === restoredSigner)
+let undefinedSealRefused = false
+try {
+  await sealedTaskRouteCommand({ ...ownerSigner, signEvent: async () => undefined },
+    getPublicKey(bridgeSk), taskBody('upsert'), routeAt)
+} catch (error) { undefinedSealRefused = /invalid or altered route seal/.test(error.message) }
+t('an injected signer that returns no event fails with a bounded route error', undefinedSealRefused)
 let alteredSealRefused = false
 try {
   await sealedTaskRouteCommand({ ...ownerSigner, signEvent: async event => wire(finalizeEvent({ ...event, content: 'substituted' }, watchedSk)) },
@@ -225,7 +238,7 @@ const taskRoutesPage = readFileSync(new URL('../console/task-routes.mjs', import
 const taskEnvelope = readFileSync(new URL('../console/task-route-envelope.mjs', import.meta.url), 'utf8')
 const operationsPage = readFileSync(new URL('../console/config-operations.mjs', import.meta.url), 'utf8')
 t('the Config console closes the entire signed state and renders only fresh verified public operations', /config-operations\.mjs/.test(configPage) && /verifyEvent/.test(operationsPage) && /exact\(state, \['v', 'observed_at', 'hive', 'bridge', 'publishing', 'follows', 'operations'\]\)/.test(operationsPage) && /exact\(state\.hive, \['id', 'name', 'handle'\]\)/.test(operationsPage) && /state\.follows\.every/.test(operationsPage) && /newest\.observed_at <= now \+ 60/.test(operationsPage) && /now - newest\.observed_at <= 900/.test(operationsPage) && /Verified signed state from/.test(operationsPage) && /Aggregate counts only/.test(operationsPage) && !/fetch\([^)]*config\.json/.test(operationsPage) && !/\/config\.json/.test(operationsPage))
-t('the Config route form emits only an encrypted gift wrap and never publishes its private tuple', /task-routes\.mjs/.test(configPage) && /waggle-task-route/.test(taskRoutesPage) && /nvoy-task-carry-v1/.test(taskRoutesPage) && /nip44\.encrypt/.test(taskEnvelope) && /kind:1059/.test(taskEnvelope) && /nip44Encrypt/.test(taskEnvelope) && !/kind:30078/.test(taskRoutesPage + taskEnvelope) && !/fetch\([^)]*config\.json/.test(taskRoutesPage) && !/\/config\.json/.test(taskRoutesPage))
+t('the Config route form emits only an encrypted gift wrap and never publishes its private tuple', /task-routes\.mjs/.test(configPage) && /waggle-task-route/.test(taskRoutesPage) && /nvoy-task-carry-v1/.test(taskRoutesPage) && /nip44\.encrypt/.test(taskEnvelope) && /kind:1059/.test(taskEnvelope) && /nip44Encrypt/.test(taskEnvelope) && /consoleSigner/.test(taskRoutesPage) && !/kind:30078/.test(taskRoutesPage + taskEnvelope) && !/fetch\([^)]*config\.json/.test(taskRoutesPage) && !/\/config\.json/.test(taskRoutesPage))
 
 console.log(`\n${pass}/${n} passed`)
 process.exit(pass === n ? 0 : 1)


### PR DESCRIPTION
## What changed

- restores the Access tab’s persisted Nave signer before task-route signing
- prevents an ambient `window.nostr` provider from silently replacing an established Bunker session
- turns an undefined signer response into a bounded, actionable error instead of a `verifyEvent` TypeError

## Evidence

- reproduced live on the deployed Config page after PR #264
- focused control-state/task-route suite: 41/41
- undefined signer and saved-Bunker-selection negative controls
- all 44 suites passed
- lint and `git diff --check` passed

Drafted with assistance from [Claude Code](https://claude.com/claude-code)