### PR TITLE
test: add live tripwire alarm delivery drill

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -373,6 +373,21 @@ sudo systemctl restart waggle-tripwire.service
 The last command is the negative control and may report `QUIET` or `OK`; it must no longer report
 `no alarm delivery path configured`. The positive drill below must then produce a sealed DM.
 
+Run the live delivery drill with only public values and credential **paths** in the environment:
+
+```
+sudo env \
+  ALARM_NSEC_FILE=/etc/waggle-tripwire/alarm.nsec \
+  ALARM_TO_FILE=/etc/waggle-tripwire/alarm.to \
+  BUZZ_RELAY_URL=wss://relay.nave.pub \
+  /usr/bin/node /opt/waggle-read/tools/tripwire.mjs \
+  --poster <bridge-poster-npub-or-hex> --drill-alarm
+```
+
+Exit 0 means at least one relay accepted the sealed test alert; exit 4 means nobody accepted it.
+The recipient must still confirm the labelled `TRIPWIRE DRILL` DM arrived—relay acceptance alone
+is not recipient read-back.
+
 The watcher **pulls** the journals (so the box needs no credentials to the watcher — a journal
 is only public event ids, nothing sensitive), on its own timer just ahead of the tripwire tick.
 

--- a/tests/tripwire_detection.mjs
+++ b/tests/tripwire_detection.mjs
@@ -13,13 +13,14 @@
 // the alarm log and the exit codes are the same code a live run executes. A drill that exercised
 // a parallel path would prove nothing about the path that matters.
 
-import { spawnSync } from 'node:child_process'
+import { spawn, spawnSync } from 'node:child_process'
 import { mkdtempSync, writeFileSync, readFileSync, existsSync, rmSync, chmodSync, lstatSync, symlinkSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { resolve, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { getPublicKey } from 'nostr-tools/pure'
+import { getPublicKey, verifyEvent } from 'nostr-tools/pure'
 import * as nip19 from 'nostr-tools/nip19'
+import { WebSocketServer } from 'ws'
 
 const HERE = dirname(fileURLToPath(import.meta.url))
 const ROOT = resolve(HERE, '..')
@@ -43,6 +44,16 @@ function run(journal, eventsFile) {
   const r = spawnSync('node', [TOOL, '--since-min', '60', '--journal', journal, '--events-from', eventsFile],
     { env: { ...process.env, POSTER, ALARM_NSEC: '', ALARM_TO: '', ALARM_LOG_PATH: ALARMS }, encoding: 'utf8' })
   return { code: r.status, out: (r.stdout || '') + (r.stderr || '') }
+}
+
+function runAsync(args, env) {
+  return new Promise(resolve => {
+    const child = spawn('node', args, { env, stdio: ['ignore', 'pipe', 'pipe'] })
+    let stdout = '', stderr = ''
+    child.stdout.on('data', chunk => { stdout += chunk })
+    child.stderr.on('data', chunk => { stderr += chunk })
+    child.on('exit', code => resolve({ code, out: stdout + stderr }))
+  })
 }
 
 const dir = mkdtempSync(resolve(tmpdir(), 'waggle-drill-'))
@@ -175,6 +186,58 @@ try {
   const publicHex = nip19.decode(POSTER).data
   const hexInit = spawnSync('node', [INIT, '--directory', resolve(dir, 'hex-recipient'), '--recipient', publicHex], { encoding: 'utf8' })
   check('a public 64-hex recipient is not mistaken for an nsec', hexInit.status === 0, hexInit.stderr)
+
+  let relayAccept = true, receivedWrap = null
+  const relay = new WebSocketServer({ host: '127.0.0.1', port: 0 })
+  await new Promise((resolve, reject) => { relay.once('listening', resolve); relay.once('error', reject) })
+  relay.on('connection', socket => socket.on('message', bytes => {
+    let frame
+    try { frame = JSON.parse(bytes.toString()) } catch { return }
+    if (frame[0] !== 'EVENT') return
+    receivedWrap = frame[1]
+    socket.send(JSON.stringify(['OK', frame[1].id, relayAccept, relayAccept ? '' : 'drill refusal']))
+  }))
+  const relayUrl = `ws://127.0.0.1:${relay.address().port}`
+  const drillEnv = { ...process.env, POSTER, ALARM_NSEC: '', ALARM_TO: '', ALARM_NSEC_FILE: alarmNsecPath,
+    ALARM_TO_FILE: alarmToPath, BUZZ_RELAY_URL: relayUrl, ALARM_LOG_PATH: ALARMS }
+  const drill = await runAsync([TOOL, '--poster', POSTER, '--drill-alarm'], drillEnv)
+  check('live drill exits 0 only after relay acceptance', drill.code === 0 && /DRILL OK/.test(drill.out), `exit ${drill.code}`)
+  check('live drill sends one valid sealed kind:1059 to the configured recipient',
+    receivedWrap?.kind === 1059 && verifyEvent(receivedWrap) && receivedWrap.tags.length === 1 &&
+    receivedWrap.tags[0][0] === 'p' && receivedWrap.tags[0][1] === nip19.decode(POSTER).data)
+  check('live drill output never exposes its signing secret', !/nsec1/i.test(drill.out))
+  relayAccept = false; receivedWrap = null
+  const refusedDrill = await runAsync([TOOL, '--poster', POSTER, '--drill-alarm'], drillEnv)
+  check('live drill exits 4 when no relay accepts the alert', refusedDrill.code === 4 && /ALARM NOT DELIVERED/.test(refusedDrill.out), `exit ${refusedDrill.code}`)
+  receivedWrap = null
+  const noExplicitRelay = await runAsync([TOOL, '--poster', POSTER, '--drill-alarm'], {
+    ...drillEnv, BUZZ_RELAY_URL: '',
+  })
+  check('live drill refuses a missing explicit relay before any publication',
+    noExplicitRelay.code === 1 && /requires exactly one explicit BUZZ_RELAY_URL/.test(noExplicitRelay.out) && receivedWrap === null,
+    `exit ${noExplicitRelay.code}`)
+  const queryCredentialRelay = await runAsync([TOOL, '--poster', POSTER, '--drill-alarm'], {
+    ...drillEnv, BUZZ_RELAY_URL: `${relayUrl}/?token=secret`,
+  })
+  check('live drill refuses relay query credentials before any publication',
+    queryCredentialRelay.code === 1 && /credential-free/.test(queryCredentialRelay.out) && receivedWrap === null,
+    `exit ${queryCredentialRelay.code}`)
+  const fragmentCredentialRelay = await runAsync([TOOL, '--poster', POSTER, '--drill-alarm'], {
+    ...drillEnv, BUZZ_RELAY_URL: `${relayUrl}/#credential`,
+  })
+  check('live drill refuses relay fragment credentials before any publication',
+    fragmentCredentialRelay.code === 1 && /credential-free/.test(fragmentCredentialRelay.out) && receivedWrap === null,
+    `exit ${fragmentCredentialRelay.code}`)
+  const badRelayBeforeSecret = await runAsync([TOOL, '--poster', POSTER, '--drill-alarm'], {
+    ...drillEnv,
+    BUZZ_RELAY_URL: `${relayUrl}/?token=secret`,
+    ALARM_NSEC_FILE: resolve(dir, 'must-not-be-read.nsec'),
+  })
+  check('invalid drill relay is refused before any alarm credential is read',
+    badRelayBeforeSecret.code === 1 && /credential-free/.test(badRelayBeforeSecret.out) &&
+      !/ALARM_NSEC_FILE cannot be read/.test(badRelayBeforeSecret.out) && receivedWrap === null,
+    `exit ${badRelayBeforeSecret.code}`)
+  await new Promise(resolve => relay.close(resolve))
 
   const dropIn = readFileSync(DROP_IN, 'utf8')
   check('the live-safe drop-in loads both systemd credentials',

--- a/tools/tripwire.mjs
+++ b/tools/tripwire.mjs
@@ -32,6 +32,23 @@ const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..')
 const arg = (n, d) => { const i = process.argv.indexOf(n); return i === -1 ? d : process.argv[i + 1] }
 const die = (m) => { console.error(`tripwire: ${m}`); process.exit(1) }
 
+// Validate the public, credential-free drill target before reading any secret file or constructing
+// either signer. A malformed target must not be able to trigger secret access or Bunker traffic.
+const DRILL_ALARM = process.argv.includes('--drill-alarm')
+let DRILL_RELAY = null
+if (DRILL_ALARM) {
+  const raw = String(process.env.BUZZ_RELAY_URL || '').trim()
+  if (!raw) die('--drill-alarm requires exactly one explicit BUZZ_RELAY_URL')
+  try {
+    const parsed = new URL(raw)
+    if (!['ws:', 'wss:'].includes(parsed.protocol) || parsed.username || parsed.password || parsed.search || parsed.hash)
+      throw new Error('not a credential-free WebSocket URL')
+    DRILL_RELAY = parsed.toString()
+  } catch {
+    die('--drill-alarm requires exactly one explicit credential-free ws:// or wss:// BUZZ_RELAY_URL')
+  }
+}
+
 // systemd credentials keep the alarm nsec out of EnvironmentFile, process listings, the repo,
 // and logs. Direct env remains for local drills/backward compatibility, but a unit that supplies
 // BOTH is a migration error: silently preferring one could leave an old secret live indefinitely.
@@ -103,6 +120,9 @@ const JOURNALS = journalPaths()
 const ALARMS = process.env.ALARM_LOG_PATH || resolve(ROOT, 'data', 'tripwire-alarms.log')
 
 function loadRelays() {
+  // A delivery drill proves one named path. Falling through to the normal fan-out would let a
+  // different relay accept the wrap and mask failure of the path the operator intended to test.
+  if (DRILL_ALARM) return [DRILL_RELAY]
   const out = new Set()
   if (process.env.BUZZ_RELAY_URL) out.add(process.env.BUZZ_RELAY_URL)
   try { const c = JSON.parse(readFileSync(resolve(ROOT, 'config.json'), 'utf8')); for (const r of c.public?.relays || []) out.add(r) } catch { /* fall through */ }
@@ -154,7 +174,7 @@ const alarmConfigured = () => !!(alarmPubkey && ALARM_TO)
 async function alarmDM(text) {
   if (!alarmConfigured()) {
     console.error('tripwire: ⚠ ALARM NOT DELIVERED — no alarm signer/ALARM_TO is configured, so this alarm exists only in this log and data/tripwire-alarms.log. Nobody has been told.')
-    return
+    return 0
   }
   try {
     const to = ALARM_TO.startsWith('npub1') ? nip19.decode(ALARM_TO).data : ALARM_TO.toLowerCase()
@@ -183,7 +203,19 @@ async function alarmDM(text) {
     const accepted = results.filter(Boolean).length
     if (accepted > 0) console.error(`tripwire: alarm DM delivered ${accepted}/${relays.length} relay(s)`)
     else console.error(`tripwire: ⚠ ALARM NOT DELIVERED — 0/${relays.length} relay(s) accepted the alarm DM. The alarm exists only in this log and data/tripwire-alarms.log.`)
-  } catch (e) { console.error(`tripwire: ⚠ ALARM NOT DELIVERED — alarm DM failed: ${e.message}`) }
+    return accepted
+  } catch (e) { console.error(`tripwire: ⚠ ALARM NOT DELIVERED — alarm DM failed: ${e.message}`); return 0 }
+}
+
+// Exercise the exact production seal/publish path without manufacturing an unauthorized poster
+// event. This is delivery evidence, not a detector all-clear: the ordinary positive/negative diff
+// drill proves detection, while this proves that a firing detector can actually reach its owner.
+if (DRILL_ALARM) {
+  console.error('tripwire: DRILL — sending a labelled test alarm through the production sealed-DM path')
+  const delivered = await alarmDM(`🚨 TRIPWIRE DRILL — test alert from ${posterHex.slice(0, 12)}… at ${new Date().toISOString()}. This is a delivery test, not a signing incident.`)
+  if (delivered < 1) process.exit(4)
+  console.log(`DRILL OK — sealed test alarm accepted by ${delivered} relay(s). Confirm arrival at the configured operator identity.`)
+  process.exit(0)
 }
 
 // --- run ---


### PR DESCRIPTION
Completes the repeatable proof surface for #263 after #265.\n\n- adds --drill-alarm using the exact production NIP-17 seal/publish path\n- exits 0 only after the explicitly named relay accepts the wrap; exits 4 otherwise\n- prevents normal fan-out from masking failure of the relay under test\n- labels the message as a drill and still requires recipient read-back\n- adds a local WebSocket relay positive control validating the signed kind:1059 recipient, plus an explicit refusal negative control\n- documents the secret-free live command using credential paths only\n\nVerification: full 44-suite gate and lint pass.\n\nReview discussion belongs only in private Buzz waggle-test.