### PR TITLE
Use Bunker for independent tripwire alarms

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -302,10 +302,13 @@ detection a property of the **install**, not of anyone remembering to run a scri
 
 ### Two rules the unit exists to enforce
 
-1. **The alarm is signed by a SEPARATE key, never the poster key.** An alarm signed by the
+1. **The alarm is signed by a SEPARATE identity, never the poster key.** An alarm signed by the
    identity under suspicion is worthless — a thief holding the poster nsec could forge the
-   all-clear too. Mint a **dedicated** key with zero authority directly into systemd credential
-   files (its only power is sending a DM). The initializer never accepts or prints an nsec:
+   all-clear too. Prefer a dedicated **Bunker identity with zero authority** (its only power is
+   sending a DM), using mode-0600 URI and NIP-46 client files. The identity nsec then never
+   exists on the watcher. For a simple/offline install, the compatibility initializer can mint
+   a disposable local alarm key directly into systemd credential files without accepting or
+   printing an nsec:
 
    ```
    sudo node tools/tripwire-alarm-init.mjs \
@@ -315,7 +318,8 @@ detection a property of the **install**, not of anyone remembering to run a scri
    ```
 
    The resulting `alarm.nsec` and `alarm.to` are mode 0600. Never set it to
-   `BUZZ_PRIVATE_KEY`, and do not copy it into `tripwire.env`.
+   `BUZZ_PRIVATE_KEY`, and do not copy it into `tripwire.env`. Never use the poster identity
+   for either signer mode.
 2. **Off-host is stronger.** A compromised box can silence an on-box watcher before it
    fires. The recommended posture runs the tripwire on a **separate host** (your Mac, a
    second droplet) against a synced copy of the journal — a box compromise then cannot kill
@@ -342,9 +346,17 @@ SEND_JOURNAL_PATH=/opt/waggle/data/journal-sealed.log:/opt/waggle/data/journal-r
 BUZZ_RELAY_URL=<relay>                          # extra public relays come from config.json
 ```
 
-`deploy/tripwire.service` loads `/etc/waggle-tripwire/alarm.nsec` and `alarm.to` with
-systemd `LoadCredential=`. The secret therefore stays out of the unit environment, command
-line, repo, and logs.
+Install exactly one signer drop-in:
+
+- `deploy/tripwire-alarm-bunker.conf` loads `alarm.bunker-uri`, `alarm.client-nsec`, and
+  `alarm.to` through systemd `LoadCredential=`. This is the preferred keyless mode.
+- `deploy/tripwire-alarm.conf` loads the compatibility `alarm.nsec` and `alarm.to` files.
+
+Both keep credentials out of the unit environment, command line, repo, and logs. For Bunker
+mode, create `/etc/waggle-tripwire` as mode `0700`; install all three files as root-owned,
+regular non-symlink files with mode `0600`. The Bunker identity must have no grants or
+application authority. Its client pairing remains a credential even though it cannot reveal
+or export the identity nsec.
 
 For an existing watcher—especially the live on-box unit that first merges read- and sealed-lane
 journals—do **not** replace its `ExecStart` with the generic off-host template. Install only the
@@ -352,7 +364,7 @@ credential drop-in, preserving the already-verified detector command:
 
 ```
 sudo install -d -m 0755 /etc/systemd/system/waggle-tripwire.service.d
-sudo install -m 0644 deploy/tripwire-alarm.conf \
+sudo install -m 0644 deploy/tripwire-alarm-bunker.conf \
   /etc/systemd/system/waggle-tripwire.service.d/alarm.conf
 sudo systemctl daemon-reload
 sudo systemctl restart waggle-tripwire.service
@@ -417,8 +429,22 @@ mistakes and crude theft; only off-host catches an adversary who owns the host.
   process.`
 - **Positive control (must fire):** temporarily point `--journal` at an empty file (or sign
   one test event off-process) so a real on-relay post is unaccounted — the run must print
-  `🚨 TRIPWIRE`, append `data/tripwire-alarms.log`, exit 2, and (if alarm credentials are loaded) DM the
-  alarm. Restore the real journal path after.
+  `🚨 TRIPWIRE`, append `data/tripwire-alarms.log`, exit 2, and (with either alarm signer mode
+  plus `ALARM_TO`) DM the alarm. Restore the real journal path after.
+
+### Alarm rotation and relay outage
+
+To rotate, first create and approve a fresh zero-authority Bunker identity/pairing, atomically
+replace both mode-0600 pairing files, run the positive drill, and only then revoke the old Bunker
+pairing. If the watcher is lost, revoke that pairing immediately; there is no reason to preserve
+it because the alarm identity owns no grants. `ALARM_TO` is the operator recipient and rotates
+independently.
+
+A `0/N` relay result is never success: the tripwire retains the durable local alarm row, exits 2,
+and says `ALARM NOT DELIVERED`. Restore relay reachability and rerun the same drill; do not clear
+the failed unit or treat the local row as acknowledged until the intended recipient cold-reads the
+the sealed DM from at least one configured relay. The systemd failed state is the independent local
+  backstop while sealed delivery is unavailable.
 
 Alert on **exit 2 / unit failure** (`systemctl --failed`, or an `OnFailure=` handler) as the
 local backstop to the out-of-band alarm DM.

--- a/deploy/tripwire-alarm-bunker.conf
+++ b/deploy/tripwire-alarm-bunker.conf
@@ -1,0 +1,13 @@
+# Bunker-backed alarm credential drop-in for an existing waggle-tripwire.service.
+# Install as /etc/systemd/system/waggle-tripwire.service.d/alarm.conf INSTEAD OF
+# deploy/tripwire-alarm.conf. The alarm identity's nsec remains in the Bunker.
+[Service]
+LoadCredential=
+LoadCredential=alarm.bunker-uri:/etc/waggle-tripwire/alarm.bunker-uri
+LoadCredential=alarm.client-nsec:/etc/waggle-tripwire/alarm.client-nsec
+LoadCredential=alarm.to:/etc/waggle-tripwire/alarm.to
+Environment=ALARM_NSEC_FILE=
+Environment=ALARM_BUNKER_URI_FILE=%d/alarm.bunker-uri
+Environment=ALARM_NIP46_CLIENT_NSEC_FILE=%d/alarm.client-nsec
+Environment=ALARM_TO_FILE=%d/alarm.to
+UMask=0077

--- a/deploy/tripwire.service
+++ b/deploy/tripwire.service
@@ -9,7 +9,8 @@
 # local backstop to the DM. See deploy/README.md "Tripwire" for the full contract.
 #
 # TWO RULES THIS UNIT EXISTS TO ENFORCE:
-#   1. ALARM_NSEC is a DEDICATED key, NEVER the poster (BUZZ_PRIVATE_KEY) key. An alarm
+#   1. The alarm signer is a DEDICATED identity, NEVER the poster key. A Bunker pairing is
+#      preferred; ALARM_NSEC is the legacy/disposable local-key fallback. An alarm
 #      signed by the identity under suspicion proves nothing. The alarm key has zero
 #      authority — its only power is sending a DM — so it is safe to hold on the watcher.
 #   2. OFF-HOST IS STRONGER. A compromised box can silence an on-box watcher before it

--- a/src/nostr_signer.mjs
+++ b/src/nostr_signer.mjs
@@ -34,14 +34,18 @@ function nsec(raw, label) {
   return decoded.data
 }
 
-export function makeBunkerSigner(uriText, clientNsec, { Pool = SimplePool } = {}) {
+export function makeBunkerSigner(uriText, clientNsec, {
+  Pool = SimplePool,
+  uriLabel = 'WAGGLE_BUNKER_URI_FILE',
+  clientLabel = 'WAGGLE_NIP46_CLIENT_NSEC_FILE',
+} = {}) {
   const raw = String(uriText || '').trim(), match = BUNKER.exec(raw)
-  if (!match) throw new Error('WAGGLE_BUNKER_URI_FILE does not contain a valid bunker URI')
+  if (!match) throw new Error(`${uriLabel} does not contain a valid bunker URI`)
   const uri = new URL(raw)
   const relays = [...new Set(uri.searchParams.getAll('relay').filter(v => /^wss:\/\//.test(v)))]
   if (!relays.length) throw new Error('Waggle bunker URI needs at least one wss relay')
   const pubkey = match[1].toLowerCase(), secret = uri.searchParams.get('secret') || ''
-  const clientKey = nsec(clientNsec, 'WAGGLE_NIP46_CLIENT_NSEC_FILE')
+  const clientKey = nsec(clientNsec, clientLabel)
   const clientPubkey = getPublicKey(clientKey)
   const conversation = nip44.v2.utils.getConversationKey(clientKey, pubkey)
   const pool = new Pool(), pending = new Map()
@@ -83,9 +87,20 @@ export function makeBunkerSigner(uriText, clientNsec, { Pool = SimplePool } = {}
   })
 }
 
-function localSigner(raw) {
-  const sk = raw.startsWith('nsec1') ? nsec(raw, 'BUZZ_PRIVATE_KEY') : Uint8Array.from(Buffer.from(raw, 'hex'))
-  if (sk.length !== 32) throw new Error('BUZZ_PRIVATE_KEY is not a valid nsec or 64-hex key')
+export function loadBunkerSignerFiles(uriFile, clientFile, deps = {}, {
+  uriLabel = 'WAGGLE_BUNKER_URI_FILE',
+  clientLabel = 'WAGGLE_NIP46_CLIENT_NSEC_FILE',
+} = {}) {
+  if (!!uriFile !== !!clientFile) throw new Error(`set both ${uriLabel} and ${clientLabel}`)
+  if (!uriFile) return null
+  return makeBunkerSigner(privateFile(uriFile, uriLabel), privateFile(clientFile, clientLabel), {
+    ...deps, uriLabel, clientLabel,
+  })
+}
+
+export function makeLocalSigner(raw, label = 'BUZZ_PRIVATE_KEY') {
+  const sk = raw.startsWith('nsec1') ? nsec(raw, label) : Uint8Array.from(Buffer.from(raw, 'hex'))
+  if (sk.length !== 32) throw new Error(`${label} is not a valid nsec or 64-hex key`)
   const pubkey = getPublicKey(sk), conversation = peer => nip44.getConversationKey(sk, peer)
   return Object.freeze({ pubkey, remote: false,
     signEvent: async event => finalizeEvent(event, sk),
@@ -98,8 +113,7 @@ function localSigner(raw) {
 export function loadNostrSigner(env = process.env, deps = {}) {
   const uriFile = String(env.WAGGLE_BUNKER_URI_FILE || '').trim()
   const clientFile = String(env.WAGGLE_NIP46_CLIENT_NSEC_FILE || '').trim()
-  if (!!uriFile !== !!clientFile) throw new Error('set both WAGGLE_BUNKER_URI_FILE and WAGGLE_NIP46_CLIENT_NSEC_FILE')
-  if (uriFile) return makeBunkerSigner(privateFile(uriFile, 'WAGGLE_BUNKER_URI_FILE'),
-    privateFile(clientFile, 'WAGGLE_NIP46_CLIENT_NSEC_FILE'), deps)
-  return env.BUZZ_PRIVATE_KEY ? localSigner(String(env.BUZZ_PRIVATE_KEY).trim()) : null
+  const remote = loadBunkerSignerFiles(uriFile, clientFile, deps)
+  if (remote) return remote
+  return env.BUZZ_PRIVATE_KEY ? makeLocalSigner(String(env.BUZZ_PRIVATE_KEY).trim()) : null
 }

--- a/tests/nostr_signer.mjs
+++ b/tests/nostr_signer.mjs
@@ -6,7 +6,8 @@ import { join } from 'node:path'
 import { finalizeEvent, generateSecretKey, getPublicKey, verifyEvent } from 'nostr-tools/pure'
 import * as nip19 from 'nostr-tools/nip19'
 import * as nip44 from 'nostr-tools/nip44'
-import { loadNostrSigner, makeBunkerSigner } from '../src/nostr_signer.mjs'
+import { loadNostrSigner, makeBunkerSigner, makeLocalSigner } from '../src/nostr_signer.mjs'
+import { buildTripwireAlarmWrap } from '../tools/tripwire_alarm_lib.mjs'
 
 let pass = 0, fail = 0
 const ok = (name, value) => { console.log(value ? 'ok  ' : 'FAIL', '—', name); value ? pass++ : fail++ }
@@ -62,6 +63,21 @@ try {
   const remoteCiphertext = await rpcSigner.nip44Encrypt(peer, 'remote round trip')
   ok('Bunker mode encrypts through NIP-46 without the identity nsec', nip44.decrypt(remoteCiphertext, nip44.getConversationKey(peerKey, liveBunkerPub)) === 'remote round trip')
   rpcSigner.close()
+
+  const alarmKey = generateSecretKey(), recipientKey = generateSecretKey(), recipient = getPublicKey(recipientKey)
+  const alarmSigner = makeLocalSigner(Buffer.from(alarmKey).toString('hex'), 'TEST_ALARM_NSEC')
+  const wrap = await buildTripwireAlarmWrap('drill', recipient, alarmSigner, { now: () => 100, backdated: () => 90 })
+  ok('tripwire builds a valid gift wrap addressed only to the operator', verifyEvent(wrap) && wrap.kind === 1059 &&
+    JSON.stringify(wrap.tags) === JSON.stringify([['p', recipient]]))
+  const alarmSeal = JSON.parse(nip44.decrypt(wrap.content, nip44.getConversationKey(recipientKey, wrap.pubkey)))
+  ok('tripwire seal is signed by the dedicated alarm identity', verifyEvent(alarmSeal) && alarmSeal.pubkey === alarmSigner.pubkey && alarmSeal.kind === 13)
+  const alarmRumor = JSON.parse(nip44.decrypt(alarmSeal.content, nip44.getConversationKey(recipientKey, alarmSigner.pubkey)))
+  ok('tripwire rumor binds recipient, alarm identity, and content', alarmRumor.kind === 14 && alarmRumor.pubkey === alarmSigner.pubkey &&
+    alarmRumor.content === 'drill' && JSON.stringify(alarmRumor.tags) === JSON.stringify([['p', recipient]]))
+  const mutating = { ...alarmSigner, async signEvent(event) { return finalizeEvent({ ...event, tags: [['p', 'f'.repeat(64)]] }, alarmKey) } }
+  let mutation = ''
+  try { await buildTripwireAlarmWrap('drill', recipient, mutating, { now: () => 100, backdated: () => 90 }) } catch (error) { mutation = error.message }
+  ok('tripwire refuses a signer that changes policy-owned seal bytes', /changed the sealed alarm event/.test(mutation))
 } finally { rmSync(dir, { recursive: true, force: true }) }
 
 console.log(`\n${pass}/${pass + fail} passed`)

--- a/tests/nostr_signer.mjs
+++ b/tests/nostr_signer.mjs
@@ -78,6 +78,10 @@ try {
   let mutation = ''
   try { await buildTripwireAlarmWrap('drill', recipient, mutating, { now: () => 100, backdated: () => 90 }) } catch (error) { mutation = error.message }
   ok('tripwire refuses a signer that changes policy-owned seal bytes', /changed the sealed alarm event/.test(mutation))
+  const widening = { ...alarmSigner, async signEvent(event) { return { ...finalizeEvent(event, alarmKey), delegated_by: 'attacker-controlled' } } }
+  let widened = ''
+  try { await buildTripwireAlarmWrap('drill', recipient, widening, { now: () => 100, backdated: () => 90 }) } catch (error) { widened = error.message }
+  ok('tripwire refuses signer-supplied fields outside the closed event schema', /changed the sealed alarm event/.test(widened))
 } finally { rmSync(dir, { recursive: true, force: true }) }
 
 console.log(`\n${pass}/${pass + fail} passed`)

--- a/tools/tripwire.mjs
+++ b/tools/tripwire.mjs
@@ -23,9 +23,10 @@ import WebSocket from 'ws'
 import { readFileSync, appendFileSync, mkdirSync, existsSync, lstatSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { getPublicKey, finalizeEvent, generateSecretKey } from 'nostr-tools/pure'
+import { getPublicKey } from 'nostr-tools/pure'
 import * as nip19 from 'nostr-tools/nip19'
-import * as nip44 from 'nostr-tools/nip44'
+import { loadBunkerSignerFiles, makeLocalSigner } from '../src/nostr_signer.mjs'
+import { buildTripwireAlarmWrap } from './tripwire_alarm_lib.mjs'
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..')
 const arg = (n, d) => { const i = process.argv.indexOf(n); return i === -1 ? d : process.argv[i + 1] }
@@ -60,12 +61,22 @@ if (!poster) die('set POSTER=<npub|hex> (or provide BUZZ_PRIVATE_KEY to derive i
 const posterHex = poster.startsWith('npub1') ? nip19.decode(poster).data : poster.toLowerCase()
 
 // Rule 1 as a property of the code, not just the docs: the alarm must be signed by a SEPARATE
-// key, never the poster. If ALARM_NSEC derives to the poster, a thief holding that nsec could
-// forge the all-clear too — so refuse to run rather than offer that false assurance.
+// key, never the poster. Prefer a Bunker pairing so the dedicated alarm nsec is absent even from
+// the watcher. ALARM_NSEC remains a disposable local-key fallback for simple/offline installs.
+const alarmBunker = loadBunkerSignerFiles(
+  String(process.env.ALARM_BUNKER_URI_FILE || '').trim(),
+  String(process.env.ALARM_NIP46_CLIENT_NSEC_FILE || '').trim(),
+  {},
+  { uriLabel: 'ALARM_BUNKER_URI_FILE', clientLabel: 'ALARM_NIP46_CLIENT_NSEC_FILE' },
+)
+let alarmLocal = null
 if (ALARM_NSEC) {
-  const alarmSk = ALARM_NSEC.startsWith('nsec1') ? nip19.decode(ALARM_NSEC).data : Uint8Array.from(Buffer.from(ALARM_NSEC, 'hex'))
-  if (getPublicKey(alarmSk) === posterHex) die('ALARM_NSEC derives to the POSTER key — the alarm must be signed by a SEPARATE, zero-authority key (rule 1). An alarm signed by the identity under suspicion proves nothing.')
+  if (alarmBunker) die('configure either the Bunker alarm signer or ALARM_NSEC, never both')
+  alarmLocal = makeLocalSigner(ALARM_NSEC, 'ALARM_NSEC')
 }
+const alarmSigner = alarmBunker || alarmLocal
+const alarmPubkey = alarmSigner?.pubkey || null
+if (alarmPubkey === posterHex) die('the alarm signer is the POSTER key — the alarm must use a SEPARATE, zero-authority identity (rule 1). An alarm signed by the identity under suspicion proves nothing.')
 
 const sinceMin = Number(arg('--since-min', 120))
 const since = Math.floor(Date.now() / 1000) - sinceMin * 60
@@ -138,22 +149,17 @@ function fetchPosterEvents() {
 // the absence of a delivery path is exactly the kind of thing discovered during an incident rather
 // than before one. Reported on every run, clean or not — a 30-minute timer saying so is cheap
 // compared to finding out when it matters.
-const alarmConfigured = () => !!(ALARM_NSEC && ALARM_TO)
+const alarmConfigured = () => !!(alarmPubkey && ALARM_TO)
 
 async function alarmDM(text) {
   if (!alarmConfigured()) {
-    console.error('tripwire: ⚠ ALARM NOT DELIVERED — ALARM_NSEC/ALARM_TO are unset, so this alarm exists only in this log and data/tripwire-alarms.log. Nobody has been told.')
+    console.error('tripwire: ⚠ ALARM NOT DELIVERED — no alarm signer/ALARM_TO is configured, so this alarm exists only in this log and data/tripwire-alarms.log. Nobody has been told.')
     return
   }
   try {
-    const ask = ALARM_NSEC.startsWith('nsec1') ? nip19.decode(ALARM_NSEC).data : Uint8Array.from(Buffer.from(ALARM_NSEC, 'hex'))
     const to = ALARM_TO.startsWith('npub1') ? nip19.decode(ALARM_TO).data : ALARM_TO.toLowerCase()
-    // NIP-17 seal+wrap (signer = the ALARM key, NOT the poster key).
-    const now = () => Math.floor(Date.now() / 1000 - Math.random() * 172800)
-    const rumor = { kind: 14, pubkey: getPublicKey(ask), created_at: Math.floor(Date.now() / 1000), tags: [['p', to]], content: text }
-    const seal = finalizeEvent({ kind: 13, created_at: now(), tags: [], content: nip44.encrypt(JSON.stringify(rumor), nip44.getConversationKey(ask, to)) }, ask)
-    const wsk = generateSecretKey()
-    const wrap = finalizeEvent({ kind: 1059, created_at: now(), tags: [['p', to]], content: nip44.encrypt(JSON.stringify(seal), nip44.getConversationKey(wsk, to)) }, wsk)
+    // NIP-17 seal+wrap (signer = the ALARM identity, NOT the poster identity).
+    const wrap = await buildTripwireAlarmWrap(text, to, alarmSigner)
     // Count what was ACCEPTED, not what was attempted. The previous version resolved on the first
     // frame of any kind — including an `["OK", id, false, "..."]` rejection — and on timeouts and
     // socket errors too, then printed "alarm DM sent" unconditionally. That is the same
@@ -205,7 +211,7 @@ console.error(`tripwire: poster ${posterHex.slice(0, 12)}… · window ${sinceMi
 // Said on EVERY run, not only when something fires. An operator who learns during an incident
 // that the alarm had nowhere to go has learned it too late, and a detector whose alarm is
 // undeliverable is a detector in name only.
-if (!alarmConfigured()) console.error('tripwire: ⚠ no alarm delivery path configured (ALARM_NSEC/ALARM_TO unset) — if this run had found something, nobody would have been told.')
+if (!alarmConfigured()) console.error('tripwire: ⚠ no alarm delivery path configured (Bunker or ALARM_NSEC plus ALARM_TO) — if this run had found something, nobody would have been told.')
 
 if (!anomalies.length) {
   // A half-synced union cannot produce an all-clear. With a lane's journal absent, "nothing

--- a/tools/tripwire_alarm_lib.mjs
+++ b/tools/tripwire_alarm_lib.mjs
@@ -5,10 +5,13 @@ import * as nip44 from 'nostr-tools/nip44'
 
 const HEX64 = /^[0-9a-f]{64}$/
 const exact = value => JSON.parse(JSON.stringify(value))
+const SIGNED_EVENT_KEYS = ['content', 'created_at', 'id', 'kind', 'pubkey', 'sig', 'tags']
 
 function verifyExactSeal(signed, draft, signerPubkey) {
   const event = exact(signed)
-  if (!verifyEvent(event) || event.pubkey !== signerPubkey || event.kind !== draft.kind ||
+  const keys = Object.keys(event).sort()
+  if (JSON.stringify(keys) !== JSON.stringify(SIGNED_EVENT_KEYS) ||
+      !verifyEvent(event) || event.pubkey !== signerPubkey || event.kind !== draft.kind ||
       event.created_at !== draft.created_at || event.content !== draft.content ||
       JSON.stringify(event.tags) !== JSON.stringify(draft.tags)) {
     throw new Error('tripwire-alarm: signer changed the sealed alarm event')

--- a/tools/tripwire_alarm_lib.mjs
+++ b/tools/tripwire_alarm_lib.mjs
@@ -1,0 +1,40 @@
+// NIP-17 alarm construction for the out-of-process tripwire. The caller supplies a dedicated
+// signer capability (preferably Bunker-backed); the identity nsec is not required here.
+import { finalizeEvent, generateSecretKey, verifyEvent } from 'nostr-tools/pure'
+import * as nip44 from 'nostr-tools/nip44'
+
+const HEX64 = /^[0-9a-f]{64}$/
+const exact = value => JSON.parse(JSON.stringify(value))
+
+function verifyExactSeal(signed, draft, signerPubkey) {
+  const event = exact(signed)
+  if (!verifyEvent(event) || event.pubkey !== signerPubkey || event.kind !== draft.kind ||
+      event.created_at !== draft.created_at || event.content !== draft.content ||
+      JSON.stringify(event.tags) !== JSON.stringify(draft.tags)) {
+    throw new Error('tripwire-alarm: signer changed the sealed alarm event')
+  }
+  return event
+}
+
+export async function buildTripwireAlarmWrap(text, recipient, signer, {
+  now = () => Math.floor(Date.now() / 1000),
+  backdated = () => Math.floor(Date.now() / 1000 - Math.random() * 172800),
+  wrapperSecret = generateSecretKey,
+} = {}) {
+  const to = String(recipient || '').toLowerCase()
+  if (!HEX64.test(to)) throw new Error('tripwire-alarm: recipient is not a 64-hex pubkey')
+  if (!signer || !HEX64.test(String(signer.pubkey || '')) || typeof signer.signEvent !== 'function' ||
+      typeof signer.nip44Encrypt !== 'function') throw new Error('tripwire-alarm: dedicated signer is unavailable')
+  const content = String(text || '')
+  if (!content || Buffer.byteLength(content) > 4096) throw new Error('tripwire-alarm: message is empty or oversized')
+  const createdAt = now(), sealAt = backdated(), wrapAt = backdated()
+  if (![createdAt, sealAt, wrapAt].every(value => Number.isSafeInteger(value) && value >= 0)) throw new Error('tripwire-alarm: timestamp is invalid')
+
+  const rumor = { kind: 14, pubkey: signer.pubkey, created_at: createdAt, tags: [['p', to]], content }
+  const sealDraft = { kind: 13, created_at: sealAt, tags: [], content: await signer.nip44Encrypt(to, JSON.stringify(rumor)) }
+  const seal = verifyExactSeal(await signer.signEvent(exact(sealDraft)), sealDraft, signer.pubkey)
+  const wsk = wrapperSecret()
+  if (!(wsk instanceof Uint8Array) || wsk.length !== 32) throw new Error('tripwire-alarm: wrapper key is invalid')
+  return finalizeEvent({ kind: 1059, created_at: wrapAt, tags: [['p', to]],
+    content: nip44.encrypt(JSON.stringify(seal), nip44.getConversationKey(wsk, to)) }, wsk)
+}


### PR DESCRIPTION
## What changed

- adds a Bunker-backed tripwire alarm signer so the alarm identity nsec never exists on the watcher
- loads the Bunker URI, NIP-46 client credential, and recipient through systemd `LoadCredential=`
- preserves the independently reviewed local alarm identity as an explicit compatibility path, while refusing simultaneous signer modes
- verifies every remotely signed seal against the exact policy-owned event before wrapping and publication
- documents zero-authority pairing, rotation, revocation, relay-outage recovery, and the mandatory positive/negative alarm drills

## Why

PR #265 made alarm delivery independently provisionable, but its compatibility signer still stores a dedicated nsec on the watcher. This follow-up keeps the detector independent while moving signing and NIP-44 encryption into Bunker. A compromised watcher therefore cannot extract the alarm identity key.

## Evidence

- focused Nostr signer and full gift-wrap round-trip: 12/12
- tripwire detection and credential drill: all checks passed
- all 44 suites passed
- lint and `git diff --check` passed

This advances #263; live closure still requires the deployed positive sealed-DM drill and a clean negative-control run.

Drafted with assistance from [Claude Code](https://claude.com/claude-code)
