### PR TITLE
Diagnose and close route signer mutations

### DIFF
--- a/console/task-route-envelope.mjs
+++ b/console/task-route-envelope.mjs
@@ -1,5 +1,23 @@
 import { finalizeEvent, generateSecretKey, getEventHash, nip44, verifyEvent } from 'nostr-tools'
 
+const SIGNED_EVENT_KEYS = ['content', 'created_at', 'id', 'kind', 'pubkey', 'sig', 'tags']
+function exactRouteSeal(seal, draft, owner) {
+  if (!seal || typeof seal !== 'object' || Array.isArray(seal))
+    throw new Error('The signer returned no signed route event.')
+  const keys = Object.keys(seal).sort()
+  if (JSON.stringify(keys) !== JSON.stringify(SIGNED_EVENT_KEYS))
+    throw new Error(`The signer changed the route seal schema (received: ${keys.join(', ') || 'no fields'}).`)
+  let valid = false
+  try { valid = verifyEvent(JSON.parse(JSON.stringify(seal))) } catch { /* bounded below */ }
+  if (!valid) throw new Error('The signer returned an invalid route-seal signature.')
+  if (seal.pubkey !== owner) throw new Error('The signer used a different identity for the route seal.')
+  if (seal.kind !== draft.kind) throw new Error('The signer changed the route-seal kind.')
+  if (seal.created_at !== draft.created_at) throw new Error('The signer changed the route-seal timestamp.')
+  if (seal.content !== draft.content) throw new Error('The signer changed the encrypted route command.')
+  if (JSON.stringify(seal.tags) !== JSON.stringify(draft.tags)) throw new Error('The signer changed the route-seal tags.')
+  return seal
+}
+
 // Build the only route-control wire artifact: a signed owner seal inside an ephemeral gift wrap.
 // The returned event exposes only kind 1059 and the bridge p-tag. Every route field is encrypted.
 export async function sealedTaskRouteCommand(signer, bridge, body, now = Math.floor(Date.now() / 1000)) {
@@ -13,10 +31,7 @@ export async function sealedTaskRouteCommand(signer, bridge, body, now = Math.fl
   rumor.id = getEventHash(rumor)
   const encrypted = await signer.nip44Encrypt(bridge, JSON.stringify(rumor))
   const sealDraft = { kind:13, created_at:fuzzed(), tags:[], content:encrypted }
-  const seal = await signer.signEvent(sealDraft)
-  if (!seal || typeof seal !== 'object' || Array.isArray(seal) || !verifyEvent(seal) || seal.pubkey !== owner || seal.kind !== sealDraft.kind ||
-      seal.created_at !== sealDraft.created_at || seal.content !== sealDraft.content ||
-      JSON.stringify(seal.tags) !== JSON.stringify(sealDraft.tags)) throw new Error('The signer returned an invalid or altered route seal.')
+  const seal = exactRouteSeal(await signer.signEvent(sealDraft), sealDraft, owner)
   const wrapKey = generateSecretKey()
   return finalizeEvent({ kind:1059, created_at:fuzzed(), tags:[['p',bridge]],
     content:nip44.encrypt(JSON.stringify(seal), nip44.getConversationKey(wrapKey, bridge)) }, wrapKey)

--- a/tests/control_state.mjs
+++ b/tests/control_state.mjs
@@ -193,14 +193,20 @@ let undefinedSealRefused = false
 try {
   await sealedTaskRouteCommand({ ...ownerSigner, signEvent: async () => undefined },
     getPublicKey(bridgeSk), taskBody('upsert'), routeAt)
-} catch (error) { undefinedSealRefused = /invalid or altered route seal/.test(error.message) }
-t('an injected signer that returns no event fails with a bounded route error', undefinedSealRefused)
+} catch (error) { undefinedSealRefused = /no signed route event/.test(error.message) }
+t('an injected signer that returns no event fails with a bounded specific route error', undefinedSealRefused)
 let alteredSealRefused = false
 try {
   await sealedTaskRouteCommand({ ...ownerSigner, signEvent: async event => wire(finalizeEvent({ ...event, content: 'substituted' }, watchedSk)) },
     getPublicKey(bridgeSk), taskBody('upsert'), routeAt)
 } catch { alteredSealRefused = true }
 t('the Console refuses a signer that alters the encrypted route seal', alteredSealRefused)
+let widenedSealRefused = false
+try {
+  await sealedTaskRouteCommand({ ...ownerSigner, signEvent: async event => ({ ...wire(finalizeEvent(event, watchedSk)), injected: 'accepted' }) },
+    getPublicKey(bridgeSk), taskBody('upsert'), routeAt)
+} catch (error) { widenedSealRefused = /changed the route seal schema/.test(error.message) }
+t('the Console refuses a signer that widens the signed route-seal schema', widenedSealRefused)
 const realWrap = await sealedTaskRouteCommand(ownerSigner, getPublicKey(bridgeSk), taskBody('upsert'), routeAt)
 const extraOuterField = await handleSealedTaskRouteControl({ ...realWrap, extra: 'not part of NIP-59' })
 t('the bridge refuses an extensible outer envelope even when its Nostr signature still verifies', !extraOuterField.ok && /invalid wrap/.test(extraOuterField.reason))


### PR DESCRIPTION
## What changed

- gives every route-seal refusal a bounded, field-specific diagnosis without exposing encrypted content
- requires the signer response to contain exactly the seven canonical signed-event fields
- verifies a JSON wire copy so signer-specific object metadata cannot bypass signature validation
- adds negative controls for missing signer output and a validly signed but schema-widened seal

## Why

The deployed saved-session fix reached the owner signer successfully, but the live Alby response was refused by the exact route-seal boundary. The old generic error could not distinguish a missing event, invalid signature, identity change, field mutation, or schema widening. This preserves the fail-closed boundary while making the live incompatibility observable enough to repair safely.

## Evidence

- focused control/route suite: 42/42
- all 44 suites passed
- lint and `git diff --check` passed

Drafted with assistance from [Claude Code](https://claude.com/claude-code)
