### PR TITLE
Fix and diagnose Console route signer output

### DIFF
--- a/console/task-route-envelope.mjs
+++ b/console/task-route-envelope.mjs
@@ -1,5 +1,20 @@
 import { finalizeEvent, generateSecretKey, getEventHash, nip44, verifyEvent } from 'nostr-tools'
 
+const SIGNED_EVENT_KEYS = ['content', 'created_at', 'id', 'kind', 'pubkey', 'sig', 'tags']
+const wire = value => JSON.parse(JSON.stringify(value))
+
+function exactSeal(signed, draft, owner) {
+  let seal
+  try { seal = wire(signed) } catch { throw new Error('The signer did not return a Nostr event.') }
+  if (!seal || typeof seal !== 'object' || Array.isArray(seal)) throw new Error('The signer did not return a Nostr event.')
+  if (JSON.stringify(Object.keys(seal).sort()) !== JSON.stringify(SIGNED_EVENT_KEYS)) throw new Error('The signer added unsupported fields to the route seal.')
+  if (!verifyEvent(seal)) throw new Error('The signer returned a route seal with an invalid signature.')
+  if (seal.pubkey !== owner) throw new Error(`The signer switched identities while signing (expected ${owner.slice(0, 12)}…, received ${String(seal.pubkey).slice(0, 12)}…).`)
+  if (seal.kind !== draft.kind || seal.created_at !== draft.created_at || seal.content !== draft.content ||
+      JSON.stringify(seal.tags) !== JSON.stringify(draft.tags)) throw new Error('The signer altered the encrypted route seal before signing it.')
+  return seal
+}
+
 // Build the only route-control wire artifact: a signed owner seal inside an ephemeral gift wrap.
 // The returned event exposes only kind 1059 and the bridge p-tag. Every route field is encrypted.
 export async function sealedTaskRouteCommand(signer, bridge, body, now = Math.floor(Date.now() / 1000)) {
@@ -13,10 +28,7 @@ export async function sealedTaskRouteCommand(signer, bridge, body, now = Math.fl
   rumor.id = getEventHash(rumor)
   const encrypted = await signer.nip44Encrypt(bridge, JSON.stringify(rumor))
   const sealDraft = { kind:13, created_at:fuzzed(), tags:[], content:encrypted }
-  const seal = await signer.signEvent(sealDraft)
-  if (!seal || typeof seal !== 'object' || Array.isArray(seal) || !verifyEvent(seal) || seal.pubkey !== owner || seal.kind !== sealDraft.kind ||
-      seal.created_at !== sealDraft.created_at || seal.content !== sealDraft.content ||
-      JSON.stringify(seal.tags) !== JSON.stringify(sealDraft.tags)) throw new Error('The signer returned an invalid or altered route seal.')
+  const seal = exactSeal(await signer.signEvent(wire(sealDraft)), sealDraft, owner)
   const wrapKey = generateSecretKey()
   return finalizeEvent({ kind:1059, created_at:fuzzed(), tags:[['p',bridge]],
     content:nip44.encrypt(JSON.stringify(seal), nip44.getConversationKey(wrapKey, bridge)) }, wrapKey)

--- a/tests/control_state.mjs
+++ b/tests/control_state.mjs
@@ -193,8 +193,20 @@ let undefinedSealRefused = false
 try {
   await sealedTaskRouteCommand({ ...ownerSigner, signEvent: async () => undefined },
     getPublicKey(bridgeSk), taskBody('upsert'), routeAt)
-} catch (error) { undefinedSealRefused = /invalid or altered route seal/.test(error.message) }
+} catch (error) { undefinedSealRefused = /did not return a Nostr event/.test(error.message) }
 t('an injected signer that returns no event fails with a bounded route error', undefinedSealRefused)
+let switchedIdentityRefused = false
+try {
+  await sealedTaskRouteCommand({ ...ownerSigner, signEvent: async event => wire(finalizeEvent(event, bridgeSk)) },
+    getPublicKey(bridgeSk), taskBody('upsert'), routeAt)
+} catch (error) { switchedIdentityRefused = /switched identities/.test(error.message) }
+t('the Console names a signer identity switch instead of publishing it', switchedIdentityRefused)
+let widenedSealRefused = false
+try {
+  await sealedTaskRouteCommand({ ...ownerSigner, signEvent: async event => ({ ...wire(finalizeEvent(event, watchedSk)), client: 'injected' }) },
+    getPublicKey(bridgeSk), taskBody('upsert'), routeAt)
+} catch (error) { widenedSealRefused = /unsupported fields/.test(error.message) }
+t('the Console refuses signer-added fields outside the closed seal schema', widenedSealRefused)
 let alteredSealRefused = false
 try {
   await sealedTaskRouteCommand({ ...ownerSigner, signEvent: async event => wire(finalizeEvent({ ...event, content: 'substituted' }, watchedSk)) },


### PR DESCRIPTION
## What changed

- round-trips the returned signer event into wire form before validation
- enforces the closed seven-field signed-event schema
- distinguishes missing output, invalid signatures, signer identity switches, and policy-byte mutation
- adds negative controls for identity switching and signer-added fields

## Live reason

The owner approved the Codex task route, but the Console only reported “invalid or altered route seal.” This keeps the fail-closed boundary and makes the actual signer incompatibility actionable.

## Evidence

- `npm run lint`
- `node tests/control_state.mjs` — 43/43
- `git diff --check`

Review is requested privately in Buzz waggle-test only.