### PR TITLE
Make quarantine rendering deterministic for policy shadowing

### DIFF
--- a/docs/DESIGN_OFFBOX_BUZZ_POLICY.md
+++ b/docs/DESIGN_OFFBOX_BUZZ_POLICY.md
@@ -248,6 +248,10 @@ that the Buzz poster key is off the bridge host:
 2. For each family in §5, add positive, hostile-evidence, replay, concurrent, restart, stale-policy,
    Bunker-mismatch, ambiguous-submit, and compromised-requester tests.
 3. Run local and remote paths in shadow mode; require identical derived event bytes and decisions.
+   For `quarantine_header`, both paths call the same source-only projection: the signed kind:1
+   supplies body, author, source timestamp, reply target, and source id. Replaceable kind:0 data and
+   local clock clamping are excluded from authored bytes; one captured `observed_at` will supply the
+   unsigned kind:9 timestamp to both paths during the shadow transaction.
 4. Enable remote-only for one family. Failure must hold; it must never fall back to the local key.
 5. Prove a live post and withdrawal, verify the signed receipts, then repeat for every family.
 6. Remove `BUZZ_PRIVATE_KEY` and the Buzz CLI write capability from both waggle lanes.

--- a/src/bridge.mjs
+++ b/src/bridge.mjs
@@ -51,6 +51,7 @@ import { markLatency } from './latency.mjs'
 import { durableSet, durableQueue } from './stores.mjs'
 import { fanout } from './fanout.mjs'
 import { recipientDmRelays } from './dm_relays.mjs'
+import { quarantineSlotsFromSource } from './buzz_policy_core.mjs'
 import { defuseRefs, defuseMarkup, quoted, renderQuarantined, renderReleased } from './render.mjs'
 import { hex as concordHex, publicChannel, openChannelWrap } from './concord_lib.mjs'
 
@@ -1111,7 +1112,7 @@ async function forwardPublic(ev, why, dest, quarantine) {
   // resolve a later reply to it. Keyed on the agent's real key, never on the bridge that signs it.
   const agent = PUB ? ((activeReturnLane().find(r => r.npub_hex === String(ev.pubkey || '').toLowerCase()) || {}).npub_hex || null) : null
   const nowSec = Math.floor(Date.now() / 1000)
-  const { clamped, outOfRange } = clampCreated(ev.created_at, nowSec)
+  const { outOfRange } = clampCreated(ev.created_at, nowSec)
   if (FORWARD_MODE !== 'buzz') {
     log(`PUBLIC[dryrun] -> ${quarantine ? 'STAGING' : 'inbox'} ${dest}: kind1 ${ev.id.slice(0, 12)}… by ${author}… (${why})${outOfRange ? ' [clamped]' : ''} :: ${JSON.stringify((ev.content || '').slice(0, 80))}`)
     return
@@ -1123,7 +1124,10 @@ async function forwardPublic(ev, why, dest, quarantine) {
   // sanitized, rendered outside the fence) plus the npub, which is what a reader can
   // actually paste into a client. Best-effort with a 2s budget; falls back to npub alone.
   let name = null
-  if (!process.env.WB_STUB_SEND) { try { name = await fetchProfileName(ev.pubkey) } catch { name = null } }
+  // Quarantine is the first remote-policy migration family. Its authored bytes are source-only:
+  // a relay-selected kind:0 or local clock clamp would make an exact local/remote shadow
+  // comparison impossible and let host state choose participant-visible policy output.
+  if (!quarantine && !process.env.WB_STUB_SEND) { try { name = await fetchProfileName(ev.pubkey) } catch { name = null } }
   let npub = null
   try { npub = nip19.npubEncode(ev.pubkey) } catch { npub = null }
   // Heavily contracted npub for the attribution line — enough to recognize/verify, not a wall.
@@ -1137,16 +1141,7 @@ async function forwardPublic(ev, why, dest, quarantine) {
     ? {
       template: 'quarantine_header',
       dest,
-      slots: {
-        body,
-        approver: (quarantine && PUB.approverMention) || undefined,
-        name,
-        npub: npub || ev.pubkey,
-        ts: clamped,
-        claimedTs: outOfRange && ev.created_at ? Number(ev.created_at) : undefined,
-        why,
-        id: ev.id,
-      },
+      slots: quarantineSlotsFromSource(ev, { approverMention: PUB.approverMention }),
     }
     : { template: 'released_post', dest, slots: { body, name, npubShort, liveRefs } }
   // Test seam: exercise the full buzz-mode path (markSeen/watermark/posted-map) without a

--- a/src/buzz_policy_core.mjs
+++ b/src/buzz_policy_core.mjs
@@ -11,6 +11,10 @@ export const BUZZ_POLICY_OPERATIONS = Object.freeze(['quarantine_header'])
 const HEX64 = /^[0-9a-f]{64}$/
 const ID = /^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/
 const EVENT_KEYS = new Set(['id', 'pubkey', 'created_at', 'kind', 'tags', 'content', 'sig'])
+// ECMAScript Date's TimeClip boundary is ±8.64e15 milliseconds. Quarantine rendering
+// intentionally preserves the source timestamp, so refuse signed-but-unrenderable seconds at
+// policy admission rather than letting catalogue rendering throw after a decision is minted.
+const MAX_RENDERABLE_UNIX_SECONDS = 8_640_000_000_000
 const REQUEST_KEYS = new Set(['version', 'policy_instance', 'operation', 'catalogue_version', 'observed_at', 'evidence'])
 const EVIDENCE_KEYS = Object.freeze({ quarantine_header: new Set(['source_event']) })
 const POLICY_REQUESTS = new WeakSet()
@@ -48,7 +52,8 @@ function verifyWireEvent(event) {
   exactKeys(event, EVENT_KEYS, 'source_event')
   if (!HEX64.test(String(event.id || '')) || !HEX64.test(String(event.pubkey || '')) ||
       !/^[0-9a-f]{128}$/.test(String(event.sig || '')) || !Number.isSafeInteger(event.created_at) ||
-      event.created_at < 0 || event.kind !== 1 || !Array.isArray(event.tags) ||
+      event.created_at < 0 || event.created_at > MAX_RENDERABLE_UNIX_SECONDS ||
+      event.kind !== 1 || !Array.isArray(event.tags) ||
       typeof event.content !== 'string') fail('source_event is not a complete kind:1 wire event')
   if (!event.tags.every(tag => Array.isArray(tag) && tag.every(value => typeof value === 'string'))) fail('source_event has malformed tags')
   let valid = false

--- a/src/buzz_policy_core.mjs
+++ b/src/buzz_policy_core.mjs
@@ -87,6 +87,23 @@ const channel = value => {
   return text
 }
 
+// The local bridge and off-box policy must derive the quarantine body from one implementation.
+// Only the complete signed source may choose participant-visible bytes: no relay-selected kind:0,
+// local clock clamp, or host-supplied display name can make shadow outputs diverge.
+export function quarantineSlotsFromSource(sourceEvent, { approverMention = '' } = {}) {
+  const source = verifyWireEvent(JSON.parse(JSON.stringify(sourceEvent)))
+  return Object.freeze({
+    body: source.content,
+    approver: approverMention || undefined,
+    name: undefined,
+    npub: npubEncode(source.pubkey),
+    ts: source.created_at,
+    claimedTs: undefined,
+    why: 'reply to our note',
+    id: source.id,
+  })
+}
+
 // First operation family: a signed public reply to one of the policy service's own watched
 // event ids.  The requester cannot pick the route, state, display name, body, or attribution;
 // all are derived from the complete signed source and policy-owned state.
@@ -100,16 +117,7 @@ export function decideQuarantineHeader(request, { stagingChannel, watchedEventId
   const decision = Object.freeze({
     template: 'quarantine_header',
     dest: channel(stagingChannel),
-    slots: Object.freeze({
-      body: source.content,
-      approver: approverMention || undefined,
-      name: undefined,
-      npub: npubEncode(source.pubkey),
-      ts: source.created_at,
-      claimedTs: undefined,
-      why: 'reply to our note',
-      id: source.id,
-    }),
+    slots: quarantineSlotsFromSource(source, { approverMention }),
   })
   POLICY_DECISIONS.add(decision)
   DECISION_REQUESTS.set(decision, request)

--- a/tests/offbox_policy_core.mjs
+++ b/tests/offbox_policy_core.mjs
@@ -1,5 +1,5 @@
 import { generateSecretKey, finalizeEvent } from 'nostr-tools/pure'
-import { BUZZ_POLICY_VERSION, canonicalJson, decodePolicyRequest, decideQuarantineHeader, policyIdempotencyKey } from '../src/buzz_policy_core.mjs'
+import { BUZZ_POLICY_VERSION, canonicalJson, decodePolicyRequest, decideQuarantineHeader, policyIdempotencyKey, quarantineSlotsFromSource } from '../src/buzz_policy_core.mjs'
 
 let fails = 0
 const t = (name, ok) => { console.log(`${ok ? 'ok  ' : 'FAIL'} — ${name}`); if (!ok) fails++ }
@@ -31,6 +31,9 @@ rejects('tampered source evidence is refused', () => decodePolicyRequest(canonic
 const decision = decideQuarantineHeader(decoded, { stagingChannel: channel, watchedEventIds: [watched], approverMention: 'jafairweather' })
 t('destination comes only from policy state', decision.dest === channel)
 t('body and attribution come only from the signed source', decision.slots.body === source.content && decision.slots.id === source.id)
+t('quarantine rendering uses the signed source timestamp without host clamping', decision.slots.ts === source.created_at && decision.slots.claimedTs === undefined)
+t('quarantine rendering refuses relay-selected profile decoration', decision.slots.name === undefined && decision.slots.npub.startsWith('npub1'))
+t('the local and remote paths share one byte projection', JSON.stringify(decision.slots) === JSON.stringify(quarantineSlotsFromSource(source, { approverMention: 'jafairweather' })))
 t('the policy derives quarantine reason rather than accepting a route assertion', decision.slots.why === 'reply to our note')
 rejects('an unrelated signed public note cannot be routed', () => decideQuarantineHeader(decoded, { stagingChannel: channel, watchedEventIds: ['f'.repeat(64)] }), /not a reply/)
 

--- a/tests/offbox_policy_core.mjs
+++ b/tests/offbox_policy_core.mjs
@@ -27,6 +27,11 @@ rejects('unsafe numeric evidence cannot enter canonical policy input', () => can
 rejects('oversize input is refused before evidence verification', () => decodePolicyRequest(' '.repeat(128 * 1024 + 1), opts), /exceeds/)
 const forged = { ...source, content: 'changed after signing' }
 rejects('tampered source evidence is refused', () => decodePolicyRequest(canonicalJson({ ...packet, evidence: { source_event: forged } }), opts), /signature or id/)
+const edgeSource = JSON.parse(JSON.stringify(finalizeEvent({ kind: 1, created_at: 8_640_000_000_000, tags: [['e', watched]], content: 'last renderable instant' }, generateSecretKey())))
+const edgeDecoded = decodePolicyRequest(canonicalJson({ ...packet, evidence: { source_event: edgeSource } }), opts)
+t('the last ECMAScript-renderable source timestamp is accepted', quarantineSlotsFromSource(edgeDecoded.evidence.source_event).ts === edgeSource.created_at)
+const beyondDateSource = JSON.parse(JSON.stringify(finalizeEvent({ kind: 1, created_at: 8_640_000_000_001, tags: [['e', watched]], content: 'signed but not renderable' }, generateSecretKey())))
+rejects('a signed source timestamp beyond the catalogue Date boundary is refused', () => decodePolicyRequest(canonicalJson({ ...packet, evidence: { source_event: beyondDateSource } }), opts), /complete kind:1/)
 
 const decision = decideQuarantineHeader(decoded, { stagingChannel: channel, watchedEventIds: [watched], approverMention: 'jafairweather' })
 t('destination comes only from policy state', decision.dest === channel)


### PR DESCRIPTION
## What changed

- gives the local bridge and off-box policy one shared source-only `quarantine_header` projection
- derives body, participant identity, timestamp, reason, and source id only from the complete signed kind:1
- excludes relay-selected kind:0 decoration and local clock clamping from authored quarantine bytes
- records the shared projection and single-`observed_at` migration gate in the #54 design

## Why

Exact shadow comparison is meaningless if local and remote paths are allowed to select different profile events or sample different clocks. This is the crew-selected source-only prerequisite; it does not enable remote-only routing.

## Evidence

- focused off-box policy core checks pass
- all 44 suites pass with `config.example.json`
- lint and `git diff --check` pass

Review discussion belongs only in private Buzz `waggle-test`.

Drafted with assistance from [Claude Code](https://claude.com/claude-code)