### PR TITLE
Add credential-free derive-only policy shadow

### DIFF
--- a/deploy/POLICY_HOST.md
+++ b/deploy/POLICY_HOST.md
@@ -11,23 +11,29 @@ The identities are deliberately split:
 - `waggle-policy` has no login shell. A sandboxed socket-activated process reads the fixed policy
   and NIP-46 pairing, writes only `/var/lib/waggle-policy/journal`, signs through Bunker, and submits
   directly to the fixed Buzz `/events` endpoint.
+- `waggle-policy-shadow-ingress` uses a different SSH key and is forced only into the derive-only
+  socket. `waggle-policy-shadow` receives one projection policy, has only `AF_UNIX`, no writable
+  path, signer, journal, recovery authority, or endpoint, and returns only a comparison digest.
 - `root` owns the release, policy, SSH key file, service environment, and credential files. Neither
   runtime identity can replace code or widen policy.
 
 This is a policy-host installation guide, not permission to cut production over. Shadow comparison,
 all operation families, and the migration gates in `docs/DESIGN_OFFBOX_BUZZ_POLICY.md` still apply.
 
-## 1. Dedicated ingress key
+## 1. Dedicated ingress keys
 
 On the Waggle host, mint a key used for this forced command only:
 
 ```sh
 install -d -m 0700 /etc/waggle/policy-client
 ssh-keygen -t ed25519 -N '' -f /etc/waggle/policy-client/id_ed25519 -C waggle-policy-ingress
+ssh-keygen -t ed25519 -N '' -f /etc/waggle/policy-client/shadow_ed25519 -C waggle-policy-shadow-ingress
 chmod 0600 /etc/waggle/policy-client/id_ed25519
+chmod 0600 /etc/waggle/policy-client/shadow_ed25519
 ```
 
-Copy only `id_ed25519.pub` to the policy-host operator. Do not reuse a management or deploy key.
+Copy only the two `.pub` files to the policy-host operator. The live and shadow keys must differ;
+do not reuse either as a management or deploy key.
 
 ## 2. Root-owned reviewed release
 
@@ -41,6 +47,7 @@ From that release tree, as root:
 
 ```sh
 WAGGLE_POLICY_CLIENT_PUB="$(cat /secure-transfer/id_ed25519.pub)" \
+WAGGLE_POLICY_SHADOW_CLIENT_PUB="$(cat /secure-transfer/shadow_ed25519.pub)" \
   sh deploy/policy-host-install.sh
 ```
 
@@ -68,6 +75,11 @@ Create `/etc/waggle-policy/policy.json` as `root:root` mode `0600`:
 }
 ```
 
+Create `/etc/waggle-policy/shadow-policy.json` as `root:root` mode `0600`. It repeats only the
+projection fields—`version`, `policy_instance`, `catalogue_version`, `staging_channel`,
+`watched_event_ids`, `approver_mention`, `poster_pubkey`, and `auth_tag`. It must not contain
+`endpoint`, `journal_path`, Bunker information, recovery state, or any credential path.
+
 Install the Bunker pairing as two separate `root:root` mode `0600` regular files—never
 symlinks:
 
@@ -93,13 +105,15 @@ Allow the policy identity/host only what the configured operation needs:
 - TCP 443 to the fixed Buzz host and the Bunker URI's relay hosts;
 - NTP for signature/freshness correctness.
 
-The Waggle host must not reach Bunker directly. It may SSH only as `waggle-policy-ingress` to the
-policy host. The policy host does not accept management through that identity.
+The Waggle host must not reach Bunker directly. Its live key may SSH only as
+`waggle-policy-ingress`; its separate comparison key may SSH only as
+`waggle-policy-shadow-ingress`. Neither identity is a management principal.
 
 ## 5. Arm and prove
 
 ```sh
 systemctl enable --now waggle-policy.socket
+systemctl enable --now waggle-policy-shadow.socket
 sh /opt/waggle-policy/deploy/verify-policy-host.sh
 ```
 
@@ -118,3 +132,5 @@ From the Waggle host, send a canonical fixture through the forced identity. Veri
 
 Do not enable a bridge remote-only route until shadow output matches the local path and its operation
 family has every positive, hostile, replay, restart, ambiguity, and withdrawal test required by §10.
+For shadow comparison, use the shadow response's `evaluation_time` for the local projection and
+compare its `decision` and `unsigned_event_sha256`; never compare or request signature bytes.

--- a/deploy/policy-host-install.sh
+++ b/deploy/policy-host-install.sh
@@ -11,7 +11,15 @@ esac
 case "$SHADOW_PUB" in ssh-ed25519\ *|ecdsa-*\ *) : ;; *)
   echo "set WAGGLE_POLICY_SHADOW_CLIENT_PUB to a distinct derive-only SSH public key" >&2; exit 2 ;;
 esac
-test "$PUB" != "$SHADOW_PUB" || { echo "live and shadow ingress keys must be distinct" >&2; exit 2; }
+key_identity() {
+  # OpenSSH comments are labels, not key identity. Compare algorithm + key blob so the same
+  # private key cannot authenticate to both the write-capable and derive-only accounts.
+  printf '%s\n' "$1" | awk 'NF >= 2 { print $1 " " $2; exit }'
+}
+PUB_ID=$(key_identity "$PUB")
+SHADOW_PUB_ID=$(key_identity "$SHADOW_PUB")
+test -n "$PUB_ID" && test -n "$SHADOW_PUB_ID" || { echo "ingress SSH keys are malformed" >&2; exit 2; }
+test "$PUB_ID" != "$SHADOW_PUB_ID" || { echo "live and shadow ingress keys must be distinct" >&2; exit 2; }
 ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
 test "$(id -u)" -eq 0 || { echo "run as root on the policy host" >&2; exit 2; }
 test -f "$ROOT/tools/buzz-policy-service.mjs" && test -f "$ROOT/tools/buzz-policy-forward.mjs" &&

--- a/deploy/policy-host-install.sh
+++ b/deploy/policy-host-install.sh
@@ -4,12 +4,18 @@
 set -eu
 
 PUB=${WAGGLE_POLICY_CLIENT_PUB:-}
+SHADOW_PUB=${WAGGLE_POLICY_SHADOW_CLIENT_PUB:-}
 case "$PUB" in ssh-ed25519\ *|ecdsa-*\ *) : ;; *)
   echo "set WAGGLE_POLICY_CLIENT_PUB to the Waggle host's dedicated SSH public key" >&2; exit 2 ;;
 esac
+case "$SHADOW_PUB" in ssh-ed25519\ *|ecdsa-*\ *) : ;; *)
+  echo "set WAGGLE_POLICY_SHADOW_CLIENT_PUB to a distinct derive-only SSH public key" >&2; exit 2 ;;
+esac
+test "$PUB" != "$SHADOW_PUB" || { echo "live and shadow ingress keys must be distinct" >&2; exit 2; }
 ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
 test "$(id -u)" -eq 0 || { echo "run as root on the policy host" >&2; exit 2; }
-test -f "$ROOT/tools/buzz-policy-service.mjs" && test -f "$ROOT/tools/buzz-policy-forward.mjs" || {
+test -f "$ROOT/tools/buzz-policy-service.mjs" && test -f "$ROOT/tools/buzz-policy-forward.mjs" &&
+  test -f "$ROOT/tools/buzz-policy-shadow.mjs" && test -f "$ROOT/tools/buzz-policy-shadow-forward.mjs" || {
   echo "run from a complete, reviewed Waggle release tree" >&2; exit 2; }
 test "$ROOT" = /opt/waggle-policy || { echo "the reviewed release must be installed at /opt/waggle-policy" >&2; exit 2; }
 test ! -e "$ROOT/.git" || { echo "deploy an exported release, not a mutable git worktree" >&2; exit 2; }
@@ -22,8 +28,12 @@ fi
 
 getent group waggle-policy >/dev/null 2>&1 || groupadd --system waggle-policy
 getent group waggle-policy-ingress >/dev/null 2>&1 || groupadd --system waggle-policy-ingress
+getent group waggle-policy-shadow >/dev/null 2>&1 || groupadd --system waggle-policy-shadow
+getent group waggle-policy-shadow-ingress >/dev/null 2>&1 || groupadd --system waggle-policy-shadow-ingress
 id waggle-policy >/dev/null 2>&1 || useradd --system --gid waggle-policy --home-dir /nonexistent --shell /usr/sbin/nologin waggle-policy
 id waggle-policy-ingress >/dev/null 2>&1 || useradd --system --gid waggle-policy-ingress --home-dir /nonexistent --shell /bin/sh waggle-policy-ingress
+id waggle-policy-shadow >/dev/null 2>&1 || useradd --system --gid waggle-policy-shadow --home-dir /nonexistent --shell /usr/sbin/nologin waggle-policy-shadow
+id waggle-policy-shadow-ingress >/dev/null 2>&1 || useradd --system --gid waggle-policy-shadow-ingress --home-dir /nonexistent --shell /bin/sh waggle-policy-shadow-ingress
 
 install -d -m 0755 -o root -g root /opt/waggle-policy
 install -d -m 0700 -o root -g root /etc/waggle-policy /etc/waggle-policy/credentials
@@ -35,6 +45,9 @@ chmod 0600 /etc/waggle-policy/release.sha256
 printf 'restrict %s\n' "$PUB" > /etc/ssh/authorized_keys/waggle-policy-ingress
 chown root:root /etc/ssh/authorized_keys/waggle-policy-ingress
 chmod 0600 /etc/ssh/authorized_keys/waggle-policy-ingress
+printf 'restrict %s\n' "$SHADOW_PUB" > /etc/ssh/authorized_keys/waggle-policy-shadow-ingress
+chown root:root /etc/ssh/authorized_keys/waggle-policy-shadow-ingress
+chmod 0600 /etc/ssh/authorized_keys/waggle-policy-shadow-ingress
 
 install -m 0644 -o root -g root "$ROOT/deploy/sshd-waggle-policy.conf" /etc/ssh/sshd_config.d/60-waggle-policy.conf
 SSHD=$(command -v sshd)
@@ -44,7 +57,9 @@ systemctl reload ssh.service 2>/dev/null || systemctl reload sshd.service
 install -m 0644 -o root -g root "$ROOT/deploy/waggle-policy.socket" /etc/systemd/system/waggle-policy.socket
 install -m 0644 -o root -g root "$ROOT/deploy/waggle-policy@.service" /etc/systemd/system/waggle-policy@.service
 install -m 0644 -o root -g root "$ROOT/deploy/waggle-policy.slice" /etc/systemd/system/waggle-policy.slice
+install -m 0644 -o root -g root "$ROOT/deploy/waggle-policy-shadow.socket" /etc/systemd/system/waggle-policy-shadow.socket
+install -m 0644 -o root -g root "$ROOT/deploy/waggle-policy-shadow@.service" /etc/systemd/system/waggle-policy-shadow@.service
 systemctl daemon-reload
 
 echo "policy-host identities, forced SSH capability, socket, and state tree installed"
-echo "NEXT: install a root-owned release at /opt/waggle-policy; create the four 0600 root:root files documented in deploy/POLICY_HOST.md; run the verifier; only then enable waggle-policy.socket"
+echo "NEXT: install the owner-controlled 0600 policy files documented in deploy/POLICY_HOST.md; run the verifier; only then enable either socket"

--- a/deploy/sshd-waggle-policy.conf
+++ b/deploy/sshd-waggle-policy.conf
@@ -14,3 +14,19 @@ Match User waggle-policy-ingress
     PermitTunnel no
     GatewayPorts no
     ForceCommand /usr/bin/node /opt/waggle-policy/tools/buzz-policy-forward.mjs
+
+# A different key and account can invoke only the derive-only shadow socket. It cannot reach the
+# live submission socket even if the bridge selects an SSH command of its own.
+Match User waggle-policy-shadow-ingress
+    AuthorizedKeysFile /etc/ssh/authorized_keys/waggle-policy-shadow-ingress
+    AuthenticationMethods publickey
+    PasswordAuthentication no
+    KbdInteractiveAuthentication no
+    PermitTTY no
+    AllowAgentForwarding no
+    AllowTcpForwarding no
+    AllowStreamLocalForwarding no
+    X11Forwarding no
+    PermitTunnel no
+    GatewayPorts no
+    ForceCommand /usr/bin/node /opt/waggle-policy/tools/buzz-policy-shadow-forward.mjs

--- a/deploy/verify-policy-host.sh
+++ b/deploy/verify-policy-host.sh
@@ -5,10 +5,14 @@ ok() { echo "  ok   $1"; }
 bad() { echo "  FAIL $1" >&2; fail=$((fail + 1)); }
 
 test "$(stat -c '%U:%G %a' /etc/ssh/authorized_keys/waggle-policy-ingress 2>/dev/null)" = 'root:root 600' && ok 'root-owned ingress key' || bad 'ingress key ownership/mode'
+test "$(stat -c '%U:%G %a' /etc/ssh/authorized_keys/waggle-policy-shadow-ingress 2>/dev/null)" = 'root:root 600' && ok 'root-owned shadow ingress key' || bad 'shadow ingress key ownership/mode'
 grep -q '^Match User waggle-policy-ingress$' /etc/ssh/sshd_config.d/60-waggle-policy.conf 2>/dev/null &&
   grep -q '^    ForceCommand /usr/bin/node /opt/waggle-policy/tools/buzz-policy-forward.mjs$' /etc/ssh/sshd_config.d/60-waggle-policy.conf && ok 'fixed SSH command' || bad 'fixed SSH command'
+grep -q '^Match User waggle-policy-shadow-ingress$' /etc/ssh/sshd_config.d/60-waggle-policy.conf 2>/dev/null &&
+  grep -q '^    ForceCommand /usr/bin/node /opt/waggle-policy/tools/buzz-policy-shadow-forward.mjs$' /etc/ssh/sshd_config.d/60-waggle-policy.conf && ok 'fixed shadow SSH command' || bad 'fixed shadow SSH command'
 sshd -t && ok 'sshd configuration parses' || bad 'sshd configuration'
 test "$(stat -c '%U:%G %a' /etc/waggle-policy/policy.json 2>/dev/null)" = 'root:root 600' && ok 'fixed policy config' || bad 'policy config ownership/mode'
+test "$(stat -c '%U:%G %a' /etc/waggle-policy/shadow-policy.json 2>/dev/null)" = 'root:root 600' && ok 'fixed shadow policy config' || bad 'shadow policy config ownership/mode'
 for file in poster.bunker-uri poster.client-nsec recovery.secret; do
   test "$(stat -c '%U:%G %a' "/etc/waggle-policy/credentials/$file" 2>/dev/null)" = 'root:root 600' && ok "$file" || bad "$file ownership/mode"
 done
@@ -17,8 +21,10 @@ test "$(stat -c '%U:%G %a' /etc/waggle-policy/release.sha256 2>/dev/null)" = 'ro
 if find /opt/waggle-policy -xdev -type l -print -quit 2>/dev/null | grep -q .; then bad 'runtime release contains a symlink'; else ok 'runtime release has no symlinks'; fi
 if find /opt/waggle-policy -xdev \( ! -user root -o ! -group root -o -perm /022 \) -print -quit 2>/dev/null | grep -q .; then bad 'runtime release ownership/mode'; else ok 'entire runtime release is root-owned and immutable to service users'; fi
 (cd /opt/waggle-policy && sha256sum -c /etc/waggle-policy/release.sha256 >/dev/null) && ok 'entire runtime release matches reviewed manifest' || bad 'runtime release digest drift'
-systemd-analyze verify /etc/systemd/system/waggle-policy.socket /etc/systemd/system/waggle-policy@.service /etc/systemd/system/waggle-policy.slice >/dev/null && ok 'systemd units verify' || bad 'systemd units'
+systemd-analyze verify /etc/systemd/system/waggle-policy.socket /etc/systemd/system/waggle-policy@.service /etc/systemd/system/waggle-policy-shadow.socket /etc/systemd/system/waggle-policy-shadow@.service /etc/systemd/system/waggle-policy.slice >/dev/null && ok 'systemd units verify' || bad 'systemd units'
 systemctl is-enabled --quiet waggle-policy.socket && ok 'request socket enabled' || bad 'request socket not enabled'
 systemctl is-active --quiet waggle-policy.socket && ok 'request socket active' || bad 'request socket not active'
+systemctl is-enabled --quiet waggle-policy-shadow.socket && ok 'shadow socket enabled' || bad 'shadow socket not enabled'
+systemctl is-active --quiet waggle-policy-shadow.socket && ok 'shadow socket active' || bad 'shadow socket not active'
 test "$fail" -eq 0 || exit 1
 echo 'policy host: all gates passed'

--- a/deploy/waggle-policy-shadow.socket
+++ b/deploy/waggle-policy-shadow.socket
@@ -1,0 +1,15 @@
+[Unit]
+Description=waggle derive-only policy shadow socket
+
+[Socket]
+ListenStream=/run/waggle-policy-shadow/request.sock
+SocketUser=waggle-policy-shadow
+SocketGroup=waggle-policy-shadow-ingress
+SocketMode=0660
+Accept=yes
+RemoveOnStop=yes
+MaxConnections=4
+MaxConnectionsPerSource=2
+
+[Install]
+WantedBy=sockets.target

--- a/deploy/waggle-policy-shadow@.service
+++ b/deploy/waggle-policy-shadow@.service
@@ -1,0 +1,38 @@
+[Unit]
+Description=waggle derive-only policy shadow transaction
+
+[Service]
+Slice=waggle-policy.slice
+User=waggle-policy-shadow
+Group=waggle-policy-shadow
+WorkingDirectory=/opt/waggle-policy
+ExecStart=/usr/bin/node /opt/waggle-policy/tools/buzz-policy-shadow.mjs
+LoadCredential=shadow-policy.json:/etc/waggle-policy/shadow-policy.json
+Environment=WAGGLE_POLICY_SHADOW_CONFIG_FILE=%d/shadow-policy.json
+StandardInput=socket
+StandardOutput=socket
+StandardError=journal
+TimeoutStartSec=20
+RuntimeMaxSec=15
+UMask=0077
+MemoryMax=128M
+TasksMax=12
+CPUQuota=100%
+
+# This is a pure comparison service: immutable code + one fixed policy file, no writable path,
+# signer credential, recovery authority, Buzz endpoint access, or network socket family.
+NoNewPrivileges=yes
+ProtectSystem=strict
+ProtectHome=yes
+PrivateTmp=yes
+PrivateDevices=yes
+ProtectClock=yes
+ProtectControlGroups=yes
+ProtectKernelLogs=yes
+ProtectKernelModules=yes
+ProtectKernelTunables=yes
+ProtectHostname=yes
+RestrictSUIDSGID=yes
+LockPersonality=yes
+RestrictAddressFamilies=AF_UNIX
+ReadOnlyPaths=/opt/waggle-policy

--- a/docs/DESIGN_OFFBOX_BUZZ_POLICY.md
+++ b/docs/DESIGN_OFFBOX_BUZZ_POLICY.md
@@ -248,6 +248,12 @@ that the Buzz poster key is off the bridge host:
 2. For each family in §5, add positive, hostile-evidence, replay, concurrent, restart, stale-policy,
    Bunker-mismatch, ambiguous-submit, and compromised-requester tests.
 3. Run local and remote paths in shadow mode; require identical derived event bytes and decisions.
+   Shadow uses a separate SSH key, forced command, socket, and networkless unit with no signer,
+   recovery, journal, endpoint, or writable path. It returns only a canonical comparison record.
+   Here “derived event bytes” means the canonical unsigned Nostr preimage
+   `[0,pubkey,created_at,kind,tags,content]`, never a signed event. The shadow host chooses
+   `evaluation_time`; the bridge reruns the local projection at that remote-owned time and compares
+   the decision plus SHA-256 preimage digest.
    For `quarantine_header`, both paths call the same source-only projection: the signed kind:1
    supplies body, author, source timestamp, reply target, and source id. Replaceable kind:0 data and
    local clock clamping are excluded from authored bytes; one captured `observed_at` will supply the

--- a/src/buzz_policy_artifacts.mjs
+++ b/src/buzz_policy_artifacts.mjs
@@ -3,11 +3,8 @@
 // here and every signer result is verified exactly.
 import { createHash } from 'node:crypto'
 import { verifyEvent } from 'nostr-tools/pure'
-import { schnorr } from '@noble/curves/secp256k1'
-import { sha256 } from '@noble/hashes/sha256'
-import { hexToBytes, utf8ToBytes } from '@noble/hashes/utils'
 import { assertPolicyDecision, canonicalJson } from './buzz_policy_core.mjs'
-import { renderTemplate } from './egress.mjs'
+import { buildBuzzEvent as projectBuzzEvent, createProjectionPolicy } from './buzz_policy_projection.mjs'
 
 const HEX64 = /^[0-9a-f]{64}$/, HEX128 = /^[0-9a-f]{128}$/
 const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
@@ -38,18 +35,16 @@ const ARTIFACT_POLICIES = new WeakSet()
 const submitFailure = (message, outcome, responseDigest = '') => Object.assign(new Error(`buzz-policy-artifact: ${message}`), { outcome, responseDigest })
 
 export function createArtifactPolicy({ posterPubkey, authTag, endpoint, timeoutMs = 15_000, maxResponseBytes = 64 * 1024, nip98MaxAgeSec = 60 } = {}) {
-  const poster = hex(posterPubkey, 'posterPubkey')
-  if (!Array.isArray(authTag) || authTag.length !== 4 || authTag[0] !== 'auth' || !authTag.every(value => typeof value === 'string')) fail('authTag must be the fixed four-field NIP-OA tag')
-  const owner = hex(authTag[1], 'authTag owner'), signature = hex(authTag[3], 'authTag signature', HEX128)
-  const attestation = sha256(utf8ToBytes(`nostr:agent-auth:${poster}:${authTag[2]}`))
-  if (!schnorr.verify(hexToBytes(signature), attestation, hexToBytes(owner))) fail('authTag owner signature is invalid for this poster')
+  let projection
+  try { projection = createProjectionPolicy({ posterPubkey, authTag }) }
+  catch (error) { fail(String(error?.message || 'projection policy is invalid').replace(/^buzz-policy-projection: /, '')) }
   let url; try { url = new URL(String(endpoint || '')) } catch { fail('endpoint is invalid') }
   if (url.protocol !== 'https:' || url.username || url.password || url.hash || url.search || url.pathname !== '/events') fail('endpoint must be the fixed HTTPS origin /events URL')
   if (!Number.isSafeInteger(timeoutMs) || timeoutMs < 1_000 || timeoutMs > 30_000) fail('timeoutMs is outside the policy bounds')
   if (!Number.isSafeInteger(maxResponseBytes) || maxResponseBytes < 1_024 || maxResponseBytes > 256 * 1024) fail('maxResponseBytes is outside the policy bounds')
   if (!Number.isSafeInteger(nip98MaxAgeSec) || nip98MaxAgeSec < 5 || nip98MaxAgeSec > 300) fail('nip98MaxAgeSec is outside the policy bounds')
-  const policy = Object.freeze({ posterPubkey: poster, authTag: Object.freeze([...authTag]), endpoint: url.toString(), endpointAuthority: url.host,
-    timeoutMs, maxResponseBytes, nip98MaxAgeSec })
+  const policy = Object.freeze({ posterPubkey: projection.posterPubkey, authTag: projection.authTag, projection,
+    endpoint: url.toString(), endpointAuthority: url.host, timeoutMs, maxResponseBytes, nip98MaxAgeSec })
   ARTIFACT_POLICIES.add(policy)
   return policy
 }
@@ -60,10 +55,8 @@ const artifactPolicy = policy => {
 }
 
 export function buildBuzzEvent(decision, policy, { now = Math.floor(Date.now() / 1000) } = {}) {
-  assertPolicyDecision(decision); artifactPolicy(policy)
-  if (decision.template !== 'quarantine_header' || !UUID.test(String(decision.dest || ''))) fail('decision is not a closed quarantine destination')
-  return Object.freeze({ kind: 9, created_at: timestamp(now), content: renderTemplate(decision.template, decision.slots),
-    tags: Object.freeze([Object.freeze(['h', decision.dest]), policy.authTag]), pubkey: policy.posterPubkey })
+  artifactPolicy(policy)
+  return projectBuzzEvent(decision, policy.projection, { now })
 }
 
 async function signExact(unsigned, signer, label) {

--- a/src/buzz_policy_projection.mjs
+++ b/src/buzz_policy_projection.mjs
@@ -1,0 +1,56 @@
+// Credential-free authored-byte projection shared by the live off-box writer and its
+// derive-only shadow. This module cannot sign, submit, journal, or load credentials.
+import { createHash } from 'node:crypto'
+import { schnorr } from '@noble/curves/secp256k1'
+import { sha256 } from '@noble/hashes/sha256'
+import { hexToBytes, utf8ToBytes } from '@noble/hashes/utils'
+import { assertPolicyDecision, canonicalJson } from './buzz_policy_core.mjs'
+import { renderQuarantineHeader } from './quarantine_projection.mjs'
+
+const HEX64 = /^[0-9a-f]{64}$/, HEX128 = /^[0-9a-f]{128}$/
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
+const PROJECTION_POLICIES = new WeakSet()
+const fail = message => { throw new Error(`buzz-policy-projection: ${message}`) }
+const hex = (value, label, pattern = HEX64) => {
+  const text = String(value || '').toLowerCase()
+  if (!pattern.test(text)) fail(`${label} is invalid`)
+  return text
+}
+const timestamp = value => {
+  if (!Number.isSafeInteger(value) || value < 0) fail('timestamp is invalid')
+  return value
+}
+
+export function createProjectionPolicy({ posterPubkey, authTag } = {}) {
+  const poster = hex(posterPubkey, 'posterPubkey')
+  if (!Array.isArray(authTag) || authTag.length !== 4 || authTag[0] !== 'auth' ||
+      !authTag.every(value => typeof value === 'string')) fail('authTag must be the fixed four-field NIP-OA tag')
+  const owner = hex(authTag[1], 'authTag owner'), signature = hex(authTag[3], 'authTag signature', HEX128)
+  const attestation = sha256(utf8ToBytes(`nostr:agent-auth:${poster}:${authTag[2]}`))
+  if (!schnorr.verify(hexToBytes(signature), attestation, hexToBytes(owner))) fail('authTag owner signature is invalid for this poster')
+  const policy = Object.freeze({ posterPubkey: poster, authTag: Object.freeze([...authTag]) })
+  PROJECTION_POLICIES.add(policy)
+  return policy
+}
+
+const projectionPolicy = policy => {
+  if (!policy || !PROJECTION_POLICIES.has(policy)) fail('an internally configured projection policy is required')
+  return policy
+}
+
+export function buildBuzzEvent(decision, policy, { now = Math.floor(Date.now() / 1000) } = {}) {
+  assertPolicyDecision(decision); projectionPolicy(policy)
+  if (decision.template !== 'quarantine_header' || !UUID.test(String(decision.dest || ''))) fail('decision is not a closed quarantine destination')
+  return Object.freeze({ kind: 9, created_at: timestamp(now), content: renderQuarantineHeader(decision.slots),
+    tags: Object.freeze([Object.freeze(['h', decision.dest]), policy.authTag]), pubkey: policy.posterPubkey })
+}
+
+export function unsignedEventSha256(unsigned, policy) {
+  projectionPolicy(policy)
+  const expected = ['content', 'created_at', 'kind', 'pubkey', 'tags']
+  if (!unsigned || Object.keys(unsigned).sort().join(',') !== expected.sort().join(',') ||
+      unsigned.pubkey !== policy.posterPubkey || unsigned.kind !== 9 || !Array.isArray(unsigned.tags) ||
+      typeof unsigned.content !== 'string') fail('unsigned event is not an exact policy projection')
+  const preimage = canonicalJson([0, unsigned.pubkey, timestamp(unsigned.created_at), unsigned.kind, unsigned.tags, unsigned.content])
+  return createHash('sha256').update(preimage).digest('hex')
+}

--- a/src/buzz_policy_shadow.mjs
+++ b/src/buzz_policy_shadow.mjs
@@ -1,0 +1,33 @@
+// Derive-only comparison boundary. It accepts the same canonical evidence packet as the live
+// policy service, chooses evaluation time locally, and returns no event or signing artifact.
+import { createHash } from 'node:crypto'
+import { canonicalJson, decodePolicyRequest, decideQuarantineHeader } from './buzz_policy_core.mjs'
+import { buildBuzzEvent, unsignedEventSha256 } from './buzz_policy_projection.mjs'
+
+const fail = message => { throw new Error(`buzz-policy-shadow: ${message}`) }
+const exactTime = value => {
+  if (!Number.isSafeInteger(value) || value < 0) fail('evaluation time is invalid')
+  return value
+}
+
+export function deriveBuzzPolicyShadow(raw, {
+  policyInstance, catalogueVersion, stagingChannel, watchedEventIds, approverMention = '',
+  projectionPolicy, now = Math.floor(Date.now() / 1000),
+} = {}) {
+  const evaluationTime = exactTime(now)
+  const request = decodePolicyRequest(raw, { policyInstance, catalogueVersion, now: evaluationTime })
+  const requestDigest = createHash('sha256').update(raw).digest('hex')
+  let decision
+  try { decision = decideQuarantineHeader(request, { stagingChannel, watchedEventIds, approverMention }) }
+  catch {
+    return Object.freeze({ v: 1, request_digest: requestDigest, policy_instance: policyInstance,
+      catalogue_version: catalogueVersion, decision: 'deny', evaluation_time: evaluationTime,
+      unsigned_event_sha256: null })
+  }
+  const unsigned = buildBuzzEvent(decision, projectionPolicy, { now: evaluationTime })
+  return Object.freeze({ v: 1, request_digest: requestDigest, policy_instance: policyInstance,
+    catalogue_version: catalogueVersion, decision: 'allow', evaluation_time: evaluationTime,
+    unsigned_event_sha256: unsignedEventSha256(unsigned, projectionPolicy) })
+}
+
+export const encodeBuzzPolicyShadow = (raw, options) => `${canonicalJson(deriveBuzzPolicyShadow(raw, options))}\n`

--- a/src/buzz_policy_shadow_runner.mjs
+++ b/src/buzz_policy_shadow_runner.mjs
@@ -1,0 +1,57 @@
+// Structurally credential-free forced-command adapter for shadow comparison. It deliberately
+// imports neither the live artifact/submission service nor the signer/journal modules.
+import { closeSync, constants, fstatSync, openSync, readFileSync } from 'node:fs'
+import { TextDecoder } from 'node:util'
+import { createProjectionPolicy } from './buzz_policy_projection.mjs'
+import { encodeBuzzPolicyShadow } from './buzz_policy_shadow.mjs'
+
+const HEX64 = /^[0-9a-f]{64}$/, UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
+const fail = message => { throw new Error(`buzz-policy-shadow-runner: ${message}`) }
+function privateText(path, maxBytes = 64 * 1024) {
+  let fd
+  try { fd = openSync(path, constants.O_RDONLY | constants.O_NOFOLLOW) } catch { fail('config cannot be read as a regular non-symlink file') }
+  try {
+    const st = fstatSync(fd)
+    if (!st.isFile() || (st.mode & 0o077) || st.size < 2 || st.size > maxBytes) fail('private input must be a bounded private regular file')
+    return readFileSync(fd)
+  } finally { closeSync(fd) }
+}
+
+export function loadBuzzPolicyShadowConfig(path) {
+  let config
+  try { config = JSON.parse(new TextDecoder('utf-8', { fatal: true }).decode(privateText(path))) }
+  catch (error) {
+    if (String(error?.message || '').startsWith('buzz-policy-shadow-runner:')) throw error
+    fail('config is not valid UTF-8 JSON')
+  }
+  const keys = ['version', 'policy_instance', 'catalogue_version', 'staging_channel', 'watched_event_ids',
+    'approver_mention', 'poster_pubkey', 'auth_tag']
+  if (Object.keys(config).sort().join(',') !== keys.sort().join(',')) fail('config has an invalid shape')
+  if (config.version !== 1 || !/^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/.test(config.policy_instance) ||
+      !HEX64.test(config.catalogue_version) || !UUID.test(config.staging_channel)) fail('config identity, catalogue, or channel is invalid')
+  if (!Array.isArray(config.watched_event_ids) || !config.watched_event_ids.every(id => HEX64.test(id)) ||
+      new Set(config.watched_event_ids).size !== config.watched_event_ids.length) fail('watched_event_ids are invalid')
+  if (typeof config.approver_mention !== 'string' || Buffer.byteLength(config.approver_mention) > 128) fail('approver_mention is invalid')
+  const projectionPolicy = createProjectionPolicy({ posterPubkey: config.poster_pubkey, authTag: config.auth_tag })
+  return Object.freeze({ ...config, watched_event_ids: Object.freeze([...config.watched_event_ids]), projectionPolicy })
+}
+
+export async function readBoundedShadowRequest(stream, maxBytes = 128 * 1024) {
+  const chunks = []; let total = 0
+  for await (const chunk of stream) {
+    const bytes = Buffer.from(chunk); total += bytes.length
+    if (total > maxBytes) fail(`request exceeds ${maxBytes} bytes`)
+    chunks.push(bytes)
+  }
+  if (!total) fail('request is empty')
+  try { return new TextDecoder('utf-8', { fatal: true }).decode(Buffer.concat(chunks)) }
+  catch { fail('request is not valid UTF-8') }
+}
+
+export function runBuzzPolicyShadow(raw, config, { now } = {}) {
+  if (!config?.projectionPolicy) fail('verified shadow config is required')
+  return encodeBuzzPolicyShadow(raw, { policyInstance: config.policy_instance,
+    catalogueVersion: config.catalogue_version, stagingChannel: config.staging_channel,
+    watchedEventIds: config.watched_event_ids, approverMention: config.approver_mention,
+    projectionPolicy: config.projectionPolicy, now })
+}

--- a/src/egress.mjs
+++ b/src/egress.mjs
@@ -15,7 +15,8 @@
 // INV-A3-4  wrapJson is single-line by contract (§2.4), enforced at render time
 // INV-A3-5  every slot of every template declares one of the closed slot types
 import { execFile } from 'node:child_process'
-import { renderQuarantined, renderReleased, renderChannelPlain } from './render.mjs'
+import { renderReleased, renderChannelPlain } from './render.mjs'
+import { renderQuarantineHeader } from './quarantine_projection.mjs'
 
 // --- The closed slot-type set (§2.2, INV-A3-5) -----------------------------------------------
 //
@@ -180,18 +181,7 @@ const CATALOGUE = {
     },
     optional: ['approver', 'name', 'claimedTs'],
     enums: { why: ['mirrored feed', 'granted participant', 'standing follow', 'reply to our note', 'released from quarantine'] },
-    render: ({ body, approver, name, npub, ts, claimedTs, why, id }) => renderQuarantined({
-      body,
-      mention: approver ? `@${approver} ` : '',
-      name,
-      npub,
-      when: new Date(Number(ts) * 1000).toISOString(),
-      // The clamp notice is prose, so it belongs here and not in a caller's string. A5 clamps an
-      // attacker-controlled created_at; this is how the reader is told the claim was moved.
-      claim: claimedTs ? `  ·  ⚠︎ author-claimed \`${new Date(Number(claimedTs) * 1000).toISOString()}\` (clamped)` : '',
-      why,
-      id,
-    }),
+    render: (slots) => renderQuarantineHeader(slots),
   },
 
   // Sites 2b and 7 — forwardPublic() released, and postRelay(). A vouched identity's own words,

--- a/src/quarantine_projection.mjs
+++ b/src/quarantine_projection.mjs
@@ -1,0 +1,26 @@
+// Pure quarantine catalogue projection shared by the local egress catalogue and the off-box
+// policy shadow. No transport, credential, signer, journal, endpoint, or ambient configuration.
+import { renderQuarantined } from './render.mjs'
+
+const REASONS = new Set(['mirrored feed', 'granted participant', 'standing follow', 'reply to our note', 'released from quarantine'])
+const fail = message => { throw new Error(`quarantine-projection: ${message}`) }
+const handle = value => {
+  if (!value) return ''
+  const out = String(value).replace(/[`\r\n]/g, '').replace(/[@[\]()*~]/g, '').trim().slice(0, 64)
+  if (!out) fail('approver is empty after sanitising')
+  return out
+}
+const displayName = value => String(value || '').replace(/[`@[\]()\n\r*_~]/g, '').trim().slice(0, 32)
+const iso = value => {
+  const seconds = Number(value)
+  if (!Number.isSafeInteger(seconds) || seconds < 0 || seconds > 8_640_000_000_000) fail('timestamp is outside the renderable range')
+  return new Date(seconds * 1000).toISOString()
+}
+
+export function renderQuarantineHeader({ body, approver, name, npub, ts, claimedTs, why, id } = {}) {
+  if (typeof body !== 'string' || !/^(npub1[0-9a-z]{20,90}|[0-9a-f]{64})$/i.test(String(npub || '')) ||
+      !/^[0-9a-f]{64}$/.test(String(id || '')) || !REASONS.has(why)) fail('slots are invalid')
+  const mention = handle(approver)
+  return renderQuarantined({ body, mention: mention ? `@${mention} ` : '', name: displayName(name), npub,
+    when: iso(ts), claim: claimedTs ? `  ·  ⚠︎ author-claimed \`${iso(claimedTs)}\` (clamped)` : '', why, id })
+}

--- a/tests/buzz_policy_runner.mjs
+++ b/tests/buzz_policy_runner.mjs
@@ -1,4 +1,4 @@
-import { chmodSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
+import { chmodSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { generateSecretKey, finalizeEvent, getPublicKey } from 'nostr-tools/pure'
@@ -10,6 +10,9 @@ import { createHash } from 'node:crypto'
 import { canonicalJson } from '../src/buzz_policy_core.mjs'
 import { PolicyJournal } from '../src/policy_journal.mjs'
 import { loadBuzzPolicyConfig, readBoundedPolicyRequest, runBuzzPolicyOrphanResolution, runBuzzPolicyRequest } from '../src/buzz_policy_runner.mjs'
+import { loadBuzzPolicyShadowConfig, runBuzzPolicyShadow } from '../src/buzz_policy_shadow_runner.mjs'
+import { buildBuzzEvent } from '../src/buzz_policy_projection.mjs'
+import { decodePolicyRequest, decideQuarantineHeader } from '../src/buzz_policy_core.mjs'
 
 let fails = 0
 const t = (name, ok) => { console.log(`${ok ? 'ok  ' : 'FAIL'} — ${name}`); if (!ok) fails++ }
@@ -50,6 +53,43 @@ const result = JSON.parse(output)
 t('the forced-command adapter emits one canonical receipt result', output === `${canonicalJson(result)}\n` && result.status === 'terminal' && JSON.parse(result.receipt).kind === 30078)
 t('the forced-command result never exposes the recovery secret', !output.includes(config.recoverySecret))
 await rejects('the configured poster cannot differ from the Bunker identity', () => runBuzzPolicyRequest(raw, config, { ...signer, pubkey: 'f'.repeat(64) }), /does not match/)
+
+const shadowConfigPath = join(root, 'shadow-policy.json')
+const shadowConfigValue = { version: 1, policy_instance: configValue.policy_instance,
+  catalogue_version: configValue.catalogue_version, staging_channel: configValue.staging_channel,
+  watched_event_ids: configValue.watched_event_ids, approver_mention: configValue.approver_mention,
+  poster_pubkey: configValue.poster_pubkey, auth_tag: configValue.auth_tag }
+writeFileSync(shadowConfigPath, `${JSON.stringify(shadowConfigValue)}\n`, { mode: 0o600 })
+const shadowConfig = loadBuzzPolicyShadowConfig(shadowConfigPath)
+const shadowTime = now + 7, shadowOutput = runBuzzPolicyShadow(raw, shadowConfig, { now: shadowTime })
+const shadowResult = JSON.parse(shadowOutput)
+t('derive-only shadow returns one canonical comparison record', shadowOutput === `${canonicalJson(shadowResult)}\n` &&
+  shadowResult.decision === 'allow' && shadowResult.evaluation_time === shadowTime && /^[0-9a-f]{64}$/.test(shadowResult.unsigned_event_sha256))
+const localRequest = decodePolicyRequest(raw, { policyInstance: config.policy_instance, catalogueVersion: config.catalogue_version, now: shadowTime })
+const localDecision = decideQuarantineHeader(localRequest, { stagingChannel: config.staging_channel,
+  watchedEventIds: config.watched_event_ids, approverMention: config.approver_mention })
+const localUnsigned = buildBuzzEvent(localDecision, shadowConfig.projectionPolicy, { now: shadowResult.evaluation_time })
+const localDigest = createHash('sha256').update(canonicalJson([0, localUnsigned.pubkey, localUnsigned.created_at,
+  localUnsigned.kind, localUnsigned.tags, localUnsigned.content])).digest('hex')
+t('local projection at remote-owned time is byte-identical to the shadow digest', localDigest === shadowResult.unsigned_event_sha256)
+t('shadow output exposes only the closed comparison record',
+  Object.keys(shadowResult).sort().join(',') === ['v', 'request_digest', 'policy_instance', 'catalogue_version',
+    'decision', 'evaluation_time', 'unsigned_event_sha256'].sort().join(','))
+const deniedSource = JSON.parse(JSON.stringify(finalizeEvent({ kind: 1, created_at: now - 1,
+  tags: [['e', 'e'.repeat(64)]], content: 'not watched' }, generateSecretKey())))
+const deniedRaw = canonicalJson({ ...JSON.parse(raw), evidence: { source_event: deniedSource } })
+const deniedResult = JSON.parse(runBuzzPolicyShadow(deniedRaw, shadowConfig, { now }))
+t('a valid but ineligible source produces a deny comparison without authored bytes',
+  deniedResult.decision === 'deny' && deniedResult.unsigned_event_sha256 === null)
+await rejects('shadow config structurally refuses live endpoint and journal fields', () => {
+  const p = join(root, 'wide-shadow.json'); writeFileSync(p, JSON.stringify({ ...shadowConfigValue, endpoint: configValue.endpoint }), { mode: 0o600 })
+  return loadBuzzPolicyShadowConfig(p)
+}, /invalid shape/)
+const shadowTool = readFileSync(new URL('../tools/buzz-policy-shadow.mjs', import.meta.url), 'utf8')
+const shadowRunner = readFileSync(new URL('../src/buzz_policy_shadow_runner.mjs', import.meta.url), 'utf8')
+const shadowProjection = readFileSync(new URL('../src/buzz_policy_projection.mjs', import.meta.url), 'utf8')
+t('derive-only executable imports no signer, submission, or journal module',
+  !/nostr_signer|buzz_policy_artifacts|buzz_policy_service|policy_journal|egress\.mjs/.test(`${shadowTool}\n${shadowRunner}\n${shadowProjection}`))
 
 const orphanSource = JSON.parse(JSON.stringify(finalizeEvent({ kind: 1, created_at: now - 2, tags: [['e', 'd'.repeat(64)]], content: 'other wisdom' }, generateSecretKey())))
 const orphanRaw = canonicalJson({ version: 1, policy_instance: 'jaf-hive', operation: 'quarantine_header', catalogue_version: 'c'.repeat(64), observed_at: now, evidence: { source_event: orphanSource } })

--- a/tests/policy_host_deploy.mjs
+++ b/tests/policy_host_deploy.mjs
@@ -1,6 +1,7 @@
 import { readFileSync } from 'node:fs'
 import { resolve, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { spawnSync } from 'node:child_process'
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), '..')
 const read = path => readFileSync(resolve(root, path), 'utf8')
@@ -9,6 +10,17 @@ const sshd = read('deploy/sshd-waggle-policy.conf'), install = read('deploy/poli
 const verify = read('deploy/verify-policy-host.sh'), forward = read('tools/buzz-policy-forward.mjs')
 const shadowSocket = read('deploy/waggle-policy-shadow.socket'), shadowService = read('deploy/waggle-policy-shadow@.service')
 const shadowForward = read('tools/buzz-policy-shadow-forward.mjs'), shadowTool = read('tools/buzz-policy-shadow.mjs')
+const relativeImports = text => [...text.matchAll(/(?:from\s+|import\s*\()\s*['"](\.[^'"]+)['"]/g)].map(match => match[1])
+const importClosure = (entry, seen = new Set()) => {
+  const path = entry.endsWith('.mjs') ? entry : `${entry}.mjs`
+  if (seen.has(path)) return seen
+  seen.add(path)
+  const text = readFileSync(path, 'utf8')
+  for (const specifier of relativeImports(text)) importClosure(resolve(dirname(path), specifier), seen)
+  return seen
+}
+const shadowClosure = importClosure(resolve(root, 'tools/buzz-policy-shadow.mjs'))
+const forbiddenShadowCapability = path => /node:child_process|\bexecFile\b|\bspawn\b|nostr_signer|buzz_policy_artifacts|buzz_policy_service|policy_journal|\.signEvent\s*\(/.test(readFileSync(path, 'utf8'))
 let fails = 0
 const ok = (name, value) => { console.log(`${value ? 'ok  ' : 'FAIL'} — ${name}`); if (!value) fails++ }
 const has = (text, pattern) => pattern.test(text)
@@ -40,9 +52,22 @@ ok('shadow worker receives one policy credential and no signing or recovery auth
 ok('shadow worker is structurally networkless and has no writable filesystem path',
   has(shadowService, /^RestrictAddressFamilies=AF_UNIX$/m) && !/^ReadWritePaths=/m.test(shadowService) &&
   !/nostr_signer|buzz_policy_artifacts|buzz_policy_service|policy_journal/.test(shadowTool))
+ok(`shadow worker transitive closure (${shadowClosure.size} modules) has no signer, submitter, journal, or child-process capability`,
+  shadowClosure.size >= 6 && ![...shadowClosure].some(forbiddenShadowCapability))
+ok('NEGATIVE CONTROL — the transitive scanner catches the writer-capable egress module',
+  forbiddenShadowCapability(resolve(root, 'src/egress.mjs')))
 ok('installer requires distinct live and derive-only ingress keys',
   install.includes('WAGGLE_POLICY_SHADOW_CLIENT_PUB') && install.includes('live and shadow ingress keys must be distinct') &&
   install.includes('tools/buzz-policy-shadow.mjs') && install.includes('tools/buzz-policy-shadow-forward.mjs'))
+const sameBlob = 'AAAAC3NzaC1lZDI1NTE5AAAAITestOnlyKeyBlob'
+const sameIdentity = spawnSync('sh', [resolve(root, 'deploy/policy-host-install.sh')], {
+  encoding: 'utf8', env: { ...process.env,
+    WAGGLE_POLICY_CLIENT_PUB: `ssh-ed25519 ${sameBlob} live-comment`,
+    WAGGLE_POLICY_SHADOW_CLIENT_PUB: `ssh-ed25519 ${sameBlob} different-shadow-comment`,
+  },
+})
+ok('NEGATIVE CONTROL — comments cannot disguise one SSH key as two capabilities',
+  sameIdentity.status === 2 && sameIdentity.stderr.includes('live and shadow ingress keys must be distinct'))
 ok('verifier requires the shadow policy and active derive-only socket',
   verify.includes('/etc/waggle-policy/shadow-policy.json') && verify.includes('waggle-policy-shadow.socket'))
 

--- a/tests/policy_host_deploy.mjs
+++ b/tests/policy_host_deploy.mjs
@@ -7,6 +7,8 @@ const read = path => readFileSync(resolve(root, path), 'utf8')
 const socket = read('deploy/waggle-policy.socket'), service = read('deploy/waggle-policy@.service'), slice = read('deploy/waggle-policy.slice')
 const sshd = read('deploy/sshd-waggle-policy.conf'), install = read('deploy/policy-host-install.sh')
 const verify = read('deploy/verify-policy-host.sh'), forward = read('tools/buzz-policy-forward.mjs')
+const shadowSocket = read('deploy/waggle-policy-shadow.socket'), shadowService = read('deploy/waggle-policy-shadow@.service')
+const shadowForward = read('tools/buzz-policy-shadow-forward.mjs'), shadowTool = read('tools/buzz-policy-shadow.mjs')
 let fails = 0
 const ok = (name, value) => { console.log(`${value ? 'ok  ' : 'FAIL'} — ${name}`); if (!value) fails++ }
 const has = (text, pattern) => pattern.test(text)
@@ -28,11 +30,26 @@ ok('installer seals and manifests the complete runtime closure', ['! -user root'
 ok('installer validates sshd before reload', install.indexOf('"$SSHD" -t') > 0 && install.indexOf('"$SSHD" -t') < install.indexOf('systemctl reload ssh.service'))
 ok('installer does not arm the socket before policy and credentials exist', !/enable --now waggle-policy\.socket/.test(install))
 ok('verifier checks credentials, complete immutable release, and active/enabled state', ['poster.bunker-uri', 'poster.client-nsec', 'recovery.secret', 'root:root 600', 'release.sha256', 'sha256sum -c', '! -user root', '-type l', 'is-enabled', 'is-active'].every(x => verify.includes(x)))
+ok('shadow ingress is a distinct fixed SSH and Unix-socket capability',
+  sshd.includes('Match User waggle-policy-shadow-ingress') && sshd.includes('ForceCommand /usr/bin/node /opt/waggle-policy/tools/buzz-policy-shadow-forward.mjs') &&
+  shadowForward.includes("const SOCKET = '/run/waggle-policy-shadow/request.sock'") &&
+  has(shadowSocket, /^SocketGroup=waggle-policy-shadow-ingress$/m))
+ok('shadow worker receives one policy credential and no signing or recovery authority',
+  (shadowService.match(/^LoadCredential=/gm) || []).length === 1 && shadowService.includes('shadow-policy.json') &&
+  !/poster\.bunker-uri|poster\.client-nsec|recovery\.secret|ReadWritePaths=/i.test(shadowService))
+ok('shadow worker is structurally networkless and has no writable filesystem path',
+  has(shadowService, /^RestrictAddressFamilies=AF_UNIX$/m) && !/^ReadWritePaths=/m.test(shadowService) &&
+  !/nostr_signer|buzz_policy_artifacts|buzz_policy_service|policy_journal/.test(shadowTool))
+ok('installer requires distinct live and derive-only ingress keys',
+  install.includes('WAGGLE_POLICY_SHADOW_CLIENT_PUB') && install.includes('live and shadow ingress keys must be distinct') &&
+  install.includes('tools/buzz-policy-shadow.mjs') && install.includes('tools/buzz-policy-shadow-forward.mjs'))
+ok('verifier requires the shadow policy and active derive-only socket',
+  verify.includes('/etc/waggle-policy/shadow-policy.json') && verify.includes('waggle-policy-shadow.socket'))
 
 const weakened = service.replace('ReadWritePaths=/var/lib/waggle-policy/journal', 'ReadWritePaths=/opt/waggle-policy /etc/waggle-policy')
 ok('NEGATIVE CONTROL — writable code/config would be detected', !has(weakened, /^ReadWritePaths=\/var\/lib\/waggle-policy\/journal$/m))
-const shell = sshd.replace(/^    ForceCommand.*$/m, '')
-ok('NEGATIVE CONTROL — removing ForceCommand would be detected', !/^    ForceCommand /m.test(shell))
+const shell = sshd.replace(/^    ForceCommand \/usr\/bin\/node \/opt\/waggle-policy\/tools\/buzz-policy-forward\.mjs$/m, '')
+ok('NEGATIVE CONTROL — removing ForceCommand would be detected', !shell.includes('ForceCommand /usr/bin/node /opt/waggle-policy/tools/buzz-policy-forward.mjs'))
 const multiplied = service.replace('Slice=waggle-policy.slice', '')
 ok('NEGATIVE CONTROL — removing the aggregate slice is detected', !/^Slice=waggle-policy\.slice$/m.test(multiplied))
 

--- a/tools/buzz-policy-shadow-forward.mjs
+++ b/tools/buzz-policy-shadow-forward.mjs
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+import net from 'node:net'
+
+const SOCKET = '/run/waggle-policy-shadow/request.sock'
+if (process.argv.length !== 2) {
+  process.stderr.write('waggle-policy-shadow-forward: arguments are not accepted\n')
+  process.exit(2)
+}
+const socket = net.createConnection(SOCKET)
+let settled = false
+const fail = message => {
+  if (settled) return
+  settled = true
+  process.stderr.write(`waggle-policy-shadow-forward: ${message}\n`)
+  process.exitCode = 2
+}
+socket.setTimeout(15_000, () => { fail('shadow service timed out'); socket.destroy() })
+socket.on('connect', () => process.stdin.pipe(socket))
+socket.on('data', chunk => process.stdout.write(chunk))
+socket.on('end', () => { settled = true })
+socket.on('error', () => fail('shadow service unavailable'))
+process.stdin.on('error', () => { fail('request stream failed'); socket.destroy() })

--- a/tools/buzz-policy-shadow.mjs
+++ b/tools/buzz-policy-shadow.mjs
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+// Sole derive-only forced command: no argv, signer, journal, endpoint, or network path.
+import { loadBuzzPolicyShadowConfig, readBoundedShadowRequest, runBuzzPolicyShadow } from '../src/buzz_policy_shadow_runner.mjs'
+
+try {
+  if (process.argv.length !== 2) throw new Error('buzz-policy-shadow: arguments are not accepted')
+  const configPath = String(process.env.WAGGLE_POLICY_SHADOW_CONFIG_FILE || '')
+  if (!configPath) throw new Error('buzz-policy-shadow: WAGGLE_POLICY_SHADOW_CONFIG_FILE is required')
+  const config = loadBuzzPolicyShadowConfig(configPath)
+  const raw = await readBoundedShadowRequest(process.stdin)
+  process.stdout.write(runBuzzPolicyShadow(raw, config))
+} catch (error) {
+  process.stderr.write(`${String(error?.message || 'buzz-policy-shadow: refused').slice(0, 512)}\n`)
+  process.exitCode = 2
+}


### PR DESCRIPTION
## What changed

- extracts the shared unsigned Buzz event projection from the live signing/submission module
- adds a derive-only shadow service returning only decision, remote-owned evaluation time, and canonical unsigned-preimage SHA-256
- gives shadow a distinct SSH key, forced command, Unix socket, service identity, and networkless/read-only systemd sandbox
- excludes Bunker, recovery, endpoint, journal, signer, submission, and writable paths structurally
- documents and tests exact local comparison at the remote-owned time

## Evidence

- focused policy runner/artifact/deploy checks pass
- lint and diff check pass
- all 44 suites pass outside the loopback-restricted sandbox

This implements the safe shadow endpoint for #54 gate 10.3; it does not cut live traffic over. Review discussion belongs only in private Buzz waggle-test.

Drafted with assistance from Claude Code.