### PR TITLE
Automate verified policy-host releases

### DIFF
--- a/deploy/POLICY_HOST.md
+++ b/deploy/POLICY_HOST.md
@@ -159,3 +159,27 @@ local signer. `off` is the default. The SSH client pins a dedicated identity and
 uses the forced account with no remote command, disables ambient identities, TTY and forwarding,
 and sends only the canonical evidence packet on stdin. Do not use a management key or a mutable
 user `known_hosts` file for either path.
+
+## 6. Automatic releases after bootstrap
+
+The trust bootstrap above is the only manual deployment. Do **not** give GitHub Actions a root SSH
+key. Instead, clone this repository as `/opt/waggle-policy-hub`, install the committed
+`policy-host-deploy-runner.service` and `.timer` into `/etc/systemd/system`, and enable the timer.
+The policy host polls `main`, accepts only an exact commit whose CI checks are green, exports a
+closed runtime file set, installs dependencies without lifecycle scripts, and promotes it only
+after installation and verification pass. A failed install, restart, or verification restores the
+prior release and leaves the old deployment watermark in place.
+
+```sh
+install -m 0644 deploy/policy-host-deploy-runner.service /etc/systemd/system/
+install -m 0644 deploy/policy-host-deploy-runner.timer /etc/systemd/system/
+systemctl daemon-reload
+systemctl enable --now policy-host-deploy-runner.timer
+systemctl start policy-host-deploy-runner.service
+journalctl -u policy-host-deploy-runner.service -n 50 --no-pager
+```
+
+For a private repository, `/etc/waggle-policy/deploy-runner.env` may contain a **read-only** GitHub
+token at mode `0600`. It is never loaded into either policy worker. Production signing credentials,
+policy JSON, ingress private keys, and recovery authority remain host-local and outside every
+release archive.

--- a/deploy/policy-host-deploy-runner.service
+++ b/deploy/policy-host-deploy-runner.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=waggle policy host — pull a CI-green immutable release
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+User=root
+Group=root
+WorkingDirectory=/opt/waggle-policy-hub
+Environment=PATH=/usr/local/bin:/usr/bin:/bin
+EnvironmentFile=-/etc/waggle-policy/deploy-runner.env
+ExecStart=/bin/sh /opt/waggle-policy-hub/deploy/policy-host-deploy-runner.sh
+ProtectHome=yes
+PrivateTmp=yes
+UMask=0027

--- a/deploy/policy-host-deploy-runner.sh
+++ b/deploy/policy-host-deploy-runner.sh
@@ -1,0 +1,122 @@
+#!/bin/sh
+# Pull a merged, CI-green Waggle release onto the dedicated policy host.
+# Bootstrap establishes ingress public keys, owner policy, and Bunker credentials once.
+set -eu
+
+HUB=${WP_HUB:-/opt/waggle-policy-hub}
+TREE=${WP_TREE:-/opt/waggle-policy}
+RELEASE_ROOT=${WP_RELEASE_ROOT:-/opt/waggle-policy-releases}
+BRANCH=${WP_BRANCH:-main}
+REF=${WP_REF:-origin/$BRANCH}
+SLUG=${WP_SLUG:-JAFairweather/waggle}
+SHA_FILE=${WP_SHA_FILE:-/etc/waggle-policy/DEPLOYED_SHA}
+NPM_CMD=${WP_NPM_CMD:-npm ci --omit=dev --ignore-scripts --no-audit --no-fund}
+INSTALL_CMD=${WP_INSTALL_CMD:-sh deploy/policy-host-install.sh}
+RESTART_CMD=${WP_RESTART_CMD:-systemctl restart waggle-policy.socket waggle-policy-shadow.socket}
+VERIFY_CMD=${WP_VERIFY_CMD:-sh deploy/verify-policy-host.sh}
+
+log() { echo "policy-deploy $*"; }
+alarm() { echo "policy-deploy ALARM: $*" >&2; }
+
+if [ -z "${WP_ALLOW_NON_ROOT:-}" ] && [ "$(id -u)" -ne 0 ]; then
+  alarm 'runner must execute as root on the dedicated policy host'; exit 2
+fi
+[ -d "$HUB/.git" ] || { alarm "hub clone not found at $HUB"; exit 2; }
+mkdir -p "$RELEASE_ROOT"
+
+ci_state_github() {
+  sha=$1
+  url="https://api.github.com/repos/$SLUG/commits/$sha/check-runs"
+  if [ -n "${GH_TOKEN:-}" ]; then set -- -H "Authorization: Bearer $GH_TOKEN"; else set --; fi
+  json=$(curl -fsSL -H 'Accept: application/vnd.github+json' "$@" "$url" 2>/dev/null) || { echo error; return; }
+  printf '%s' "$json" | node -e '
+    let s=""; process.stdin.on("data",d=>s+=d).on("end",()=>{
+      try { const r=JSON.parse(s).check_runs||[];
+        if(!r.length||r.some(x=>x.status!=="completed")) return console.log("pending");
+        console.log(r.every(x=>x.conclusion==="success")?"success":"failure");
+      } catch (_) { console.log("error") }
+    })' 2>/dev/null || echo error
+}
+
+if [ -z "${WP_NO_FETCH:-}" ]; then
+  git -C "$HUB" fetch --quiet origin "$BRANCH" || { alarm 'git fetch failed'; exit 2; }
+fi
+TARGET_SHA=$(git -C "$HUB" rev-parse "$REF" 2>/dev/null) || { alarm "cannot resolve $REF"; exit 2; }
+case "$TARGET_SHA" in *[!0-9a-f]*|'') alarm 'resolved ref is not a commit SHA'; exit 2 ;; esac
+[ "${#TARGET_SHA}" -eq 40 ] || { alarm 'resolved ref is not a full commit SHA'; exit 2; }
+SHORT=$(printf '%.12s' "$TARGET_SHA")
+DEPLOYED_SHA=$(cat "$SHA_FILE" 2>/dev/null || echo none)
+
+if [ "$TARGET_SHA" = "$DEPLOYED_SHA" ]; then
+  (cd "$TREE" && sh -c "$VERIFY_CMD") || { alarm "deployed $SHORT failed verification"; exit 1; }
+  log "already current and verified at $SHORT"; exit 0
+fi
+
+if [ -n "${WP_CI_STATE_CMD:-}" ]; then
+  STATE=$(sh -c "$WP_CI_STATE_CMD \"$TARGET_SHA\"" 2>/dev/null || echo error)
+else
+  STATE=$(ci_state_github "$TARGET_SHA")
+fi
+case "$STATE" in
+  success) log "CI green for $SHORT" ;;
+  failure) alarm "CI is red for $SHORT; refusing deployment"; exit 0 ;;
+  pending) log "CI pending for $SHORT; retrying next tick"; exit 0 ;;
+  *) alarm "CI state unavailable for $SHORT; refusing deployment"; exit 0 ;;
+esac
+
+if [ -n "${DRY_RUN:-}" ]; then log "DRY_RUN would deploy $SHORT to $TREE"; exit 0; fi
+
+# Public identity is bootstrap state, not release state. Private keys never enter this process.
+LIVE_AUTH=${WP_LIVE_AUTHORIZED_KEY:-/etc/ssh/authorized_keys/waggle-policy-ingress}
+SHADOW_AUTH=${WP_SHADOW_AUTHORIZED_KEY:-/etc/ssh/authorized_keys/waggle-policy-shadow-ingress}
+LIVE_PUB=$(sed -n 's/^restrict //p' "$LIVE_AUTH" | head -n 1)
+SHADOW_PUB=$(sed -n 's/^restrict //p' "$SHADOW_AUTH" | head -n 1)
+[ -n "$LIVE_PUB" ] && [ -n "$SHADOW_PUB" ] || { alarm 'bootstrap ingress public keys are missing'; exit 2; }
+
+STAGE="$RELEASE_ROOT/.stage-$TARGET_SHA"
+FAILED="$RELEASE_ROOT/failed-$TARGET_SHA"
+PREVIOUS="$RELEASE_ROOT/previous"
+ARCHIVE="$RELEASE_ROOT/.archive-$TARGET_SHA.tar"
+rm -rf -- "$STAGE"
+rm -f -- "$ARCHIVE"
+mkdir -p "$STAGE"
+git -C "$HUB" archive --output="$ARCHIVE" "$TARGET_SHA" src tools deploy package.json package-lock.json || {
+  alarm 'could not export the exact candidate commit'; exit 1;
+}
+tar -x -f "$ARCHIVE" -C "$STAGE" || { alarm 'could not extract candidate release'; exit 1; }
+rm -f -- "$ARCHIVE"
+(cd "$STAGE" && sh -c "$NPM_CMD") || { alarm 'dependency installation failed before promotion'; exit 1; }
+rm -rf -- "$STAGE/node_modules/.bin"
+if find "$STAGE" -xdev -type l -print -quit | grep -q .; then alarm 'staged release contains a symlink'; exit 1; fi
+if [ -n "${WP_TEST_SKIP_OWNERSHIP:-}" ] && [ -n "${WP_ALLOW_NON_ROOT:-}" ]; then
+  : # Test seam: production has neither variable and always seals the complete release below.
+else
+  chown -R root:root "$STAGE"
+  find "$STAGE" -xdev -type d -exec chmod 0755 {} +
+  find "$STAGE" -xdev -type f -exec chmod a-w,go+r {} +
+fi
+
+rollback() {
+  alarm "deployment of $SHORT failed; restoring previous verified release"
+  rm -rf -- "$FAILED"
+  [ ! -e "$TREE" ] || mv "$TREE" "$FAILED"
+  if [ -d "$PREVIOUS" ]; then
+    mv "$PREVIOUS" "$TREE"
+    (cd "$TREE" && WAGGLE_POLICY_CLIENT_PUB="$LIVE_PUB" WAGGLE_POLICY_SHADOW_CLIENT_PUB="$SHADOW_PUB" sh -c "$INSTALL_CMD") || true
+    sh -c "$RESTART_CMD" || true
+    (cd "$TREE" && sh -c "$VERIFY_CMD") || alarm 'ROLLBACK VERIFICATION FAILED — operator action required'
+  else
+    alarm 'no previous release exists; sockets require operator recovery'
+  fi
+  exit 1
+}
+
+rm -rf -- "$PREVIOUS"
+[ ! -d "$TREE" ] || mv "$TREE" "$PREVIOUS"
+mv "$STAGE" "$TREE" || rollback
+(cd "$TREE" && WAGGLE_POLICY_CLIENT_PUB="$LIVE_PUB" WAGGLE_POLICY_SHADOW_CLIENT_PUB="$SHADOW_PUB" sh -c "$INSTALL_CMD") || rollback
+sh -c "$RESTART_CMD" || rollback
+(cd "$TREE" && sh -c "$VERIFY_CMD") || rollback
+printf '%s\n' "$TARGET_SHA" > "$SHA_FILE.tmp"
+mv "$SHA_FILE.tmp" "$SHA_FILE"
+log "deploy verified at $SHORT; previous release retained at $PREVIOUS"

--- a/deploy/policy-host-deploy-runner.sh
+++ b/deploy/policy-host-deploy-runner.sh
@@ -26,12 +26,15 @@ mkdir -p "$RELEASE_ROOT"
 
 ci_state_github() {
   sha=$1
-  url="https://api.github.com/repos/$SLUG/commits/$sha/check-runs"
+  # One complete page is sufficient only when GitHub says every run fit on it. If a repository
+  # ever grows past 100 checks, fail closed instead of promoting from a successful-looking prefix.
+  url="https://api.github.com/repos/$SLUG/commits/$sha/check-runs?per_page=100"
   if [ -n "${GH_TOKEN:-}" ]; then set -- -H "Authorization: Bearer $GH_TOKEN"; else set --; fi
   json=$(curl -fsSL -H 'Accept: application/vnd.github+json' "$@" "$url" 2>/dev/null) || { echo error; return; }
   printf '%s' "$json" | node -e '
     let s=""; process.stdin.on("data",d=>s+=d).on("end",()=>{
-      try { const r=JSON.parse(s).check_runs||[];
+      try { const body=JSON.parse(s), r=body.check_runs||[], total=body.total_count;
+        if(!Number.isSafeInteger(total)||total<0||r.length!==total) return console.log("error");
         if(!r.length||r.some(x=>x.status!=="completed")) return console.log("pending");
         console.log(r.every(x=>x.conclusion==="success")?"success":"failure");
       } catch (_) { console.log("error") }

--- a/deploy/policy-host-deploy-runner.timer
+++ b/deploy/policy-host-deploy-runner.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=waggle policy host — check for a CI-green release every three minutes
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=3min
+RandomizedDelaySec=45s
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/docs/DESIGN_OFFBOX_BUZZ_POLICY.md
+++ b/docs/DESIGN_OFFBOX_BUZZ_POLICY.md
@@ -254,6 +254,12 @@ that the Buzz poster key is off the bridge host:
    `[0,pubkey,created_at,kind,tags,content]`, never a signed event. The shadow host chooses
    `evaluation_time`; the bridge reruns the local projection at that remote-owned time and compares
    the decision plus SHA-256 preimage digest.
+   Bridge modes are closed and distinct: `observe` reports mismatch/unavailability and denies
+   burn-in credit while preserving today's local delivery; `enforce-shadow` holds delivery on
+   mismatch or unavailable shadow with a recorded bounded reason. Only after a clean enforced
+   rehearsal may an operation move to remote-only. The two SSH capabilities are distinct by key
+   algorithm + key blob (comments are ignored), and CI audits the derive worker's complete
+   transitive import closure for signer, submission, journal, and network capabilities.
    For `quarantine_header`, both paths call the same source-only projection: the signed kind:1
    supplies body, author, source timestamp, reply target, and source id. Replaceable kind:0 data and
    local clock clamping are excluded from authored bytes; one captured `observed_at` will supply the

--- a/tests/buzz_policy_runner.mjs
+++ b/tests/buzz_policy_runner.mjs
@@ -90,6 +90,22 @@ const shadowRunner = readFileSync(new URL('../src/buzz_policy_shadow_runner.mjs'
 const shadowProjection = readFileSync(new URL('../src/buzz_policy_projection.mjs', import.meta.url), 'utf8')
 t('derive-only executable imports no signer, submission, or journal module',
   !/nostr_signer|buzz_policy_artifacts|buzz_policy_service|policy_journal|egress\.mjs/.test(`${shadowTool}\n${shadowRunner}\n${shadowProjection}`))
+const shadowRoot = new URL('../', import.meta.url)
+const closure = new Map()
+const walkImports = url => {
+  const key = url.href
+  if (closure.has(key)) return
+  const sourceText = readFileSync(url, 'utf8'); closure.set(key, sourceText)
+  for (const match of sourceText.matchAll(/(?:import|export)\s+(?:[^'";]+?\s+from\s+)?['"](\.\.?\/[^'"]+)['"]/g)) {
+    const child = new URL(match[1], url)
+    if (child.href.startsWith(shadowRoot.href)) walkImports(child)
+  }
+}
+walkImports(new URL('../tools/buzz-policy-shadow.mjs', import.meta.url))
+const closureText = [...closure.entries()].map(([path, text]) => `${path}\n${text}`).join('\n')
+t('the full derive-worker import closure contains no transport, signer, submission, or journal capability',
+  !/node:(?:child_process|net|http|https|tls|dgram)|nostr_signer|buzz_policy_artifacts|buzz_policy_service|policy_journal/.test(closureText) &&
+  !/\bfetch\s*\(/.test(closureText) && closure.size >= 6)
 
 const orphanSource = JSON.parse(JSON.stringify(finalizeEvent({ kind: 1, created_at: now - 2, tags: [['e', 'd'.repeat(64)]], content: 'other wisdom' }, generateSecretKey())))
 const orphanRaw = canonicalJson({ version: 1, policy_instance: 'jaf-hive', operation: 'quarantine_header', catalogue_version: 'c'.repeat(64), observed_at: now, evidence: { source_event: orphanSource } })

--- a/tests/policy_host_deploy.mjs
+++ b/tests/policy_host_deploy.mjs
@@ -1,7 +1,8 @@
-import { readFileSync } from 'node:fs'
+import { readFileSync, writeFileSync, mkdirSync, mkdtempSync, rmSync, existsSync } from 'node:fs'
 import { resolve, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { spawnSync } from 'node:child_process'
+import { tmpdir } from 'node:os'
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), '..')
 const read = path => readFileSync(resolve(root, path), 'utf8')
@@ -11,6 +12,9 @@ const verify = read('deploy/verify-policy-host.sh'), forward = read('tools/buzz-
 const shadowSocket = read('deploy/waggle-policy-shadow.socket'), shadowService = read('deploy/waggle-policy-shadow@.service')
 const shadowForward = read('tools/buzz-policy-shadow-forward.mjs'), shadowTool = read('tools/buzz-policy-shadow.mjs')
 const shadowClient = read('deploy/waggle-policy-shadow-client.conf')
+const deployRunner = read('deploy/policy-host-deploy-runner.sh')
+const deployRunnerService = read('deploy/policy-host-deploy-runner.service')
+const deployRunnerTimer = read('deploy/policy-host-deploy-runner.timer')
 const relativeImports = text => [...text.matchAll(/(?:from\s+|import\s*\()\s*['"](\.[^'"]+)['"]/g)].map(match => match[1])
 const importClosure = (entry, seen = new Set()) => {
   const path = entry.endsWith('.mjs') ? entry : `${entry}.mjs`
@@ -76,6 +80,67 @@ ok('NEGATIVE CONTROL — comments cannot disguise one SSH key as two capabilitie
   sameIdentity.status === 2 && sameIdentity.stderr.includes('live and shadow ingress keys must be distinct'))
 ok('verifier requires the shadow policy and active derive-only socket',
   verify.includes('/etc/waggle-policy/shadow-policy.json') && verify.includes('waggle-policy-shadow.socket'))
+ok('policy host pulls code without a GitHub-to-production SSH credential',
+  deployRunner.includes('git -C "$HUB" fetch') && !/\bscp\b|\brsync\b|ssh ["'$]/.test(deployRunner))
+ok('only an exact commit with successful CI can promote',
+  deployRunner.includes('TARGET_SHA=$(git -C "$HUB" rev-parse') && deployRunner.includes('case "$STATE"') &&
+  deployRunner.includes('success)') && deployRunner.includes('failure)') && deployRunner.includes('pending)'))
+ok('release archive is a closed runtime list and excludes host policy and credentials',
+  deployRunner.includes('"$TARGET_SHA" src tools deploy package.json package-lock.json') &&
+  !deployRunner.includes('config.json') && !deployRunner.includes('poster.bunker-uri'))
+ok('promotion stages an immutable release and retains an explicit rollback release',
+  deployRunner.includes('STAGE="$RELEASE_ROOT/.stage-$TARGET_SHA"') &&
+  deployRunner.includes('PREVIOUS="$RELEASE_ROOT/previous"') && deployRunner.includes('rollback()') &&
+  deployRunner.includes('mv "$STAGE" "$TREE"'))
+ok('deployment watermark follows install, restart, and final verification',
+  deployRunner.indexOf('printf \'%s\\n\' "$TARGET_SHA"') > deployRunner.lastIndexOf('sh -c "$VERIFY_CMD"') &&
+  deployRunner.lastIndexOf('sh -c "$VERIFY_CMD"') > deployRunner.lastIndexOf('sh -c "$RESTART_CMD"') &&
+  deployRunner.lastIndexOf('sh -c "$RESTART_CMD"') > deployRunner.lastIndexOf('sh -c "$INSTALL_CMD"'))
+ok('failed verification restores and verifies the previous release',
+  /rollback\(\)[\s\S]+mv "\$PREVIOUS" "\$TREE"[\s\S]+ROLLBACK VERIFICATION FAILED/.test(deployRunner))
+ok('systemd runs the pull runner locally and the timer is persistent',
+  deployRunnerService.includes('ExecStart=/bin/sh /opt/waggle-policy-hub/deploy/policy-host-deploy-runner.sh') &&
+  deployRunnerService.includes('ProtectHome=yes') && deployRunnerTimer.includes('OnUnitActiveSec=3min') &&
+  deployRunnerTimer.includes('Persistent=true'))
+
+// Exercise a real archive -> stage -> promote and then a failed candidate -> rollback. The host
+// mutations are explicit seams; git archive, directory rotation, and the watermark are real.
+const deployFixture = mkdtempSync(resolve(tmpdir(), 'waggle-policy-deploy-'))
+const fixtureHub = resolve(deployFixture, 'hub')
+const fixtureTree = resolve(deployFixture, 'live')
+const fixtureReleases = resolve(deployFixture, 'releases')
+const fixtureSha = resolve(deployFixture, 'DEPLOYED_SHA')
+const liveAuth = resolve(deployFixture, 'live.pub')
+const shadowAuth = resolve(deployFixture, 'shadow.pub')
+const clone = spawnSync('git', ['clone', '--quiet', '--no-hardlinks', root, fixtureHub], { encoding: 'utf8' })
+ok('deploy fixture clones the exact reviewed repository', clone.status === 0)
+const fixtureHead = spawnSync('git', ['-C', fixtureHub, 'rev-parse', 'HEAD'], { encoding: 'utf8' }).stdout.trim()
+mkdirSync(fixtureTree, { recursive: true })
+writeFileSync(resolve(fixtureTree, 'previous-proof'), 'old verified release\n')
+writeFileSync(liveAuth, 'restrict ssh-ed25519 AAAATestLive live\n')
+writeFileSync(shadowAuth, 'restrict ssh-ed25519 AAAATestShadow shadow\n')
+const fixtureEnv = { ...process.env, WP_ALLOW_NON_ROOT: '1', WP_TEST_SKIP_OWNERSHIP: '1',
+  WP_HUB: fixtureHub, WP_TREE: fixtureTree, WP_RELEASE_ROOT: fixtureReleases, WP_SHA_FILE: fixtureSha,
+  WP_REF: fixtureHead, WP_NO_FETCH: '1', WP_CI_STATE_CMD: 'echo success #', WP_NPM_CMD: ':',
+  WP_INSTALL_CMD: ':', WP_RESTART_CMD: ':', WP_VERIFY_CMD: 'test -f package.json',
+  WP_LIVE_AUTHORIZED_KEY: liveAuth, WP_SHADOW_AUTHORIZED_KEY: shadowAuth }
+const promoted = spawnSync('/bin/sh', ['deploy/policy-host-deploy-runner.sh'], { cwd: root, env: fixtureEnv, encoding: 'utf8' })
+ok('green exact commit promotes and verifies a staged release', promoted.status === 0 && existsSync(resolve(fixtureTree, 'package.json')))
+ok('successful promotion retains the prior release', existsSync(resolve(fixtureReleases, 'previous', 'previous-proof')))
+ok('successful promotion records the exact verified SHA', readFileSync(fixtureSha, 'utf8').trim() === fixtureHead)
+
+// Create a second local commit, force final verification to fail, and prove directory rotation
+// restores the first candidate while leaving its SHA as the last verified deployment.
+writeFileSync(resolve(fixtureHub, 'src', 'policy-deploy-failure-fixture.mjs'), 'export const candidate = true\n')
+spawnSync('git', ['-C', fixtureHub, 'add', 'src/policy-deploy-failure-fixture.mjs'])
+spawnSync('git', ['-C', fixtureHub, '-c', 'user.name=Test', '-c', 'user.email=test@example.invalid', 'commit', '--quiet', '-m', 'candidate'])
+const secondHead = spawnSync('git', ['-C', fixtureHub, 'rev-parse', 'HEAD'], { encoding: 'utf8' }).stdout.trim()
+const rejected = spawnSync('/bin/sh', ['deploy/policy-host-deploy-runner.sh'], { cwd: root,
+  env: { ...fixtureEnv, WP_REF: secondHead, WP_VERIFY_CMD: 'false' }, encoding: 'utf8' })
+ok('failed candidate exits nonzero and emits a rollback alarm', rejected.status === 1 && /restoring previous/.test(rejected.stderr))
+ok('failed candidate restores the previously verified release', existsSync(resolve(fixtureTree, 'package.json')) && !existsSync(resolve(fixtureTree, 'src', 'policy-deploy-failure-fixture.mjs')))
+ok('failed candidate cannot advance the verified deployment SHA', readFileSync(fixtureSha, 'utf8').trim() === fixtureHead)
+rmSync(deployFixture, { recursive: true, force: true })
 
 const weakened = service.replace('ReadWritePaths=/var/lib/waggle-policy/journal', 'ReadWritePaths=/opt/waggle-policy /etc/waggle-policy')
 ok('NEGATIVE CONTROL — writable code/config would be detected', !has(weakened, /^ReadWritePaths=\/var\/lib\/waggle-policy\/journal$/m))

--- a/tests/policy_host_deploy.mjs
+++ b/tests/policy_host_deploy.mjs
@@ -85,6 +85,8 @@ ok('policy host pulls code without a GitHub-to-production SSH credential',
 ok('only an exact commit with successful CI can promote',
   deployRunner.includes('TARGET_SHA=$(git -C "$HUB" rev-parse') && deployRunner.includes('case "$STATE"') &&
   deployRunner.includes('success)') && deployRunner.includes('failure)') && deployRunner.includes('pending)'))
+ok('GitHub CI promotion requires the complete reported check-run set',
+  deployRunner.includes('check-runs?per_page=100') && deployRunner.includes('r.length!==total'))
 ok('release archive is a closed runtime list and excludes host policy and credentials',
   deployRunner.includes('"$TARGET_SHA" src tools deploy package.json package-lock.json') &&
   !deployRunner.includes('config.json') && !deployRunner.includes('poster.bunker-uri'))
@@ -128,6 +130,18 @@ const promoted = spawnSync('/bin/sh', ['deploy/policy-host-deploy-runner.sh'], {
 ok('green exact commit promotes and verifies a staged release', promoted.status === 0 && existsSync(resolve(fixtureTree, 'package.json')))
 ok('successful promotion retains the prior release', existsSync(resolve(fixtureReleases, 'previous', 'previous-proof')))
 ok('successful promotion records the exact verified SHA', readFileSync(fixtureSha, 'utf8').trim() === fixtureHead)
+
+// A successful-looking first page must not authorize promotion when total_count proves another
+// check run was omitted. This drives the real GitHub parsing path with only curl replaced.
+const fakeBin = resolve(deployFixture, 'bin')
+mkdirSync(fakeBin)
+writeFileSync(resolve(fakeBin, 'curl'), `#!/bin/sh\nprintf '%s\\n' '{"total_count":2,"check_runs":[{"status":"completed","conclusion":"success"}]}'\n`, { mode: 0o700 })
+const truncated = spawnSync('/bin/sh', ['deploy/policy-host-deploy-runner.sh'], { cwd: root,
+  env: { ...fixtureEnv, WP_REF: fixtureHead, WP_SHA_FILE: resolve(deployFixture, 'truncated-sha'),
+    WP_CI_STATE_CMD: '', PATH: `${fakeBin}:${process.env.PATH}` }, encoding: 'utf8' })
+ok('NEGATIVE CONTROL — a truncated successful check-run page fails closed',
+  truncated.status === 0 && /CI state unavailable/.test(truncated.stderr) &&
+  !existsSync(resolve(deployFixture, 'truncated-sha')))
 
 // Create a second local commit, force final verification to fail, and prove directory rotation
 // restores the first candidate while leaving its SHA as the last verified deployment.


### PR DESCRIPTION
Closes the deployment gap exposed while reviewing #273.

- policy host pulls only an exact merged, CI-green commit
- GitHub receives no production SSH credential
- closed code-only release archive; policy, Bunker, ingress, and recovery state stay host-local
- immutable staging, install/restart/verify gate, verified-SHA watermark
- automatic rollback to the prior verified release
- real promotion/failure/rollback regression test
- folds in crew review: closed observe/enforce-shadow semantics and transitive derive-worker capability scan

Bootstrap remains the one manual trust-establishment step. Subsequent releases are timer-driven and CI-gated.

Verification: npm run lint; npm test (44/44 suites).