### PR TITLE
Fix owner-control persistence under the read-only service tree

### DIFF
--- a/src/bridge.mjs
+++ b/src/bridge.mjs
@@ -61,6 +61,11 @@ const __dirname = dirname(fileURLToPath(import.meta.url))
 const ROOT = resolve(__dirname, '..')
 
 const CONFIG_PATH = process.env.CONFIG_PATH || resolve(ROOT, 'config.json')
+// Owner-control commands must survive a crash without giving the network-facing bridge write
+// access to its source directory.  systemd therefore exposes the existing config inode as
+// writable, but keeps its parent directory read-only.  The transaction journal lives beside the
+// other mutable runtime state; startup replays it before config.json is parsed.
+const CONFIG_JOURNAL_PATH = process.env.CONFIG_JOURNAL_PATH || resolve(dirname(process.env.SEEN_PATH || resolve(ROOT, 'data', 'seen-ids.log')), 'config-write-journal.json')
 const SEEN_PATH = process.env.SEEN_PATH || resolve(ROOT, 'data', 'seen-ids.log')
 const SEEN_CAP = Number(process.env.SEEN_CAP || 100000)
 // Return-lane dedup store — same append-only, capped lifecycle as seen-ids, but a SEPARATE file:
@@ -100,6 +105,31 @@ if (!existsSync(CONFIG_PATH)) {
   err(`FATAL: no config at ${CONFIG_PATH}. Copy config.example.json → config.json and fill inbox UUIDs.`)
   process.exit(1)
 }
+function fsyncDir(path) {
+  const fd = openSync(path, 'r')
+  try { fsyncSync(fd) } finally { closeSync(fd) }
+}
+function overwriteExistingConfig(payload) {
+  // Opening the existing file with O_TRUNC changes its inode contents, not the parent directory.
+  // That is the narrow operation allowed by waggle-read.service's ReadWritePaths policy.
+  const fd = openSync(CONFIG_PATH, 'w', 0o600)
+  try { writeFileSync(fd, payload); fsyncSync(fd) } finally { closeSync(fd) }
+}
+function recoverConfigJournal() {
+  if (!existsSync(CONFIG_JOURNAL_PATH)) return
+  try {
+    const payload = readFileSync(CONFIG_JOURNAL_PATH, 'utf8')
+    JSON.parse(payload) // never replace a live config with a partial/corrupt journal
+    overwriteExistingConfig(payload)
+    unlinkSync(CONFIG_JOURNAL_PATH)
+    fsyncDir(dirname(CONFIG_JOURNAL_PATH))
+    log('commands: recovered an interrupted config transaction')
+  } catch (e) {
+    err(`FATAL: config transaction recovery failed: ${e.message}`)
+    process.exit(1)
+  }
+}
+recoverConfigJournal()
 const cfg = JSON.parse(readFileSync(CONFIG_PATH, 'utf8'))
 const RELAYS = cfg.relays || []
 const RECIPIENTS = {} // hex -> { name, inbox, npub_hex }
@@ -1410,18 +1440,24 @@ function mutateConfig(fn) {
   try {
     const fresh = JSON.parse(readFileSync(CONFIG_PATH, 'utf8'))
     fn(fresh)
-    // Never truncate the live config in place.  A successful command must leave either the
-    // complete old document or the complete new document, including its replay watermark.
-    // fsync both the replacement and parent directory so a power loss cannot report a command
-    // accepted while silently losing the state that makes it non-replayable.
-    temporary = `${CONFIG_PATH}.${process.pid}.${randomBytes(8).toString('hex')}.tmp`
-    writeFileSync(temporary, JSON.stringify(fresh, null, 2) + '\n', { mode: 0o600 })
+    const payload = JSON.stringify(fresh, null, 2) + '\n'
+    JSON.parse(payload)
+    // The source-tree parent is deliberately read-only.  First durably record the complete
+    // intended replacement under data/, then update the existing config inode and fsync it.
+    // A crash before journal removal is recovered at the next boot; a crash after removal sees
+    // the already-fsynced config.  This preserves the old atomicity guarantee without widening
+    // the bridge's write authority to code, package metadata, or its service directory.
+    mkdirSync(dirname(CONFIG_JOURNAL_PATH), { recursive: true })
+    temporary = `${CONFIG_JOURNAL_PATH}.${process.pid}.${randomBytes(8).toString('hex')}.tmp`
+    writeFileSync(temporary, payload, { mode: 0o600 })
     const fileFd = openSync(temporary, 'r')
     try { fsyncSync(fileFd) } finally { closeSync(fileFd) }
-    renameSync(temporary, CONFIG_PATH)
+    renameSync(temporary, CONFIG_JOURNAL_PATH)
     temporary = null
-    const dirFd = openSync(dirname(CONFIG_PATH), 'r')
-    try { fsyncSync(dirFd) } finally { closeSync(dirFd) }
+    fsyncDir(dirname(CONFIG_JOURNAL_PATH))
+    overwriteExistingConfig(payload)
+    unlinkSync(CONFIG_JOURNAL_PATH)
+    fsyncDir(dirname(CONFIG_JOURNAL_PATH))
     return true
   } catch (e) {
     if (temporary) { try { unlinkSync(temporary) } catch { /* best-effort cleanup */ } }
@@ -2624,7 +2660,7 @@ function connectPublic(url) {
 // Exported so a harness can drive the REAL routing functions (not a copy) with synthetic
 // events in dryrun, without opening any relay socket. Set WB_NO_BOOT=1 to import without
 // booting the live subscriber. No effect on normal `node src/bridge.mjs` runs.
-export { recordUndelivered, UNDELIVERED_PATH, durableSet, durableQueue, rlPending, retryPendingCarries, RLPENDING_MAX_ATTEMPTS, fanout, defuseRefs, defuseMarkup, quoted, renderQuarantined, renderReleased, fetchEventById, returnLaneSend, publishWrapToRelays, publishWrapToRelayList, fetchRecipientDmRelays, scanReturnLane, pollScanChannels, ensureScanPolling, scanChannel, scanSince, bumpScanCursor, loadScanCursors, agentAuthoredBy, rlSeen, rlKey, loadRlSeen, markRlSeen, addRlSeen, dropRlSeen, route, routePublic, routeDelete, processGrantEvent, grantSet, activeReturnLane, processConsentEvent, mirrorConsent, mirrorRevoked, consentRecordIds, refreshConsentRevocations, CONSENT_REFRESHERS, maybeAskConsent, sendConsentRequest, buildConsentPrefill, mirrorAsked, addWatchAuthor, removeWatchAuthor, refreshWatched, WATCH_REFRESHERS, watchlistTarget, handleWatchlistCommand, handleCommand, forwardPublic, clampCreated, rateOk, bumpPubWatermark, loadPubWatermark, markSeen, seen, PUB, postedMap, recordPosted, parseBuzzEventId, resolveChannels, pollCommands, __resetReadPollingForTests, handleRelayIngress, handleSealedTaskRouteControl, relaySeen, markRelaySeen, addRelaySeen, dropRelaySeen, loadRelaySeen, relayRateOk, resolveRelayDest, relayDropTotalPreAuth, relayDropCounts, buildControlState, publishControlState, publishControlStateToRelays, scheduleControlState, handleControlStateCommand, handleWatchlistControlCommand, handleTaskRouteControlCommand, CONTROL_COMMAND_KIND, CONTROL_COMMAND_D, WATCHLIST_COMMAND_D, TASK_ROUTE_MESSAGE_TYPE, TASK_ROUTE_PROTOCOL }
+export { recordUndelivered, UNDELIVERED_PATH, durableSet, durableQueue, rlPending, retryPendingCarries, RLPENDING_MAX_ATTEMPTS, fanout, defuseRefs, defuseMarkup, quoted, renderQuarantined, renderReleased, fetchEventById, returnLaneSend, publishWrapToRelays, publishWrapToRelayList, fetchRecipientDmRelays, scanReturnLane, pollScanChannels, ensureScanPolling, scanChannel, scanSince, bumpScanCursor, loadScanCursors, agentAuthoredBy, rlSeen, rlKey, loadRlSeen, markRlSeen, addRlSeen, dropRlSeen, route, routePublic, routeDelete, processGrantEvent, grantSet, activeReturnLane, processConsentEvent, mirrorConsent, mirrorRevoked, consentRecordIds, refreshConsentRevocations, CONSENT_REFRESHERS, maybeAskConsent, sendConsentRequest, buildConsentPrefill, mirrorAsked, addWatchAuthor, removeWatchAuthor, refreshWatched, WATCH_REFRESHERS, watchlistTarget, handleWatchlistCommand, handleCommand, forwardPublic, clampCreated, rateOk, bumpPubWatermark, loadPubWatermark, markSeen, seen, PUB, postedMap, recordPosted, parseBuzzEventId, resolveChannels, pollCommands, __resetReadPollingForTests, handleRelayIngress, handleSealedTaskRouteControl, relaySeen, markRelaySeen, addRelaySeen, dropRelaySeen, loadRelaySeen, relayRateOk, resolveRelayDest, relayDropTotalPreAuth, relayDropCounts, buildControlState, publishControlState, publishControlStateToRelays, scheduleControlState, handleControlStateCommand, handleWatchlistControlCommand, handleTaskRouteControlCommand, recoverConfigJournal, CONTROL_COMMAND_KIND, CONTROL_COMMAND_D, WATCHLIST_COMMAND_D, TASK_ROUTE_MESSAGE_TYPE, TASK_ROUTE_PROTOCOL }
 export { comparePublicShadow, shadowGatePublic, shadowInFlight, __setShadowRunnerForTests }
 
 // --- boot -------------------------------------------------------------------

--- a/tests/watchlist.mjs
+++ b/tests/watchlist.mjs
@@ -11,14 +11,18 @@
 //
 //   node tests/watchlist.mjs
 
-import { mkdtempSync, writeFileSync, readFileSync, chmodSync } from 'node:fs'
+import { mkdtempSync, writeFileSync, readFileSync, chmodSync, mkdirSync, existsSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { generateSecretKey, getPublicKey, finalizeEvent } from 'nostr-tools/pure'
 
 const tmp = mkdtempSync(join(tmpdir(), 'wb-watchlist-'))
+const configDir = join(tmp, 'tree')
+const stateDir = join(tmp, 'data')
+mkdirSync(configDir)
+mkdirSync(stateDir)
 const CHAN = '77777777-7777-7777-7777-777777777777'
-const CFG = join(tmp, 'config.json')
+const CFG = join(configDir, 'config.json')
 const existing = getPublicKey(generateSecretKey())   // a pre-existing static watch author
 const approverSk = generateSecretKey(), approver = getPublicKey(approverSk)
 writeFileSync(CFG, JSON.stringify({
@@ -28,11 +32,14 @@ writeFileSync(CFG, JSON.stringify({
 process.env.WB_NO_BOOT = '1'
 process.env.FORWARD_MODE = 'dryrun'
 process.env.CONFIG_PATH = CFG
-process.env.SEEN_PATH = join(tmp, 'seen.log')
+process.env.SEEN_PATH = join(stateDir, 'seen.log')
 process.env.PUB_WATERMARK_PATH = join(tmp, 'wm')
 process.env.POSTED_MAP_PATH = join(tmp, 'pm.log')
+// Match production's systemd boundary: the bridge may update the existing config inode and its
+// data directory, but it cannot create/rename anything in the source-tree parent.
+chmodSync(configDir, 0o555)
 
-const { addWatchAuthor, removeWatchAuthor, WATCH_REFRESHERS, PUB, routePublic, handleCommand } = await import('../src/bridge.mjs')
+const { addWatchAuthor, removeWatchAuthor, WATCH_REFRESHERS, PUB, routePublic, handleCommand, recoverConfigJournal } = await import('../src/bridge.mjs')
 
 const realLog = console.log.bind(console)
 let n = 0, pass = 0
@@ -63,6 +70,7 @@ const r = addWatchAuthor(X)
 t('addWatchAuthor returns added', r.ok === true && r.added === true)
 t('  PUB.authors now includes X', PUB.authors.includes(X))
 t('  the config file persisted X (survives a real reboot)', cfgAuthors().includes(X))
+t('  the crash journal was cleared after the fsynced config write', !existsSync(join(stateDir, 'config-write-journal.json')))
 t('  the relay re-subscribe refresher fired (posts will actually be fetched)', fired === firedBefore + 1)
 t('  now X\'s feed post IS routed as mirrored feed', mirrored(routeOf(feedPost(sk))))
 
@@ -85,12 +93,11 @@ t('  X\'s feed post is no longer mirrored', !mirrored(routeOf(feedPost(sk))))
 t('the original watch_authors entry survived every mutation', cfgAuthors().includes(existing) && PUB.authors.includes(existing))
 
 // --- 6. persistence failure is fail-closed ----------------------------------------------------
-// The config write is the commit point: a temporary live mutation would lie to the operator and
-// reverse at the next restart. An atomic replace needs write permission on its parent directory,
-// not on the old file, so remove directory write permission and prove neither add nor remove
-// changes the active set or triggers a relay re-subscribe.
+// The journal is the commit point: a temporary live mutation would lie to the operator and
+// reverse at the next restart. Remove state-directory write permission and prove neither add nor
+// remove changes the active set or triggers a relay re-subscribe.
 const Y = getPublicKey(generateSecretKey())
-chmodSync(tmp, 0o555)
+chmodSync(stateDir, 0o555)
 const beforeFailedAdd = fired
 const failedAdd = addWatchAuthor(Y)
 t('a failed persist refuses an add', failedAdd.ok === false)
@@ -101,9 +108,20 @@ const failedRemove = removeWatchAuthor(existing)
 t('a failed persist refuses a removal', failedRemove.ok === false)
 t('  a failed removal does NOT alter the live watched set', PUB.authors.includes(existing))
 t('  a failed removal does NOT refresh relay filters', fired === beforeFailedRemove)
-chmodSync(tmp, 0o700)
+chmodSync(stateDir, 0o700)
 
-// --- 7. signed staging-console commands -------------------------------------------------------
+// --- 7. an interrupted inode update is recovered before config parsing ------------------------
+const beforeRecovery = readFileSync(CFG, 'utf8')
+const recovered = JSON.parse(beforeRecovery)
+recovered.public.watchlist_command_at = 424242
+const recoveryPayload = JSON.stringify(recovered, null, 2) + '\n'
+writeFileSync(join(stateDir, 'config-write-journal.json'), recoveryPayload, { mode: 0o600 })
+writeFileSync(CFG, '{"interrupted":')
+recoverConfigJournal()
+t('an interrupted config write replays the complete journal', readFileSync(CFG, 'utf8') === recoveryPayload)
+t('  successful recovery clears the journal durably', !existsSync(join(stateDir, 'config-write-journal.json')))
+
+// --- 8. signed staging-console commands -------------------------------------------------------
 // `watch` already means reply-follow, so whole-feed administration is explicitly namespaced:
 // `waggle mirror` / `waggle unmirror`. Only a configured approver may operate it.
 const Z = getPublicKey(generateSecretKey())


### PR DESCRIPTION
## What changed
- journal the complete intended config under the writable runtime data directory
- update and fsync the existing config inode without granting write access to the source directory
- replay an interrupted transaction before config parsing on boot
- exercise the real systemd boundary, fail-closed behavior, and torn-write recovery

## Production evidence
The owner-signed Codex task route passed crypto and admission checks but was rejected with `could not persist task route`; `/opt/waggle-read` is intentionally read-only while only the existing config inode and data directory are writable. Atomic rename therefore could never succeed.

## Verification
- `node tests/watchlist.mjs` — 29/29
- `npm run lint`
- `npm test` — all 46 suites