### PR TITLE
React to messages after return-lane relay

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -245,6 +245,7 @@ firewall → root-SSH off → reboot test. (Same verify-before-lock philosophy a
 SEALED_LANES=off
 FORWARD_MODE=dryrun            # buzz only at cutover step 4c
 BUZZ_RELAY_URL=...
+BUZZ_EVENT_ENDPOINT=https://<fixed Buzz host>/events  # exact-event API; never a wss relay URL
 BUZZ_PRIVATE_KEY=...           # the BRIDGE posting identity — never an agent key
 BUZZ_AUTH_TAG=...
 ```

--- a/deploy/waggle-read.service
+++ b/deploy/waggle-read.service
@@ -5,7 +5,8 @@
 #   SEALED_LANES=off           # this instance runs the public lane ONLY (sealed lanes are
 #                              # per-process-deduped — two instances running them = double delivery)
 #   FORWARD_MODE=dryrun        # flip to 'buzz' only at cutover (see deploy/README.md)
-#   BUZZ_RELAY_URL=...  BUZZ_PRIVATE_KEY=...  BUZZ_AUTH_TAG=...
+#   BUZZ_RELAY_URL=...  BUZZ_EVENT_ENDPOINT=https://<fixed Buzz host>/events
+#   BUZZ_PRIVATE_KEY=...  BUZZ_AUTH_TAG=...
 # Optional keyless Nostr transport (both mode-0600 files are required together):
 #   WAGGLE_BUNKER_URI_FILE=/etc/waggle/credentials/bridge.bunker-uri
 #   WAGGLE_NIP46_CLIENT_NSEC_FILE=/etc/waggle/credentials/bridge.client-nsec

--- a/src/bridge.mjs
+++ b/src/bridge.mjs
@@ -38,7 +38,7 @@ import WebSocket from 'ws'
 import { getEventHash, verifyEvent } from 'nostr-tools/pure'
 import * as nip19 from 'nostr-tools/nip19'
 import { emit, query, checkConfigRenderable, runPolicyShadowSsh } from './egress.mjs'
-import { bridgePubkey, bridgeSignerMode, hasBridgeKey, openSeal, openRumor, sealAndWrap, consentTosBlock, signControlState } from './nostr_egress.mjs'
+import { bridgePubkey, bridgeSignerMode, hasBridgeKey, openSeal, openRumor, sealAndWrap, consentTosBlock, signControlState, prepareRelayActionReaction, submitRelayActionReaction } from './nostr_egress.mjs'
 import { verifyConsent } from './consent.mjs'   // in-door consent (#131/#132, docs/CONSENT.md §8)
 import { createHash, randomBytes } from 'node:crypto'
 import { readFileSync, writeFileSync, appendFileSync, existsSync, mkdirSync, renameSync, unlinkSync, openSync, closeSync, fsyncSync } from 'node:fs'
@@ -74,10 +74,13 @@ const SEEN_CAP = Number(process.env.SEEN_CAP || 100000)
 const RLSEEN_PATH = process.env.RLSEEN_PATH || resolve(ROOT, 'data', 'return-lane-seen.log')
 const MIRRORASKED_PATH = process.env.MIRRORASKED_PATH || resolve(ROOT, 'data', 'mirror-asked.log')
 const RLPENDING_PATH = process.env.RLPENDING_PATH || resolve(ROOT, 'data', 'return-lane-pending.log')
+const RLREACTION_PATH = process.env.RLREACTION_PATH || resolve(ROOT, 'data', 'return-lane-reactions.log')
+const RLREACTIONSEEN_PATH = process.env.RLREACTIONSEEN_PATH || resolve(ROOT, 'data', 'return-lane-reactions-seen.log')
 // Bounded, or one permanently-unreachable recipient retries forever. On the ~4-minute scan poll
 // this is roughly two hours of outage before a carry is dead-lettered — long enough to ride out a
 // relay flap, short enough that a dead key is surfaced the same day.
 const RLPENDING_MAX_ATTEMPTS = Number(process.env.RLPENDING_MAX_ATTEMPTS || 30)
+const RLREACTION_MAX_ATTEMPTS = Number(process.env.RLREACTION_MAX_ATTEMPTS || 30)
 const RLSEEN_CAP = Number(process.env.RLSEEN_CAP || 100000)
 // Relay-lane dedup store (DESIGN_RELAY_INGRESS §6): wraps addressed to waggle's OWN key that it
 // unwraps and relays into a channel. Its own append-only capped file — checked BEFORE decryption
@@ -1645,10 +1648,40 @@ const rlKey = (srcId, recipHex) => String(srcId) + '\x1f' + String(recipHex)
 // durable storage instead of from the window, so the cursor keeps advancing (no lane-wide stall
 // from one dead recipient) and the carry survives anyway.
 const rlPending = durableQueue({ path: RLPENDING_PATH, cap: 5000, label: 'return lane pending' })
+// A landed carry and its visible Buzz acknowledgement have different failure domains. Never
+// re-carry a sealed instruction merely because the reaction write failed; remember the reaction
+// as separately owed work and retry it independently.
+const rlReactionPending = durableQueue({ path: RLREACTION_PATH, cap: 5000, label: 'return lane reaction' })
+// Source-level completion is separate from source×recipient carry completion. A message that
+// reaches recipient A now and recipient B on a later retry still earns exactly one visible 👍.
+const rlReactionSeenStore = durableSet({ path: RLREACTIONSEEN_PATH, cap: RLSEEN_CAP, label: 'return lane reaction', noun: 'confirmed source ids' })
+const rlReactionSeen = rlReactionSeenStore.mem
+const rlReactionInFlight = new Set()
 const loadRlSeen = () => rlSeenStore.load()
 const addRlSeen = (key) => rlSeenStore.claim(key)
 const dropRlSeen = (key) => rlSeenStore.rollback(key)
 const markRlSeen = (key) => rlSeenStore.commit(key)
+
+function oweRelayAction(sourceId) {
+  const id = String(sourceId || '').toLowerCase()
+  if (!/^[0-9a-f]{64}$/.test(id) || rlReactionSeen.has(id) || rlReactionPending.has(id)) return false
+  if (!rlReactionPending.enqueue(id, { source: id }, true)) throw new Error(`return-lane reaction debt could not be durably persisted for ${id}`)
+  return true
+}
+
+// The reaction debt MUST become durable before the accepted carry does. If the process exits
+// between these two commits, restart may conservatively re-carry once, but it cannot lose the
+// user-visible acknowledgement forever. The optional hook exists only for the hermetic crash
+// regression; production callers cannot inject it.
+function commitLandedCarry(key, sourceId, afterReactionOwed = null) {
+  oweRelayAction(sourceId)
+  if (afterReactionOwed) {
+    if (process.env.WB_NO_BOOT !== '1') throw new Error('return-lane crash hook is test-only')
+    afterReactionOwed()
+  }
+  markRlSeen(key)
+  rlPending.remove(key)
+}
 
 // Drop-log dedup (finding #2). The signer-gate err() in scanReturnLane fires before the
 // per-recipient rlSeen check, so without this a STATIC backlog of non-admitted signers re-logs
@@ -2141,6 +2174,49 @@ function carryDescriptor(recipient, message, why, channel) {
   return { template: 'return_task_carry', slots: { channel: ch, why, source } }
 }
 
+async function confirmRelayAction(sourceId, send = submitRelayActionReaction) {
+  const id = String(sourceId || '').toLowerCase()
+  if (!/^[0-9a-f]{64}$/.test(id) || rlReactionSeen.has(id) || rlReactionInFlight.has(id)) return false
+  oweRelayAction(id)
+  if (rlReactionPending.entries().find(x => x.key === id)?.attempts >= RLREACTION_MAX_ATTEMPTS) return false
+  rlReactionInFlight.add(id)
+  const attempt = rlReactionPending.attempt(id)
+  try {
+    let item = rlReactionPending.mem.get(id)?.item
+    if (!item?.event) {
+      const event = await prepareRelayActionReaction(id)
+      item = { source: id, event }
+      if (!rlReactionPending.update(id, item, true)) throw new Error('exact signed reaction could not be durably prepared')
+    }
+    const reactionId = String(item.event.id || '').toLowerCase()
+    // Journal the exact prepared id durably BEFORE submitting those same signed bytes. An extra
+    // journal row after a definite refusal is harmless; an accepted unjournaled signer event is
+    // not. On crash/restart the queue retains item.event and resubmits it byte-identically.
+    if (!journalSend(reactionId, { kind: 7, lane: 'return-reaction', source: id }, true)) throw new Error('prepared reaction tripwire row could not be persisted')
+    const submittedId = await send(item.event)
+    if (submittedId !== reactionId) throw new Error('Buzz reaction submitter did not bind the exact prepared event id')
+    if (!rlReactionSeenStore.commit(id, true)) throw new Error('reaction acceptance could not be durably completed')
+    rlReactionPending.remove(id, true)
+    log(`RETURN confirm[👍]: ${id.slice(0, 12)}… reacted after relay acceptance`)
+    return true
+  } catch (e) {
+    err(`RETURN confirm[pending]: ${id.slice(0, 12)}… reaction attempt ${attempt} failed: ${String(e?.message || e).slice(0, 160)}`)
+    return false
+  } finally { rlReactionInFlight.delete(id) }
+}
+
+async function retryPendingReactions(send = submitRelayActionReaction) {
+  for (const { key, item, attempts } of rlReactionPending.entries()) {
+    if (rlReactionSeen.has(key)) { rlReactionPending.remove(key); continue }
+    if (!item?.source || attempts >= RLREACTION_MAX_ATTEMPTS) {
+      if (attempts >= RLREACTION_MAX_ATTEMPTS) err(`RETURN confirm[dead-letter]: ${String(item?.source || key).slice(0, 12)}… reaction failed ${attempts} times`)
+      rlReactionPending.remove(key)
+      continue
+    }
+    await confirmRelayAction(item.source, send)
+  }
+}
+
 // Scan a batch of channel messages for return-lane triggers and carry each out — exactly once.
 // Two trigger types:
 //   • @mention — a resolved p-tag EXACTLY equal to the recipient's delivery key (Buzz resolves an
@@ -2166,6 +2242,9 @@ function carryDescriptor(recipient, message, why, channel) {
 // only ever moves bytes to an address. The one place a body could reach a prompt is the action
 // layer, where the wake is content-free and the body is read-plane data (design §5).
 async function scanReturnLane(msgs, opts = {}) {
+  // WB_NO_BOOT is the established hermetic test seam. Production uses the closed Buzz egress;
+  // a harness must inject `react` explicitly when it wants to drive acknowledgement behavior.
+  const react = opts.react || (process.env.WB_NO_BOOT || FORWARD_MODE !== 'buzz' ? async event => event.id : submitRelayActionReaction)
   const recipients = activeReturnLane()
   if (!recipients.length || !hasBridgeKey()) return
   const gateActive = opts.authors !== undefined            // an explicit (even empty) gate is default-closed
@@ -2190,6 +2269,7 @@ async function scanReturnLane(msgs, opts = {}) {
     // Direct parent(s) only — the `reply`-marked e-tag. NOT the `root` tag: matching root would
     // deliver every message in a thread the agent started, not the replies actually to it.
     const parents = tags.filter(t => t[0] === 'e' && t[1] && t[3] === 'reply').map(t => String(t[1]).toLowerCase())
+    let carried = false
     // No break: one message fans out to EVERY matching recipient, each deduped on its own
     // (source × recipient) key. "@a @b" reaching only one of them was finding #4.
     for (const r of recipients) {
@@ -2220,8 +2300,8 @@ async function scanReturnLane(msgs, opts = {}) {
       // Persist-on-landed: durable dedup only once the seal reached a relay. A silent 0/N is rolled
       // back so the overlap re-read (and a restart) re-carry it — a rare re-carry beats a lost mention.
       if (accepted >= 1) {
-        markRlSeen(key)
-        rlPending.remove(key)                              // landed: no longer owed
+        commitLandedCarry(key, m.id, opts.afterReactionOwed)
+        carried = true
       } else {
         dropRlSeen(key)
         // Owed, durably. The overlap re-read may still catch it first; enqueue is idempotent and
@@ -2230,6 +2310,7 @@ async function scanReturnLane(msgs, opts = {}) {
           protocol: r.protocol || null, channel: opts.channel || null, source: r.protocol === 'nvoy-task-carry-v1' ? sourceWireEvent(m) : null })
       }
     }
+    if (carried) await confirmRelayAction(m.id, react)
   }
 }
 
@@ -2242,6 +2323,7 @@ async function scanReturnLane(msgs, opts = {}) {
 // stops. The bound converts it into a loud, dated, per-recipient report — and a dead-letter that
 // is logged and dropped, never a queue that grows forever.
 async function retryPendingCarries(opts = {}) {
+  const react = opts.react || (process.env.WB_NO_BOOT || FORWARD_MODE !== 'buzz' ? async event => event.id : submitRelayActionReaction)
   if (!PUB || !activeReturnLane().length || !hasBridgeKey()) return
   const owed = rlPending.entries()
   if (!owed.length) return
@@ -2267,8 +2349,8 @@ async function retryPendingCarries(opts = {}) {
     const accepted = await returnLaneSend(item.to, descriptor,
       { src: item.src, why: item.why, protocol: item.protocol || 'return-carry-v1', channel: item.channel || null, retry: n }, opts.publish)
     if (accepted >= 1) {
-      markRlSeen(key)
-      rlPending.remove(key)
+      commitLandedCarry(key, item.src, opts.afterReactionOwed)
+      await confirmRelayAction(item.src, react)
       landed++
       log(`RETURN retry ok: carried ${String(item.src).slice(0, 12)}… to ${String(item.to).slice(0, 12)}… on attempt ${n}`)
     }
@@ -2298,6 +2380,7 @@ async function pollCommands(now = Date.now()) {
     for (const m of msgs) { if ((m.created_at || 0) >= cmdCursor - 300) handleCommand(m).catch(er => err(`commands: ${er.message}`)) }
     scanReturnLane(msgs)
       .then(() => retryPendingCarries())                  // #117: owed carries, independent of the cursor
+      .then(() => retryPendingReactions())
       .catch(er => err(`return lane: staging carry failed: ${er.message}`))
     cmdCursor = Math.floor(Date.now() / 1000)
     commandPollFailures = 0
@@ -2411,6 +2494,8 @@ async function pollScanChannels() {
   for (const ch of PUB.scanChannels) {
     try { await scanChannel(ch) } catch (e) { err(`scan: poll failed for ${String(ch).slice(0, 8)}…: ${e.message}`) }
   }
+  await retryPendingCarries()
+  await retryPendingReactions()
 }
 
 let scanPollingTimer = null
@@ -2670,6 +2755,9 @@ function connectPublic(url) {
   open()
 }
 
+// Reaction helpers are exported separately to keep the existing broad test-hook line stable.
+export { rlReactionPending, rlReactionSeen, oweRelayAction, commitLandedCarry, confirmRelayAction, retryPendingReactions, RLREACTION_MAX_ATTEMPTS }
+
 // --- test hook --------------------------------------------------------------
 // Exported so a harness can drive the REAL routing functions (not a copy) with synthetic
 // events in dryrun, without opening any relay socket. Set WB_NO_BOOT=1 to import without
@@ -2684,6 +2772,8 @@ if (!process.env.WB_NO_BOOT) {
   loadRlSeen()
   mirrorAskedStore.load()   // §6: who we've already sent a consent-request DM (once per target)
   rlPending.load()
+  rlReactionPending.load()
+  rlReactionSeenStore.load()
   loadRelaySeen()
   // #171 — say it on every boot. A record of lost messages that nobody reads is the same silence
   // it exists to end, one level further out. Non-fatal: these are past losses, not a reason to

--- a/src/egress.mjs
+++ b/src/egress.mjs
@@ -283,6 +283,15 @@ const CATALOGUE = {
       reject('enum', `watchlist_ack verb fell through: ${JSON.stringify(verb)}`)
     },
   },
+
+  // Visible delivery confirmation for a Buzz message that triggered a return-lane carry. The
+  // emoji is catalogue-owned: the bridge may acknowledge this one closed operation, never react
+  // with caller-supplied sentiment or prose.
+  relay_action_reaction: {
+    action: 'reaction',
+    slots: {},
+    render: () => null,
+  },
 }
 
 export const TEMPLATE_NAMES = Object.freeze(Object.keys(CATALOGUE))
@@ -440,6 +449,7 @@ function argvFor(spec, descriptor, content) {
     case 'reply':  return ['messages', 'send', '--channel', SLOT_TYPES.channel(descriptor.dest), '--reply-to', SLOT_TYPES.id(descriptor.parentId), '--content', content]
     case 'edit':   return ['messages', 'edit', '--event', SLOT_TYPES.id(descriptor.targetId), '--content', content]
     case 'delete': return ['messages', 'delete', '--event', SLOT_TYPES.id(descriptor.targetId), '--reason-code', 'nip09', '--public-reason', 'withdrawn by author (NIP-09)']
+    case 'reaction': return ['reactions', 'add', '--event', SLOT_TYPES.id(descriptor.targetId), '--emoji', '👍']
     default:       return reject('action', `unknown action ${JSON.stringify(spec.action)}`)
   }
 }

--- a/src/nostr_egress.mjs
+++ b/src/nostr_egress.mjs
@@ -76,7 +76,11 @@ function exactPreparedReaction(event) {
 export async function submitRelayActionReaction(prepared, fetchImpl = globalThis.fetch) {
   const event = exactPreparedReaction(prepared)
   let endpoint
-  try { endpoint = new URL('/events', String(process.env.BUZZ_RELAY_URL || 'http://localhost:3000')) } catch { reject('BUZZ_RELAY_URL is invalid') }
+  // A Nostr relay URL is commonly wss:// and is not necessarily the Buzz event API. Keep the
+  // write authority on a separately named, fixed HTTPS origin; accept the historical variable
+  // only when it already names an HTTP(S) API so existing deployments do not break silently.
+  const endpointBase = String(process.env.BUZZ_EVENT_ENDPOINT || process.env.BUZZ_RELAY_URL || 'http://localhost:3000')
+  try { endpoint = new URL('/events', endpointBase) } catch { reject('BUZZ_EVENT_ENDPOINT is invalid') }
   if (endpoint.username || endpoint.password || endpoint.search || endpoint.hash ||
       (endpoint.protocol !== 'https:' && !(endpoint.protocol === 'http:' && ['localhost', '127.0.0.1', '::1'].includes(endpoint.hostname)))) reject('Buzz event endpoint must be HTTPS or loopback HTTP')
   const body = JSON.stringify(event)

--- a/src/nostr_egress.mjs
+++ b/src/nostr_egress.mjs
@@ -17,6 +17,7 @@
 import { finalizeEvent, generateSecretKey, getEventHash, verifyEvent } from 'nostr-tools/pure'
 import * as nip44 from 'nostr-tools/nip44'
 import { loadNostrSigner } from './nostr_signer.mjs'
+import { createHash, randomBytes } from 'node:crypto'
 
 // --- The key, held here and nowhere else ------------------------------------------------------
 const BRIDGE_SIGNER = loadNostrSigner()
@@ -37,6 +38,65 @@ async function signExact(template, label) {
       event.created_at !== template.created_at || event.content !== template.content ||
       JSON.stringify(event.tags) !== JSON.stringify(template.tags)) reject(`bridge signer changed or invalidated ${label}`)
   return event
+}
+
+const configuredBuzzAuthTag = () => {
+  const raw = String(process.env.BUZZ_AUTH_TAG || '').trim()
+  if (!raw) return null
+  let tag
+  try { tag = JSON.parse(raw) } catch { reject('BUZZ_AUTH_TAG is not JSON') }
+  if (!Array.isArray(tag) || tag.length !== 4 || tag[0] !== 'auth' || !tag.every(v => typeof v === 'string')) reject('BUZZ_AUTH_TAG is not one exact auth tag')
+  return tag
+}
+
+// Closed kind:7 transaction for the return-lane acknowledgement. Preparation and submission are
+// deliberately separate capabilities: bridge.mjs durably stores the exact signed event and its
+// tripwire row between them. A restart therefore retries identical bytes, never re-signs.
+export async function prepareRelayActionReaction(targetId, now = Math.floor(Date.now() / 1000)) {
+  const target = hex64(targetId, 'reaction target')
+  const auth = configuredBuzzAuthTag()
+  return signExact({ kind: 7, created_at: Math.floor(num(now, 'reaction created_at')),
+    tags: [...(auth ? [auth] : []), ['e', target]], content: '👍' }, 'relay action reaction')
+}
+
+function exactPreparedReaction(event) {
+  const wire = JSON.parse(JSON.stringify(event))
+  let valid = false
+  try { valid = verifyEvent(wire) } catch { valid = false }
+  const auth = configuredBuzzAuthTag()
+  const expectedTags = [...(auth ? [auth] : []), ['e', wire.tags?.find(t => t[0] === 'e')?.[1]]]
+  if (!valid || wire.pubkey !== BRIDGE_PK || wire.kind !== 7 || wire.content !== '👍' ||
+      Object.keys(wire).sort().join(',') !== 'content,created_at,id,kind,pubkey,sig,tags' ||
+      !/^[0-9a-f]{64}$/.test(String(expectedTags.at(-1)?.[1] || '')) || JSON.stringify(wire.tags) !== JSON.stringify(expectedTags)) {
+    reject('prepared relay action reaction is invalid or outside the closed template')
+  }
+  return wire
+}
+
+export async function submitRelayActionReaction(prepared, fetchImpl = globalThis.fetch) {
+  const event = exactPreparedReaction(prepared)
+  let endpoint
+  try { endpoint = new URL('/events', String(process.env.BUZZ_RELAY_URL || 'http://localhost:3000')) } catch { reject('BUZZ_RELAY_URL is invalid') }
+  if (endpoint.username || endpoint.password || endpoint.search || endpoint.hash ||
+      (endpoint.protocol !== 'https:' && !(endpoint.protocol === 'http:' && ['localhost', '127.0.0.1', '::1'].includes(endpoint.hostname)))) reject('Buzz event endpoint must be HTTPS or loopback HTTP')
+  const body = JSON.stringify(event)
+  const auth = await signExact({ kind: 27235, created_at: Math.floor(Date.now() / 1000), content: '', tags: [
+    ['u', endpoint.toString()], ['method', 'POST'], ['payload', createHash('sha256').update(body).digest('hex')],
+    ['nonce', randomBytes(24).toString('base64url')],
+  ] }, 'relay action NIP-98 authorization')
+  const headers = { authorization: `Nostr ${Buffer.from(JSON.stringify(auth)).toString('base64')}`, 'content-type': 'application/json' }
+  const authTag = configuredBuzzAuthTag()
+  if (authTag) headers['x-auth-tag'] = JSON.stringify(authTag)
+  let response
+  try { response = await fetchImpl(endpoint, { method: 'POST', redirect: 'manual', signal: globalThis.AbortSignal.timeout(30_000), headers, body }) }
+  catch (e) { throw new Error(`Buzz reaction submission outcome unknown: ${e?.name || 'network error'}`) }
+  const text = await response.text()
+  if (Buffer.byteLength(text) > 64 * 1024) throw new Error('Buzz reaction response exceeded 64 KiB')
+  if (!response.ok) throw new Error(`Buzz reaction submission failed HTTP ${response.status}`)
+  let result
+  try { result = JSON.parse(text) } catch { throw new Error('Buzz reaction response was not JSON') }
+  if (result?.event_id !== event.id || result?.accepted !== true) throw new Error('Buzz reaction response did not accept the exact prepared event')
+  return event.id
 }
 
 // NIP-78 application data. This is deliberately an addressable event: consumers ask for the

--- a/src/stores.mjs
+++ b/src/stores.mjs
@@ -1,7 +1,7 @@
 // Extracted from bridge.mjs by #154. Behaviour is byte-identical; only the file boundary is new.
 //
 // Depends only on node:fs, node:path and the logger — no config, no lane knowledge.
-import { readFileSync, appendFileSync, existsSync, mkdirSync } from 'node:fs'
+import { readFileSync, appendFileSync, existsSync, mkdirSync, openSync, writeFileSync, fsyncSync, closeSync } from 'node:fs'
 import { dirname } from 'node:path'
 import { log, err } from './log.mjs'
 
@@ -26,17 +26,37 @@ import { log, err } from './log.mjs'
 // `mem` is the Set itself, exposed because the lanes (and the suites) check it directly.
 function durableSet({ path, cap, label, noun }) {
   const mem = new Set()
+  const append = (text, durable = false) => {
+    let fileFd = null, dirFd = null
+    try {
+      const directory = dirname(path)
+      mkdirSync(directory, { recursive: true })
+      if (!durable) { appendFileSync(path, text); return true }
+      fileFd = openSync(path, 'a', 0o600)
+      writeFileSync(fileFd, text); fsyncSync(fileFd); closeSync(fileFd); fileFd = null
+      dirFd = openSync(directory, 'r'); fsyncSync(dirFd); closeSync(dirFd); dirFd = null
+      return true
+    } catch (e) {
+      err(`${label}: append failed: ${e.message}`)
+      return false
+    } finally {
+      if (fileFd !== null) { try { closeSync(fileFd) } catch {} }
+      if (dirFd !== null) { try { closeSync(dirFd) } catch {} }
+    }
+  }
   return {
     mem,
     has: (k) => mem.has(k),
     claim: (k) => { mem.add(k) },
     rollback: (k) => { mem.delete(k) },
-    commit(k) {
+    commit(k, durable = false) {
+      const already = mem.has(k)
       mem.add(k)
       // Truncated at 64 so a full event id still prints whole, while a long composite key
       // (source × recipient) cannot flood the journal the tripwire reads.
-      try { appendFileSync(path, k + '\n') }
-      catch (e) { err(`${label}: append failed for ${String(k).slice(0, 64)}: ${e.message}`) }
+      if (append(k + '\n', durable)) return true
+      if (!already) mem.delete(k)
+      return false
     },
     load() {
       // The mkdir on the missing-file path is what guarantees the directory exists for every
@@ -70,19 +90,44 @@ function durableSet({ path, cap, label, noun }) {
 // to the last `cap` records.
 function durableQueue({ path, cap, label }) {
   const mem = new Map()   // key -> { item, attempts }
-  const append = (rec) => {
-    try { appendFileSync(path, JSON.stringify(rec) + '\n') }
-    catch (e) { err(`${label}: append failed for ${String(rec.k).slice(0, 64)}: ${e.message}`) }
+  const append = (rec, durable = false) => {
+    let fileFd = null, dirFd = null
+    try {
+      const directory = dirname(path), text = JSON.stringify(rec) + '\n'
+      mkdirSync(directory, { recursive: true })
+      if (!durable) { appendFileSync(path, text); return true }
+      fileFd = openSync(path, 'a', 0o600)
+      writeFileSync(fileFd, text); fsyncSync(fileFd); closeSync(fileFd); fileFd = null
+      dirFd = openSync(directory, 'r'); fsyncSync(dirFd); closeSync(dirFd); dirFd = null
+      return true
+    } catch (e) {
+      err(`${label}: append failed for ${String(rec.k).slice(0, 64)}: ${e.message}`)
+      return false
+    } finally {
+      if (fileFd !== null) { try { closeSync(fileFd) } catch {} }
+      if (dirFd !== null) { try { closeSync(dirFd) } catch {} }
+    }
   }
   return {
     mem,
     size: () => mem.size,
     has: (k) => mem.has(k),
     entries: () => [...mem.entries()].map(([k, v]) => ({ key: k, item: v.item, attempts: v.attempts })),
-    enqueue(k, item) {
-      if (mem.has(k)) return                       // already owed; do not reset its attempt count
+    enqueue(k, item, durable = false) {
+      if (mem.has(k)) return true                  // already owed; do not reset its attempt count
       mem.set(k, { item, attempts: 0 })
-      append({ k, v: item })
+      if (append({ k, v: item }, durable)) return true
+      mem.delete(k)                                // memory may never claim durability that failed
+      return false
+    },
+    update(k, item, durable = false) {
+      const current = mem.get(k)
+      if (!current) return false
+      const previous = current.item
+      current.item = item
+      if (append({ k, v: item, a: current.attempts }, durable)) return true
+      current.item = previous
+      return false
     },
     // Recording the attempt BEFORE the retry is deliberate: a crash mid-retry must not buy a free
     // attempt, or a permanently-failing item could loop forever across restarts and never reach
@@ -90,13 +135,16 @@ function durableQueue({ path, cap, label }) {
     attempt(k) {
       const e = mem.get(k)
       if (!e) return 0
-      e.attempts += 1
-      append({ k, a: e.attempts })
-      return e.attempts
+      const next = e.attempts + 1
+      if (!append({ k, a: next })) return e.attempts
+      e.attempts = next
+      return next
     },
-    remove(k) {
-      if (!mem.delete(k)) return false
-      append({ k, d: 1 })
+    remove(k, durable = false) {
+      const existing = mem.get(k)
+      if (!existing) return false
+      if (!append({ k, d: 1 }, durable)) return false
+      mem.delete(k)
       return true
     },
     load() {
@@ -108,7 +156,7 @@ function durableQueue({ path, cap, label }) {
         try { r = JSON.parse(line) } catch { continue }   // a torn final write is skipped, not fatal
         if (!r || !r.k) continue
         if (r.d) { mem.delete(r.k); continue }
-        if (r.v !== undefined) { mem.set(r.k, { item: r.v, attempts: 0 }); continue }
+        if (r.v !== undefined) { mem.set(r.k, { item: r.v, attempts: Number.isSafeInteger(r.a) && r.a >= 0 ? r.a : 0 }); continue }
         if (r.a !== undefined && mem.has(r.k)) mem.get(r.k).attempts = r.a
       }
       log(`${label}: loaded ${mem.size} owed item(s) from ${path}${lines.length > kept.length ? ` (pruned ${lines.length - kept.length})` : ''}`)

--- a/tests/admission_return_lane.mjs
+++ b/tests/admission_return_lane.mjs
@@ -42,6 +42,7 @@ const scope = () => {
 const grant = wire(finalizeEvent({ kind: 440, created_at: Math.floor(Date.now() / 1000), tags: [['p', burnerPk], ['da-scope', ...scope()], ['da-cap', 'admit']], content: '' }, grantorSk))
 const journal = () => existsSync(process.env.SEND_JOURNAL_PATH)
   ? readFileSync(process.env.SEND_JOURNAL_PATH, 'utf8').trim().split('\n').filter(Boolean).map(JSON.parse) : []
+const returnRows = () => journal().filter(row => row.lane === 'return')
 let failed = 0
 const ok = (label, cond) => { console.log(`${cond ? 'ok  ' : 'FAIL'} — ${label}`); if (!cond) failed++ }
 
@@ -50,16 +51,16 @@ processGrantEvent(grant)
 ok('a valid grant auto-registers the burner as a return recipient', activeReturnLane().some(r => r.npub_hex === burnerPk && r.dynamic))
 
 await scanReturnLane([{ id: 'a'.repeat(64), pubkey: authorPk, tags: [['p', burnerPk]], content: 'a structured reply for the burner' }])
-ok('a p-tagged post reaches the admitted burner', journal().length === 1 && journal()[0].to === burnerPk.slice(0, 12))
+ok('a p-tagged post reaches the admitted burner', returnRows().length === 1 && returnRows()[0].to === burnerPk.slice(0, 12))
 
 await scanReturnLane([{ id: 'b'.repeat(64), pubkey: authorPk, tags: [], content: 'hello @someone else' }])
-ok('a bare grant does not create a catch-all textual mention', journal().length === 1)
+ok('a bare grant does not create a catch-all textual mention', returnRows().length === 1)
 
 const rev = wire(finalizeEvent({ kind: 441, created_at: Math.floor(Date.now() / 1000) + 1, tags: [['e', grant.id]], content: '' }, grantorSk))
 processGrantEvent(rev)
 ok('a valid revocation removes the dynamic return address', !activeReturnLane().some(r => r.npub_hex === burnerPk))
 await scanReturnLane([{ id: 'c'.repeat(64), pubkey: authorPk, tags: [['p', burnerPk]], content: 'must not leave after revocation' }])
-ok('a revoked burner receives no later p-tagged carry', journal().length === 1)
+ok('a revoked burner receives no later p-tagged carry', returnRows().length === 1)
 
 console.log(failed ? `\nADMISSION RETURN FAIL — ${failed}` : '\nADMISSION RETURN PASS — grant and reachability share one lifecycle')
 process.exit(failed ? 1 : 0)

--- a/tests/egress_catalogue.mjs
+++ b/tests/egress_catalogue.mjs
@@ -178,6 +178,11 @@ console.log('\n-- emit(): the type has no field for a sentence (INV-A3-3) --')
   const content = argv[argv.indexOf('--content') + 1]
   ok('emit sends exactly the template text', content === '🚫 rejected — no action taken; the author remains quarantined.')
 
+  await emit({ template: 'relay_action_reaction', targetId: 'd'.repeat(64), slots: {} })
+  const reaction = calls[1] || []
+  ok('relay confirmation is a fixed thumbs-up reaction on the exact source event',
+    JSON.stringify(reaction) === JSON.stringify(['reactions', 'add', '--event', 'd'.repeat(64), '--emoji', '👍']))
+
   let rejected = false
   try { await emit('just send this sentence') } catch { rejected = true }
   ok('NEGATIVE CONTROL — emit refuses a bare string descriptor', rejected)

--- a/tests/return_lane_nomiss.mjs
+++ b/tests/return_lane_nomiss.mjs
@@ -63,6 +63,7 @@ let fails = 0
 const ok = (n, c) => { console.log(`${c ? 'ok  ' : 'FAIL'} — ${n}`); if (!c) fails++ }
 const journal = () => existsSync(process.env.SEND_JOURNAL_PATH)
   ? readFileSync(process.env.SEND_JOURNAL_PATH, 'utf8').split('\n').filter(Boolean).map(JSON.parse) : []
+const carries = () => journal().filter(row => row.lane === 'return')
 const short = k => k.slice(0, 12)
 
 // --- synthetic backlog: 7 crew messages inside the 48h window, newest-first ids m1..m7 -----------
@@ -104,15 +105,15 @@ ok('the newest page does not even contain the buried mention (hazard reproduced)
 
 // --- ATOMIC DRAIN: a read that fails mid-walk carries nothing and never advances the cursor -------
 // Page 1 succeeds (3 msgs, none a mention), page 2 errors → acc is dropped, cursor untouched.
-let before = journal().length
+let before = carries().length
 await scanChannel('failchan', makeFetch(2))
-ok('a mid-drain read failure carries NOTHING', journal().length === before)
+ok('a mid-drain read failure carries NOTHING', carries().length === before)
 ok('a failed drain never advances the cursor (next poll re-reads)', loadScanCursors().failchan === undefined)
 
 // --- NO-MISS: a clean paginated drain carries the buried mention despite the page limit -----------
-before = journal().length
+before = carries().length
 await scanChannel('scanchan', makeFetch())
-let carried = journal().slice(before)
+let carried = carries().slice(before)
 const toBuried = carried.filter(e => e.to === short(claude))
 ok('the buried mention is delivered (no-miss across the backlog)',
   toBuried.length === 2)                        // buried m7 + recent m2, both @claude, one carry each
@@ -125,10 +126,10 @@ ok('the next poll now reads from cursor-minus-overlap, not the 48h floor',
 
 // --- OVERLAP is a no-op: the re-read re-scans an already-carried mention, rlSeen suppresses it -----
 // scanSince is now (now-1)-5 = now-6, so the re-read window includes the RECENT mention (now-2).
-before = journal().length
+before = carries().length
 await scanChannel('scanchan', makeFetch())
 ok('the overlap re-read carries nothing new (durable rlSeen suppresses the re-send)',
-  journal().length === before)
+  carries().length === before)
 ok('the recent mention was inside the overlap window (the re-read really did re-scan it)',
   scanSince('scanchan') <= (now - 2))
 

--- a/tests/return_lane_pending.mjs
+++ b/tests/return_lane_pending.mjs
@@ -11,7 +11,7 @@
 //
 // Holding the cursor was the rejected alternative: one permanently-unreachable recipient would pin
 // it forever and stall the lane for everyone. Hence the bound and the dead letter, asserted here.
-import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync } from 'node:fs'
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync, mkdirSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -106,6 +106,14 @@ try {
   ok('a restart reloads exactly what is still owed, and nothing already settled',
     reloaded.size() === 1 && reloaded.entries()[0].key.startsWith('9'.repeat(64)),
     `reloaded ${reloaded.size()}: ${reloaded.entries().map(e => e.key.slice(0, 8)).join(',')}`)
+
+  // A queue entry is not "durable" merely because it reached memory. Force appendFileSync to
+  // fail against a directory and prove enqueue rolls the hot claim back and reports failure.
+  const unwritablePath = join(dir, 'queue-is-a-directory')
+  mkdirSync(unwritablePath)
+  const failing = (await import('../src/stores.mjs')).durableQueue({ path: unwritablePath, cap: 10, label: 'forced-failure' })
+  ok('a failed durable enqueue returns false and leaves no memory-only phantom debt',
+    failing.enqueue('owed', { source: 'x' }) === false && failing.size() === 0)
 } finally {
   rmSync(dir, { recursive: true, force: true })
 }

--- a/tests/return_lane_scan.mjs
+++ b/tests/return_lane_scan.mjs
@@ -71,7 +71,7 @@ const journal = () => existsSync(process.env.SEND_JOURNAL_PATH)
   ? readFileSync(process.env.SEND_JOURNAL_PATH, 'utf8').split('\n').filter(Boolean).map(JSON.parse) : []
 // Run a scan and return only the journal entries it produced.
 async function scanDelta(msgs, opts) {
-  const before = journal().length
+  const before = journal().filter(row => row.lane === 'return').length
   // A working-channel message is a real wire-form signed kind:9. The JSON round-trip strips
   // nostr-tools' finalize symbol, forcing production signature verification in the bridge.
   const wire = msgs.map((m, i) => {
@@ -82,7 +82,7 @@ async function scanDelta(msgs, opts) {
   })
   if (opts === undefined) await scanReturnLane(wire)
   else await scanReturnLane(wire, opts)
-  const j = journal()
+  const j = journal().filter(row => row.lane === 'return')
   return j.slice(before)
 }
 const toOf = e => e.to

--- a/tests/return_lane_task_carry.mjs
+++ b/tests/return_lane_task_carry.mjs
@@ -2,7 +2,7 @@
 // own carrier attestation. Nvoy can therefore authorize the original signer without treating the
 // bridge as the instructor.
 
-import { mkdtempSync, writeFileSync } from 'node:fs'
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { resolve } from 'node:path'
 import { finalizeEvent, generateSecretKey, getPublicKey, verifyEvent } from 'nostr-tools/pure'
@@ -24,18 +24,45 @@ process.env.SEEN_PATH = resolve(dir, 'seen.log')
 process.env.POSTED_MAP_PATH = resolve(dir, 'posted.log')
 process.env.RLSEEN_PATH = resolve(dir, 'rlseen.log')
 process.env.RLPENDING_PATH = resolve(dir, 'pending.log')
+process.env.RLREACTION_PATH = resolve(dir, 'reactions.log')
+process.env.RLREACTIONSEEN_PATH = resolve(dir, 'reactions-seen.log')
 process.env.BUZZ_PRIVATE_KEY = Buffer.from(bridgeSk).toString('hex')
 process.env.FORWARD_MODE = 'buzz'; process.env.WB_NO_BOOT = '1'
 
-const { scanReturnLane, sourceWireRejectReason, PUB, grantSet } = await import('../src/bridge.mjs')
+const { scanReturnLane, sourceWireRejectReason, PUB, grantSet, rlPending, retryPendingCarries, rlReactionPending, rlReactionSeen, retryPendingReactions, rlKey, dropRlSeen } = await import('../src/bridge.mjs')
+const { submitRelayActionReaction } = await import('../src/nostr_egress.mjs')
 grantSet.set(participant, { grantId: '1'.repeat(64), grantor: author })
 let pass = 0, fail = 0
 const ok = (name, value) => { console.log(`${value ? 'ok  ' : 'FAIL'} — ${name}`); value ? pass++ : fail++ }
 const source = JSON.parse(JSON.stringify(finalizeEvent({ kind: 9, created_at: 1785870000,
   tags: [['h', 'private-signed-channel-address'], ['p', participant]], content: 'Codex, please inspect this.' }, authorSk)))
 const wraps = []
-await scanReturnLane([source], { authors: PUB.scanAuthors, channel, publish: async wrap => { wraps.push(wrap); return 2 } })
+const reactions = []
+let journalWasReadyAtSubmit = false
+const reactionOk = event => {
+  reactions.push(event)
+  journalWasReadyAtSubmit = readFileSync(process.env.SEND_JOURNAL_PATH, 'utf8').includes(event.id)
+  return event.id
+}
+await scanReturnLane([source], { authors: PUB.scanAuthors, channel, publish: async wrap => { wraps.push(wrap); return 2 }, react: reactionOk })
 ok('the opt-in recipient receives one sealed typed carry', wraps.length === 1 && wraps[0].kind === 1059)
+ok('a landed relay action reacts once to the exact originating Buzz event', reactions.length === 1 && reactions[0].kind === 7 && reactions[0].content === '👍' && reactions[0].tags.some(t => t[0] === 'e' && t[1] === source.id))
+ok('the exact reaction id is durably tripwire-journaled before submission starts', journalWasReadyAtSubmit)
+ok('the bridge-authored kind:7 is recorded in the tripwire send journal',
+  readFileSync(process.env.SEND_JOURNAL_PATH, 'utf8').split('\n').some(line => { try { const row = JSON.parse(line); return row.kind === 7 && row.lane === 'return-reaction' && row.source === source.id } catch { return false } }))
+let submittedBody = '', submittedAuth = ''
+const exactSubmitted = await submitRelayActionReaction(reactions[0], async (_url, request) => {
+  submittedBody = request.body
+  submittedAuth = request.headers.authorization
+  return { ok: true, status: 200, text: async () => JSON.stringify({ event_id: reactions[0].id, accepted: true, message: 'stored' }) }
+})
+ok('the writer submits the byte-identical prepared event with exact-body NIP-98 authorization',
+  exactSubmitted === reactions[0].id && submittedBody === JSON.stringify(reactions[0]) && submittedAuth.startsWith('Nostr '))
+let alteredPreparedRejected = false
+try { await submitRelayActionReaction({ ...reactions[0], content: '❤️' }, async () => { throw new Error('must not submit') }) } catch { alteredPreparedRejected = true }
+ok('the exact-event submitter refuses altered prepared bytes before network access', alteredPreparedRejected)
+await scanReturnLane([source], { authors: PUB.scanAuthors, channel, publish: async wrap => { wraps.push(wrap); return 2 }, react: reactionOk })
+ok('durable carry dedup also prevents a duplicate confirmation reaction', reactions.length === 1)
 const seal = JSON.parse(nip44.decrypt(wraps[0].content, nip44.getConversationKey(participantSk, wraps[0].pubkey)))
 const rumor = JSON.parse(nip44.decrypt(seal.content, nip44.getConversationKey(participantSk, seal.pubkey)))
 const carry = JSON.parse(rumor.content)
@@ -69,11 +96,62 @@ const wrongChannel = JSON.parse(JSON.stringify(finalizeEvent({ kind: 9, created_
   tags: [['p', participant]], content: 'right sender, wrong channel' }, authorSk)))
 await scanReturnLane([wrongChannel], { authors: [author], channel: '99999999-9999-4999-8999-999999999999', publish: async wrap => { wraps.push(wrap); return 2 } })
 ok('a managed route binds its source channel instead of inheriting the global channel union', wraps.length === 1)
+const reactionRetry = JSON.parse(JSON.stringify(finalizeEvent({ kind: 9, created_at: 1785870006,
+  tags: [['p', participant]], content: 'reaction retry' }, authorSk)))
+let failedPrepared
+await scanReturnLane([reactionRetry], { authors: [author], channel, publish: async wrap => { wraps.push(wrap); return 2 }, react: async event => { failedPrepared = JSON.stringify(event); throw new Error('temporary Buzz outage') } })
+ok('a failed confirmation does not undo or repeat the landed sealed carry', wraps.length === 2 && rlReactionPending.has(reactionRetry.id))
+const retried = []
+const realFetch = globalThis.fetch
+globalThis.fetch = async (_url, request) => {
+  const event = JSON.parse(request.body)
+  retried.push(event)
+  return { ok: true, status: 200, text: async () => JSON.stringify({ event_id: event.id, accepted: true, message: 'stored' }) }
+}
+try { await retryPendingReactions() } finally { globalThis.fetch = realFetch }
+ok('a failed confirmation retries independently and clears only after success', retried.length === 1 && retried[0].tags.some(t => t[0] === 'e' && t[1] === reactionRetry.id) && !rlReactionPending.has(reactionRetry.id))
+ok('the production retry path submits the byte-identical prepared event instead of re-signing', JSON.stringify(retried[0]) === failedPrepared)
+
+// Review regression: simulate process death at the only dangerous boundary. The reaction debt
+// must already be durable while the source×recipient carry completion is still absent.
+const crashSource = JSON.parse(JSON.stringify(finalizeEvent({ kind: 9, created_at: 1785870007,
+  tags: [['p', participant]], content: 'crash ordering' }, authorSk)))
+const crashKey = rlKey(crashSource.id, participant)
+let crashed = false
+try {
+  await scanReturnLane([crashSource], { authors: [author], channel, publish: async wrap => { wraps.push(wrap); return 2 },
+    react: async () => {}, afterReactionOwed: () => { throw new Error('simulated process exit') } })
+} catch (e) { crashed = e.message === 'simulated process exit' }
+ok('a crash after accepted carry cannot lose its reaction obligation', crashed && rlReactionPending.has(crashSource.id))
+ok('reaction debt commits before carry completion, so restart may safely recover',
+  !rlReactionSeen.has(crashSource.id) && !readFileSync(process.env.RLSEEN_PATH, 'utf8').includes(crashKey) &&
+  readFileSync(process.env.RLREACTION_PATH, 'utf8').includes(crashSource.id))
+dropRlSeen(crashKey) // simulated restart discards the pre-commit in-memory claim
+await retryPendingReactions(async event => event.id)
+
+// Review regression: recipient A lands now, recipient B is queued and lands later. Completion is
+// source-level, so B's carry retry must not create a second reaction for the same channel message.
+const participant2Sk = generateSecretKey(), participant2 = getPublicKey(participant2Sk)
+PUB.returnLane.push({ ...PUB.returnLane[0], npub_hex: participant2 })
+grantSet.set(participant2, { grantId: '2'.repeat(64), grantor: author })
+const partial = JSON.parse(JSON.stringify(finalizeEvent({ kind: 9, created_at: 1785870008,
+  tags: [['p', participant], ['p', participant2]], content: 'partial fanout' }, authorSk)))
+let fanoutAttempt = 0
+const partialReactions = []
+await scanReturnLane([partial], { authors: [author], channel,
+  publish: async wrap => { wraps.push(wrap); return fanoutAttempt++ === 0 ? 2 : 0 },
+  react: async event => { partialReactions.push(event); return event.id } })
+ok('partial fanout reacts once when its first recipient lands', partialReactions.length === 1 && rlReactionSeen.has(partial.id) && rlPending.size() === 1)
+await retryPendingCarries({ publish: async wrap => { wraps.push(wrap); return 2 }, react: async event => { partialReactions.push(event); return event.id } })
+ok('a later recipient retry cannot react to an already-confirmed source again', partialReactions.length === 1 && rlPending.size() === 0)
+grantSet.delete(participant2)
+PUB.returnLane.pop()
 grantSet.delete(participant)
+const wrapsBeforeRevoked = wraps.length
 const revoked = JSON.parse(JSON.stringify(finalizeEvent({ kind: 9, created_at: 1785870006,
   tags: [['p', participant]], content: 'admission revoked' }, authorSk)))
 await scanReturnLane([revoked], { authors: [author], channel, publish: async wrap => { wraps.push(wrap); return 2 } })
-ok('revoking participant admission removes a saved managed route from active fan-out', wraps.length === 1)
+ok('revoking participant admission removes a saved managed route from active fan-out', wraps.length === wrapsBeforeRevoked)
 
 console.log(`\n${pass}/${pass + fail} passed`)
 process.exit(fail ? 1 : 0)

--- a/tests/return_lane_task_carry.mjs
+++ b/tests/return_lane_task_carry.mjs
@@ -27,6 +27,7 @@ process.env.RLPENDING_PATH = resolve(dir, 'pending.log')
 process.env.RLREACTION_PATH = resolve(dir, 'reactions.log')
 process.env.RLREACTIONSEEN_PATH = resolve(dir, 'reactions-seen.log')
 process.env.BUZZ_PRIVATE_KEY = Buffer.from(bridgeSk).toString('hex')
+process.env.BUZZ_EVENT_ENDPOINT = 'https://hive.example/events'
 process.env.FORWARD_MODE = 'buzz'; process.env.WB_NO_BOOT = '1'
 
 const { scanReturnLane, sourceWireRejectReason, PUB, grantSet, rlPending, retryPendingCarries, rlReactionPending, rlReactionSeen, retryPendingReactions, rlKey, dropRlSeen } = await import('../src/bridge.mjs')
@@ -50,14 +51,16 @@ ok('a landed relay action reacts once to the exact originating Buzz event', reac
 ok('the exact reaction id is durably tripwire-journaled before submission starts', journalWasReadyAtSubmit)
 ok('the bridge-authored kind:7 is recorded in the tripwire send journal',
   readFileSync(process.env.SEND_JOURNAL_PATH, 'utf8').split('\n').some(line => { try { const row = JSON.parse(line); return row.kind === 7 && row.lane === 'return-reaction' && row.source === source.id } catch { return false } }))
-let submittedBody = '', submittedAuth = ''
-const exactSubmitted = await submitRelayActionReaction(reactions[0], async (_url, request) => {
+let submittedBody = '', submittedAuth = '', submittedUrl = ''
+const exactSubmitted = await submitRelayActionReaction(reactions[0], async (url, request) => {
+  submittedUrl = String(url)
   submittedBody = request.body
   submittedAuth = request.headers.authorization
   return { ok: true, status: 200, text: async () => JSON.stringify({ event_id: reactions[0].id, accepted: true, message: 'stored' }) }
 })
 ok('the writer submits the byte-identical prepared event with exact-body NIP-98 authorization',
-  exactSubmitted === reactions[0].id && submittedBody === JSON.stringify(reactions[0]) && submittedAuth.startsWith('Nostr '))
+  exactSubmitted === reactions[0].id && submittedUrl === 'https://hive.example/events' &&
+  submittedBody === JSON.stringify(reactions[0]) && submittedAuth.startsWith('Nostr '))
 let alteredPreparedRejected = false
 try { await submitRelayActionReaction({ ...reactions[0], content: '❤️' }, async () => { throw new Error('must not submit') }) } catch { alteredPreparedRejected = true }
 ok('the exact-event submitter refuses altered prepared bytes before network access', alteredPreparedRejected)


### PR DESCRIPTION
## Outcome

When a Buzz channel message successfully triggers a sealed return-lane carry, Waggle adds a fixed 👍 reaction to the exact source event so the sender can see that relay action occurred.

## Safety and failure semantics

- the reaction is a closed egress-catalogue operation; callers cannot choose emoji or prose
- one reaction per source message even when it fans out to multiple recipients
- carry dedup prevents repeat reactions on rescans
- reaction work is persisted and retried independently
- reaction failure never causes the sealed carry to be repeated
- dry-run and hermetic test modes perform no live reaction transport

## Verification

- `npm run lint`
- full 46-suite `npm test` gate
- focused return-lane test includes failed-reaction retry and no re-carry
- egress catalogue test asserts exact argv and fixed 👍