### PR TITLE
feat: stage keyless tripwire alarm pairing

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -358,6 +358,23 @@ regular non-symlink files with mode `0600`. The Bunker identity must have no gra
 application authority. Its client pairing remains a credential even though it cannot reveal
 or export the identity nsec.
 
+To stage those three files without ever putting the Bunker URI or client credential on argv or
+in an environment variable, save the URI temporarily in a root-owned mode-0600 file, then feed
+it only on stdin. The initializer refuses an existing destination so a working pairing is never
+partially overwritten:
+
+```
+sudo node tools/tripwire-alarm-bunker-init.mjs \
+  --directory /etc/waggle-tripwire \
+  --recipient <operator-npub> \
+  --poster <bridge-poster-npub-or-hex> \
+  < /root/alarm.bunker-uri
+sudo shred -u /root/alarm.bunker-uri 2>/dev/null || sudo rm -f /root/alarm.bunker-uri
+```
+
+The tool prints only the two public npubs and destination paths. It generates a fresh revocable
+NIP-46 client credential locally; the alarm identity nsec remains in the Bunker.
+
 For an existing watcher—especially the live on-box unit that first merges read- and sealed-lane
 journals—do **not** replace its `ExecStart` with the generic off-host template. Install only the
 credential drop-in, preserving the already-verified detector command:

--- a/tests/tripwire_detection.mjs
+++ b/tests/tripwire_detection.mjs
@@ -18,7 +18,7 @@ import { mkdtempSync, writeFileSync, readFileSync, existsSync, rmSync, chmodSync
 import { tmpdir } from 'node:os'
 import { resolve, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { getPublicKey, verifyEvent } from 'nostr-tools/pure'
+import { generateSecretKey, getPublicKey, verifyEvent } from 'nostr-tools/pure'
 import * as nip19 from 'nostr-tools/nip19'
 import { WebSocketServer } from 'ws'
 
@@ -26,6 +26,7 @@ const HERE = dirname(fileURLToPath(import.meta.url))
 const ROOT = resolve(HERE, '..')
 const TOOL = resolve(ROOT, 'tools', 'tripwire.mjs')
 const INIT = resolve(ROOT, 'tools', 'tripwire-alarm-init.mjs')
+const BUNKER_INIT = resolve(ROOT, 'tools', 'tripwire-alarm-bunker-init.mjs')
 const DROP_IN = resolve(ROOT, 'deploy', 'tripwire-alarm.conf')
 const BUNKER_DROP_IN = resolve(ROOT, 'deploy', 'tripwire-alarm-bunker.conf')
 const BASE_UNIT = resolve(ROOT, 'deploy', 'tripwire.service')
@@ -161,6 +162,31 @@ try {
   check('initializer mints a separate identity', getPublicKey(alarmSecret) !== nip19.decode(POSTER).data)
   check('initializer refuses to overwrite a live credential directory',
     spawnSync('node', [INIT, '--directory', credentials, '--recipient', POSTER], { encoding: 'utf8' }).status === 1)
+
+  const bunkerDirectory = resolve(dir, 'bunker-credentials')
+  const bunkerPub = getPublicKey(generateSecretKey())
+  const bunkerUri = `bunker://${bunkerPub}?relay=wss%3A%2F%2Frelay.nave.pub&secret=pairing-secret`
+  const bunkerInit = spawnSync('node', [BUNKER_INIT, '--directory', bunkerDirectory,
+    '--recipient', POSTER, '--poster', nip19.decode(POSTER).data], { encoding: 'utf8', input: bunkerUri + '\n' })
+  const bunkerUriPath = resolve(bunkerDirectory, 'alarm.bunker-uri')
+  const bunkerClientPath = resolve(bunkerDirectory, 'alarm.client-nsec')
+  const bunkerToPath = resolve(bunkerDirectory, 'alarm.to')
+  check('keyless initializer stages a Bunker pairing from stdin', bunkerInit.status === 0, bunkerInit.stderr)
+  check('keyless initializer output exposes neither URI nor client nsec',
+    !bunkerInit.stdout.includes(bunkerUri) && !/pairing-secret|nsec1/i.test((bunkerInit.stdout || '') + (bunkerInit.stderr || '')))
+  check('all keyless pairing files are mode 0600', [bunkerUriPath, bunkerClientPath, bunkerToPath]
+    .every(path => (lstatSync(path).mode & 0o777) === 0o600))
+  check('keyless initializer preserves the exact URI without ever minting the alarm identity locally',
+    readFileSync(bunkerUriPath, 'utf8').trim() === bunkerUri && nip19.decode(readFileSync(bunkerClientPath, 'utf8').trim()).type === 'nsec')
+  check('keyless initializer refuses the bridge poster as the alarm identity',
+    spawnSync('node', [BUNKER_INIT, '--directory', resolve(dir, 'same-poster'), '--recipient', POSTER, '--poster', POSTER],
+      { encoding: 'utf8', input: `bunker://${nip19.decode(POSTER).data}?relay=wss%3A%2F%2Frelay.nave.pub\n` }).status === 1)
+  check('keyless initializer refuses a Bunker URI on argv',
+    spawnSync('node', [BUNKER_INIT, '--directory', resolve(dir, 'argv-uri'), '--recipient', POSTER, bunkerUri],
+      { encoding: 'utf8' }).status === 1)
+  check('keyless initializer refuses to overwrite a live pairing directory',
+    spawnSync('node', [BUNKER_INIT, '--directory', bunkerDirectory, '--recipient', POSTER],
+      { encoding: 'utf8', input: bunkerUri + '\n' }).status === 1)
 
   const credentialRun = spawnSync('node', [TOOL, '--since-min', '60', '--journal', full, '--events-from', eventsFile], {
     env: { ...process.env, POSTER, ALARM_NSEC: '', ALARM_TO: '', ALARM_NSEC_FILE: alarmNsecPath, ALARM_TO_FILE: alarmToPath, ALARM_LOG_PATH: ALARMS },

--- a/tools/tripwire-alarm-bunker-init.mjs
+++ b/tools/tripwire-alarm-bunker-init.mjs
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+// Stage the preferred keyless tripwire alarm pairing without putting either credential on argv.
+// The Bunker URI is read from stdin; this tool generates only the revocable NIP-46 transport key.
+// The alarm identity's nsec remains in the Bunker and never exists on this host.
+import { mkdirSync, openSync, writeFileSync, closeSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { generateSecretKey } from 'nostr-tools/pure'
+import * as nip19 from 'nostr-tools/nip19'
+
+const fail = message => { console.error(`tripwire-alarm-bunker-init: ${message}`); process.exit(1) }
+const allowed = new Set(['--directory', '--recipient', '--poster'])
+const parsed = new Map()
+for (let i = 2; i < process.argv.length; i += 2) {
+  const name = process.argv[i], value = process.argv[i + 1]
+  if (!allowed.has(name) || value == null || value.startsWith('--')) fail(`unknown or incomplete argument: ${name}`)
+  if (parsed.has(name)) fail(`${name} may be supplied only once`)
+  parsed.set(name, String(value).trim())
+}
+if (process.argv.some(value => /^nsec1|^bunker:\/\//i.test(value))) fail('never pass a Bunker URI or secret key on argv')
+const arg = name => parsed.get(name) || ''
+const directory = resolve(arg('--directory') || '/etc/waggle-tripwire')
+
+function publicKey(value, label) {
+  if (!value) fail(`${label} is required`)
+  let result
+  try { result = value.startsWith('npub1') ? nip19.decode(value).data : value.toLowerCase() }
+  catch { fail(`${label} is not a valid npub`) }
+  if (!/^[0-9a-f]{64}$/.test(result)) fail(`${label} must be an npub or 64-hex public key`)
+  return result
+}
+const recipient = publicKey(arg('--recipient'), '--recipient')
+const posterInput = arg('--poster'), poster = posterInput ? publicKey(posterInput, '--poster') : ''
+
+let input = ''
+for await (const chunk of process.stdin) {
+  input += chunk
+  if (Buffer.byteLength(input) > 8192) fail('Bunker URI input exceeds 8192 bytes')
+}
+const uriText = input.trim()
+if (!uriText || /[\r\n]/.test(uriText)) fail('stdin must contain exactly one Bunker URI')
+const match = /^bunker:\/\/([0-9a-f]{64})/i.exec(uriText)
+if (!match) fail('stdin does not contain a valid bunker:// URI')
+let uri
+try { uri = new URL(uriText) } catch { fail('stdin does not contain a valid bunker:// URI') }
+if (![...uri.searchParams.getAll('relay')].some(value => /^wss:\/\//.test(value))) fail('Bunker URI needs at least one wss relay')
+const alarmPub = match[1].toLowerCase()
+if (poster && alarmPub === poster) fail('alarm Bunker identity must differ from the bridge poster identity')
+
+try { mkdirSync(dirname(directory), { recursive: true, mode: 0o700 }); mkdirSync(directory, { mode: 0o700 }) }
+catch (error) { fail(`refusing existing/unwritable directory ${directory}: ${error.message}`) }
+const writePrivate = (path, value) => {
+  const fd = openSync(path, 'wx', 0o600)
+  try { writeFileSync(fd, value + '\n') } finally { closeSync(fd) }
+}
+try {
+  writePrivate(resolve(directory, 'alarm.bunker-uri'), uriText)
+  writePrivate(resolve(directory, 'alarm.client-nsec'), nip19.nsecEncode(generateSecretKey()))
+  writePrivate(resolve(directory, 'alarm.to'), nip19.npubEncode(recipient))
+} catch (error) { fail(`credential write failed: ${error.message}`) }
+
+console.log(`tripwire alarm identity: ${nip19.npubEncode(alarmPub)}`)
+console.log(`recipient: ${nip19.npubEncode(recipient)}`)
+console.log(`credentials: ${directory}/alarm.bunker-uri + alarm.client-nsec + alarm.to (0600; secrets not printed)`)
+console.log('Next: install/reload the unit, approve the Bunker pairing, run the positive sealed-delivery drill, then a clean timer tick.')


### PR DESCRIPTION
Makes #263's preferred Bunker deployment as safe and simple as the legacy local-key initializer.\n\n- reads the Bunker URI only from bounded stdin, never argv/env/output\n- generates only a revocable NIP-46 client transport key; the alarm nsec remains in Bunker\n- writes all three root-staged credentials mode 0600 into a fresh, non-overwriting directory\n- refuses the bridge poster identity as the alarm identity\n- adds focused adversarial coverage and operator commands\n\nVerified: lint green; tripwire detection/drill suite green; complete 46-suite gate green.\n\nReview is requested privately in Buzz waggle-test only.