### PR TITLE
Fix direct review replies on the return lane

### DIFF
--- a/src/bridge.mjs
+++ b/src/bridge.mjs
@@ -2155,11 +2155,12 @@ function carryDescriptor(recipient, message, why, channel) {
 //     is a bridge event the registry records as authored for this recipient. No body match needed.
 //
 // opts.authors, when supplied, is a SIGNER gate (spam/abuse control + defense-in-depth — NOT the
-// load-bearing safety property; that is the wake/payload split in the action layer). A message
-// whose signer is outside it is dropped, LOUDLY, before any carry-out. Supplying the option at all
-// makes the gate default-closed: an explicitly-empty gate passes nobody (a misconfiguration that
-// is WARNed at boot, never silent). The staging path passes no option and stays open — staging is
-// human-gated content already.
+// load-bearing safety property; that is the wake/payload split in the action layer). A new mention
+// from outside it is dropped, LOUDLY. One narrow exception preserves a conversation the agent
+// itself opened: a signed direct reply to an event recorded for that recipient is carried as data.
+// The downstream broker still requires its independent live task grant before promotion, so this
+// exception cannot turn the replier into an instructor. Supplying the option at all otherwise
+// makes the gate default-closed. The staging path passes no option and stays open.
 //
 // The carried body is DATA, never instruction: it is quoted into a sealed 1059 delivered to the
 // recipient's own key. Nothing here starts a session, evaluates, or acts on the body — this lane
@@ -2173,7 +2174,12 @@ async function scanReturnLane(msgs, opts = {}) {
   for (const m of msgs || []) {
     if (!m || !m.id) continue
     const from = String(m.pubkey || '').toLowerCase()
-    if (gateActive && !gate.has(from)) {                   // signer gate — logged once per id, never silent
+    const tags = Array.isArray(m.tags) ? m.tags : []
+    // Resolve only a direct reply marker, never a root/thread association. The registry is
+    // bridge-authored state: an outsider cannot nominate an arbitrary event as an agent post.
+    const parents = tags.filter(t => t[0] === 'e' && t[1] && t[3] === 'reply').map(t => String(t[1]).toLowerCase())
+    const repliesToAgent = parents.some(pid => !!agentAuthoredBy(pid))
+    if (gateActive && !gate.has(from) && !repliesToAgent) { // signer gate — logged once per id, never silent
       if (rlDropOnce(m.id)) err(`RETURN drop[author]: ${String(m.id).slice(0, 12)}… signer ${from.slice(0, 12)}… not in scan_authors`)
       continue
     }
@@ -2185,19 +2191,19 @@ async function scanReturnLane(msgs, opts = {}) {
       continue
     }
     const body = String(m.content || '')
-    const tags = Array.isArray(m.tags) ? m.tags : []
     const ptags = tags.filter(t => t[0] === 'p' && t[1]).map(t => String(t[1]).toLowerCase())
-    // Direct parent(s) only — the `reply`-marked e-tag. NOT the `root` tag: matching root would
-    // deliver every message in a thread the agent started, not the replies actually to it.
-    const parents = tags.filter(t => t[0] === 'e' && t[1] && t[3] === 'reply').map(t => String(t[1]).toLowerCase())
     // No break: one message fans out to EVERY matching recipient, each deduped on its own
     // (source × recipient) key. "@a @b" reaching only one of them was finding #4.
     for (const r of recipients) {
+      const repliedTo = parents.some(pid => agentAuthoredBy(pid) === r.npub_hex)
       // Owner-managed task routes bind BOTH the source channel and original signer to this
       // recipient.  The legacy global scan set remains supported, but a route created through
       // the Console cannot accidentally fan a message from another watched channel/author into
-      // this participant merely because both appear in the global unions.
-      if (r.managedTaskRoute && (r.scan_channel !== String(opts.channel || '').toLowerCase() || r.scan_author !== from)) continue
+      // this participant merely because both appear in the global unions. A direct reply to an
+      // event already recorded for this recipient is the one exception: it continues that exact
+      // conversation as data even when the replier is not the route's instruction principal.
+      if (r.managedTaskRoute && (r.scan_channel !== String(opts.channel || '').toLowerCase() ||
+          (r.scan_author !== from && !repliedTo))) continue
       const key = rlKey(m.id, r.npub_hex)
       if (rlSeen.has(key)) continue                        // this recipient already carried for this message
       // Echo: never carry the recipient's own words back. Three forms, all the agent's own:
@@ -2208,7 +2214,6 @@ async function scanReturnLane(msgs, opts = {}) {
       if (from === r.npub_hex || boundUnique || agentAuthoredBy(m.id) === r.npub_hex) continue
       const mentioned = ptags.includes(r.npub_hex) ||
         (!r.dynamic && !!r.mention && new RegExp('@' + r.mention.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '(?![\\w-])', 'i').test(body))
-      const repliedTo = parents.some(pid => agentAuthoredBy(pid) === r.npub_hex)
       if (!mentioned && !repliedTo) continue
       const why = repliedTo && !mentioned ? 'reply' : 'mention'
       let descriptor

--- a/tests/return_lane_scan.mjs
+++ b/tests/return_lane_scan.mjs
@@ -63,7 +63,7 @@ process.env.FORWARD_MODE = 'buzz'
 process.env.WB_STUB_SEND = '1'
 process.env.WB_NO_BOOT = '1'
 
-const { scanReturnLane, recordPosted, PUB } = await import('../src/bridge.mjs')
+const { scanReturnLane, recordPosted, PUB, grantSet } = await import('../src/bridge.mjs')
 
 let fails = 0
 const ok = (n, c) => { console.log(`${c ? 'ok  ' : 'FAIL'} — ${n}`); if (!c) fails++ }
@@ -136,6 +136,13 @@ ok('a registry-attributed event is echo-skipped', d.length === 0)
 
 // --- reply-to-agent via the registry, no body mention needed ----------------
 recordPosted({ id: 'orig-p', author: claude, buzz: 'parenta', dest: 'chan', q: false, ts: 0, agent: claude })
+grantSet.set(claude, { grantId: '1'.repeat(64), grantor: crew })
+Object.assign(PUB.returnLane[0], { managedTaskRoute: true, scan_channel: 'chan', scan_author: crew })
+d = await scanDelta([{ id: 'rep0', pubkey: outsider, content: 'a direct reply from outside the author allowlist',
+  tags: [['e', 'parenta', '', 'reply']] }], { authors: PUB.scanAuthors, channel: 'chan' })
+ok('a signed direct reply crosses both the spam gate and managed sender binding as data', d.length === 1 && toOf(d[0]) === short(claude))
+ok('the outside direct reply is still labelled reply, never promoted here', d[0]?.why === 'reply')
+grantSet.delete(claude); delete PUB.returnLane[0].managedTaskRoute; delete PUB.returnLane[0].scan_channel; delete PUB.returnLane[0].scan_author
 d = await scanDelta([{ id: 'rep1', pubkey: crew, content: 'good point, agreed', tags: [['e', 'parenta', '', 'reply']] }])
 ok('a reply to an agent-authored post is carried', d.length === 1 && toOf(d[0]) === short(claude))
 ok('it is labelled a reply, not a mention', d[0]?.why === 'reply')


### PR DESCRIPTION
Closes the live review-return gap found during the Codex MCP wake proof.\n\nA new mention still requires the configured scan_authors signer gate. A signed direct reply to a bridge-recorded agent event may cross that spam gate and a managed route's sender binding, but only for the exact recorded recipient and only as a typed, signed-source carry. Nvoy remains the instruction-authority boundary: without a live task grant, the replier's content is data only.\n\nVerification:\n- focused return-lane scan regression passes\n- full 46-suite gate passes outside the sandbox\n- lint and diff check pass