### PR TITLE
Keep claimed off-box policy work retryable

### DIFF
--- a/src/buzz_policy_service.mjs
+++ b/src/buzz_policy_service.mjs
@@ -28,6 +28,24 @@ function derive(raw, { policyInstance, catalogueVersion, stagingChannel, watched
   return { request, decision, requestDigest, key: policyIdempotencyKey(request, decision) }
 }
 
+// Freshness is a first-admission property, not a durability expiry. A remote-only bridge must
+// retry the SAME canonical request after an outage or restart; changing observed_at would change
+// its request digest while leaving the policy idempotency key unchanged. First try the strict
+// fresh path. Only a request rejected specifically for age gets a second parse, and that parse is
+// usable solely when the policy journal already binds the derived key to these exact bytes.
+function deriveFreshOrPreviouslyClaimed(raw, options, journal) {
+  try { return derive(raw, options) } catch (error) {
+    if (!String(error?.message || '').includes('observed_at is outside the freshness window')) throw error
+    let observedAt
+    try { observedAt = JSON.parse(raw)?.observed_at } catch { throw error }
+    if (!Number.isSafeInteger(observedAt) || observedAt < 0) throw error
+    const candidate = derive(raw, { ...options, now: observedAt })
+    const existing = journal.get(candidate.key)
+    if (!existing || existing.request_digest !== candidate.requestDigest) throw error
+    return candidate
+  }
+}
+
 export async function processBuzzPolicyRequest(raw, {
   policyInstance, catalogueVersion, stagingChannel, watchedEventIds, approverMention = '',
   artifactPolicy, journal, signer, fetchImpl = fetch, now = Math.floor(Date.now() / 1000),
@@ -35,7 +53,8 @@ export async function processBuzzPolicyRequest(raw, {
 } = {}) {
   if (!journal || typeof journal.claim !== 'function' || typeof journal.prepare !== 'function' || typeof journal.commit !== 'function') fail('journal is unavailable')
   if (!signer || typeof signer.signEvent !== 'function') fail('signer is unavailable')
-  const { request, decision, requestDigest, key } = derive(raw, { policyInstance, catalogueVersion, stagingChannel, watchedEventIds, approverMention, now })
+  const { request, decision, requestDigest, key } = deriveFreshOrPreviouslyClaimed(raw,
+    { policyInstance, catalogueVersion, stagingChannel, watchedEventIds, approverMention, now }, journal)
   const claim = journal.claim(key, requestDigest, now)
   if (!claim.claimed && claim.record.status !== 'prepared') return replay(claim.record)
 

--- a/tests/buzz_policy_service.mjs
+++ b/tests/buzz_policy_service.mjs
@@ -57,8 +57,9 @@ const options = (journal, signer, extra = {}) => ({ policyInstance, catalogueVer
   } }))
   t('accepted work returns only a signed terminal receipt', first.status === 'terminal' && first.result === 'accepted' && JSON.parse(first.receipt).kind === 30078 && !('event' in first))
   t('the event, HTTP authorization, and receipt are each signed once', signed.map(x => x.kind).join(',') === '9,27235,30078')
-  const replay = await processBuzzPolicyRequest(raw, options(journal, signer, { fetchImpl: async () => { calls++; throw new Error('must not submit') } }))
-  t('a terminal replay returns byte-identical receipt without signing or network', replay.receipt === first.receipt && calls === 1 && signed.length === 3)
+  const replay = await processBuzzPolicyRequest(raw, options(journal, signer, { now: now + 3600,
+    fetchImpl: async () => { calls++; throw new Error('must not submit') } }))
+  t('a stale terminal replay returns byte-identical receipt without signing or network', replay.receipt === first.receipt && calls === 1 && signed.length === 3)
 }
 
 {
@@ -68,10 +69,24 @@ const options = (journal, signer, extra = {}) => ({ policyInstance, catalogueVer
   } }))
   t('an ambiguous submit leaves the exact event prepared', ambiguous.status === 'ambiguous' && firstJournal.get(createHash('sha256').update(canonicalJson([1, policyInstance, catalogueVersion, 'quarantine_header', [source.id], channel])).digest('hex')).status === 'prepared')
   const secondJournal = new PolicyJournal(path), secondSigner = makeSigner(); let recoveredBody = ''
-  const recovered = await processBuzzPolicyRequest(raw, options(secondJournal, secondSigner.signer, { fetchImpl: async (_url, request) => {
+  const recovered = await processBuzzPolicyRequest(raw, options(secondJournal, secondSigner.signer, { now: now + 3600, fetchImpl: async (_url, request) => {
     recoveredBody = request.body; return acceptedResponse(JSON.parse(request.body))
   } }))
-  t('restart recovery resubmits byte-identical event and never re-signs kind:9', recovered.status === 'terminal' && recoveredBody === preparedBody && secondSigner.signed.map(x => x.kind).join(',') === '27235,30078')
+  t('stale restart recovery resubmits byte-identical event and never re-signs kind:9', recovered.status === 'terminal' && recoveredBody === preparedBody && secondSigner.signed.map(x => x.kind).join(',') === '27235,30078')
+}
+
+{
+  const journal = new PolicyJournal(directory()), { signer } = makeSigner()
+  await rejects('an unseen stale request cannot create a policy claim', () => processBuzzPolicyRequest(raw,
+    options(journal, signer, { now: now + 3600, fetchImpl: async () => { throw new Error('must not fetch') } })), /freshness/)
+}
+
+{
+  const journal = new PolicyJournal(directory()), { signer } = makeSigner()
+  await processBuzzPolicyRequest(raw, options(journal, signer, { fetchImpl: async (_url, request) => acceptedResponse(JSON.parse(request.body)) }))
+  const changed = canonicalJson({ ...JSON.parse(raw), observed_at: now - 1 })
+  await rejects('a stale request cannot borrow an existing idempotency key with different bytes', () => processBuzzPolicyRequest(changed,
+    options(journal, signer, { now: now + 3600, fetchImpl: async () => { throw new Error('must not fetch') } })), /freshness/)
 }
 
 {

--- a/tests/trust_command.mjs
+++ b/tests/trust_command.mjs
@@ -125,9 +125,12 @@ for (const [name, ev, expected] of reasons) {
   const r = handleTrustControlCommand(ev)
   ok(`${name} — for its own reason`, r.ok === false && r.reason === expected, `got '${r.reason}', wanted '${expected}'`)
 }
-ok('a tampered signature is refused', handleTrustControlCommand({
-  ...cmd('follow', stranger), sig: '0'.repeat(128),
-}).ok === false)
+// Cross the wire boundary before tampering. nostr-tools marks finalized in-memory events with
+// a private verification symbol; verifyEvent intentionally trusts that marker, so spreading the
+// object and changing `sig` is not a cryptographic negative unless serialization removes it.
+const tampered = JSON.parse(JSON.stringify(cmd('follow', stranger)))
+tampered.sig = '0'.repeat(128)
+ok('a tampered wire-form signature is refused', handleTrustControlCommand(tampered).ok === false)
 ok('a non-30078 event is not a trust command',
   handleTrustControlCommand({ ...cmd('follow', stranger), kind: 1 }).ok === false)
 


### PR DESCRIPTION
## Outcome

Claimed off-box policy transactions now remain replayable with byte-identical canonical requests after the five-minute first-admission window. This closes a prerequisite for #54's remote-only policy path: a bridge outage or restart cannot force a new request digest or strand prepared work.

## Safety boundary

- freshness still gates every first admission
- only an existing journal claim with the exact idempotency key and exact request digest may replay stale
- unseen stale requests remain rejected
- changed stale bytes cannot borrow an existing claim
- prepared recovery reuses the exact signed Buzz event and does not re-sign kind:9

## Verification

- focused policy-service tests: 15/15
- complete 
> waggle@1.0.0 test
> node tests/suite_count.mjs && node tests/offbox_policy_core.mjs && node tests/buzz_policy_client.mjs && node tests/buzz_policy_shadow_client.mjs && node tests/policy_shadow_gate.mjs && node tests/policy_journal.mjs && node tests/buzz_policy_artifacts.mjs && node tests/buzz_policy_service.mjs && node tests/buzz_policy_runner.mjs && node tests/policy_host_deploy.mjs && node tests/nostr_signer.mjs && node tests/boot.mjs && node tests/read_resilience.mjs && node tests/egress_catalogue.mjs && node tests/egress_ban.mjs && node tests/relay_fanout.mjs && node tests/durable_store.mjs && node tests/a1_quarantine.mjs && node tests/a7_deletion.mjs && node tests/lane2_caps.mjs && node tests/nipda_admission.mjs && node tests/admission_return_lane.mjs && node tests/render_states.mjs && node tests/deploy_verify.mjs && node tests/routing_policy.mjs && node tests/latency_trace.mjs && node tests/return_lane.mjs && node tests/return_lane_scan.mjs && node tests/return_lane_task_carry.mjs && node tests/return_lane_nomiss.mjs && node tests/return_lane_pending.mjs && node tests/relay_ingress.mjs && node tests/tripwire_union.mjs && node tests/tripwire_detection.mjs && node tests/deploy_runner.mjs && node tests/console_host.mjs && node tests/undelivered.mjs && node tests/console_requests.mjs && node tests/consent.mjs && node tests/consent_request.mjs && node tests/consent_gate.mjs && node tests/consent_ask.mjs && node tests/dm_relays.mjs && node tests/dm_relay_list_publish.mjs && node tests/watchlist.mjs && node tests/control_state.mjs && node tests/trust_command.mjs && node tests/lanes.mjs && node tests/capabilities.mjs

suite count (#172)
  ok   package.json invokes 49 suite(s)
  ok   every invoked suite exists on disk
  ok   every suite on disk is invoked — an orphan file is a test nobody runs
  ok   no suite is invoked twice
  ok   CLAUDE.md: every stated suite count is 49
  ok   README.md: every stated suite count is 49
  ok   docs/GETTING_STARTED.md: every stated suite count is 49
  ok   CLAUDE.md stale-base threshold matches the real count
  ok   CLAUDE.md: roster lists 49 suites
  ok   README.md: roster lists 49 suites

all checks passed
ok   — an exact canonical packet with a real signed source is accepted
ok   — pretty/whitespace-varied JSON is refused at the digest boundary
ok   — duplicate JSON keys are refused at the digest boundary
ok   — caller-supplied approved decision is structurally impossible
ok   — caller-supplied rendered body is structurally impossible
ok   — caller-supplied destination is structurally impossible
ok   — another policy instance cannot replay the packet
ok   — another catalogue cannot reinterpret the packet
ok   — stale observation is refused
ok   — unsafe numeric evidence cannot enter canonical policy input
ok   — oversize input is refused before evidence verification
ok   — tampered source evidence is refused
ok   — the last ECMAScript-renderable source timestamp reaches actual catalogue rendering
ok   — a signed source timestamp beyond the catalogue Date boundary is refused
ok   — destination comes only from policy state
ok   — body and attribution come only from the signed source
ok   — quarantine rendering uses the signed source timestamp without host clamping
ok   — quarantine rendering refuses relay-selected profile decoration
ok   — the local and remote paths share one byte projection
ok   — the policy derives quarantine reason rather than accepting a route assertion
ok   — an unrelated signed public note cannot be routed
ok   — idempotency key is stable and opaque
ok   — policy-resolved destination is part of idempotency
ok   — a host-shaped decision cannot enter idempotency

offbox_policy_core: all checks passed
ok   — an exact signed receipt closes the exact request
ok   — a held response remains owed and carries no authority claim
ok   — the bridge cannot construct a request around tampered source evidence
ok   — a response cannot bless a request with caller-added authority
ok   — a response cannot bless malformed source evidence
ok   — non-canonical response bytes are refused
ok   — unknown response fields are refused
ok   — a non-terminal response cannot smuggle a receipt
ok   — a validly signed receipt for another request digest is refused
ok   — a validly signed receipt for another destination is refused
ok   — a validly signed receipt for another source is refused
ok   — a validly signed receipt with another idempotency key is refused
ok   — a receipt from another valid signer is refused
ok   — a forged receipt signature is refused
ok   — an accepted result cannot carry an ambiguous reason
ok   — the receipt d-tag cannot point at another transaction

buzz_policy_client: all checks passed
ok   — the local projection matches the remote-owned evaluation time and unsigned digest
ok   — a canonical but different remote digest is a loud mismatch
ok   — decision disagreement is distinguished from a byte disagreement
ok   — a response for another exact request is refused
ok   — non-canonical or multi-line output is refused
ok   — a denied response cannot smuggle an event digest
ok   — the shadow cannot choose a far-future comparison clock
ok   — SSH sends the exact canonical request to the forced identity and returns its bytes
ok   — SSH pins host identity and disables ambient identities, commands, TTY, and forwarding
ok   — relative credential paths are refused before process creation
ok   — host strings cannot become SSH options
ok   — a group-readable forced-command key is refused before SSH
ok   — request digest fixture is stable

buzz_policy_shadow_client: all checks passed
2026-08-06T03:22:10.556Z PUBLIC[stub] -> STAGING a8186b53-537d-46ad-a7e7-b6486c58970e: kind1 9ff438735fdb… by c974e1990da22843… (reply to our note)
ok   — observe: one in-flight claim collapses duplicate relay delivery
ok   — observe: mismatch is loud but preserves local quarantine delivery

policy_shadow_gate[observe]: all checks passed
ok   — enforce-shadow: one in-flight claim collapses duplicate relay delivery
ok   — enforce-shadow: mismatch remains owed and never reaches local delivery
2026-08-06T03:22:10.690Z PUBLIC shadow[match]: 0138da97497c… at 1785986530 (9543235122c4…)
2026-08-06T03:22:10.692Z PUBLIC[stub] -> STAGING a8186b53-537d-46ad-a7e7-b6486c58970e: kind1 0138da97497c… by 2ad24bf6863c9c90… (reply to our note)
ok   — enforce-shadow: exact decision+digest match crosses commit-before-dispatch once

policy_shadow_gate[enforce-shadow]: all checks passed
ok   — the first process atomically claims the key
ok   — the claim is a durable canonical record
ok   — a second process converges on the existing in-flight claim
ok   — a duplicate process cannot complete the first process claim
ok   — the same key cannot be reused for different request bytes
ok   — an unclaimed key cannot be committed
ok   — the exact signed event is durable before submission
ok   — the Buzz id is derived from the verified signed event
ok   — a restarted process recovers the same prepared event without re-signing
ok   — a prepared event cannot commit a substituted Buzz id
ok   — completion atomically publishes first-winner terminal state
ok   — a restarted process receives the terminal result and never reclaims
ok   — a competing terminal commit returns the exact first-winner receipt
ok   — an accepted result requires the policy-derived Buzz id
ok   — even a named Buzz id cannot be accepted before durable preparation
ok   — arbitrary bytes cannot become a prepared event
ok   — a caller cannot smuggle an id independent of the signed bytes
ok   — an empty receipt cannot become terminal state
ok   — corrupt state fails loudly rather than looking unclaimed
ok   — a symlinked record is refused
ok   — an oversized record is refused before parsing
ok   — a bridge process cannot resolve an orphan without the policy-host secret
ok   — an operator cannot resolve a stale observation of the claim
ok   — an operator can terminalize a proven-dead orphan without claiming the post failed
ok   — the signing-to-prepare crash window therefore fails closed as ambiguous
ok   — restart converges on the signed ambiguous receipt

policy_journal: all checks passed
ok   — the policy constructs kind:9 content and destination from its decision
ok   — hostile source prose is rendered as attributed carried content
ok   — an owner attestation for another poster is refused
ok   — a host-fabricated decision is refused
ok   — a host-fabricated artifact policy is refused
ok   — the exact policy-owned Buzz event is signed and verified
ok   — a signer cannot substitute its own event bytes
ok   — NIP-98 pins POST, endpoint, and canonical body hash
ok   — the exact policy-owned NIP-98 event is signed and verified
ok   — a signer cannot redirect NIP-98 authorization
ok   — a caller cannot configure an unsafe endpoint
ok   — a caller cannot swap a different policy object into NIP-98 construction
ok   — a host-fabricated request cannot choose idempotency
ok   — the policy service submits exact bytes and keeps authorization inside the call
ok   — NIP-98 for another payload cannot be submitted
ok   — a stale but valid NIP-98 event is refused before network I/O
ok   — a redirect is never followed as authority
ok   — a transient relay response stays retryable
ok   — a proxy or WAF 403 cannot mint a terminal refusal
ok   — an oversized response is refused before interpretation
ok   — a success response for another event is refused
ok   — an authoritative accepted:false is a terminal refusal
ok   — a valid foreign owner policy cannot submit this event
ok   — owner-policy mismatch is refused before network I/O
ok   — the return is a signed canonical receipt, not the signed Buzz event
ok   — a signer cannot substitute the receipt identity
ok   — receipt fields cannot be widened
ok   — a receipt cannot name a caller-selected endpoint
ok   — an authoritative refusal becomes a signed terminal receipt

buzz_policy_artifacts: all checks passed
ok   — orphan resolution is bound to the exact inspected claimed_at
ok   — a pre-prepare orphan becomes only a signed ambiguous terminal receipt
ok   — operator recovery remains possible after the request freshness window
ok   — accepted work returns only a signed terminal receipt
ok   — the event, HTTP authorization, and receipt are each signed once
ok   — a stale terminal replay returns byte-identical receipt without signing or network
ok   — an ambiguous submit leaves the exact event prepared
ok   — stale restart recovery resubmits byte-identical event and never re-signs kind:9
ok   — an unseen stale request cannot create a policy claim
ok   — a stale request cannot borrow an existing idempotency key with different bytes
ok   — 429 retries the same prepared event with fresh authorization
ok   — authoritative exact-event refusal is terminal and binds the attempted event without claiming acceptance
ok   — a generic 4xx is ambiguous because it does not bind an exact-event outcome
ok   — a substituted signing identity cannot create a durable prepared event
ok   — an internal submit-validation failure is not disguised as network ambiguity

buzz_policy_service: all checks passed
ok   — a mode-0600 fixed config creates an internal artifact policy
ok   — the policy-host recovery secret is loaded only from its private file
ok   — a fixed systemd credential path supplies recovery without widening policy JSON
ok   — ordinary ingress neither loads nor retains operator recovery authority
ok   — the forced-command adapter emits one canonical receipt result
ok   — the forced-command result never exposes the recovery secret
ok   — the configured poster cannot differ from the Bunker identity
ok   — derive-only shadow returns one canonical comparison record
ok   — local projection at remote-owned time is byte-identical to the shadow digest
ok   — shadow output exposes only the closed comparison record
ok   — a valid but ineligible source produces a deny comparison without authored bytes
ok   — shadow config structurally refuses live endpoint and journal fields
ok   — derive-only executable imports no signer, submission, or journal module
ok   — the full derive-worker import closure contains no transport, signer, submission, or journal capability
ok   — the local operator adapter emits only a signed ambiguous receipt
ok   — group/world-readable config is refused
ok   — a symlinked config is refused
ok   — unknown config fields are refused
ok   — a world-readable recovery secret is refused
ok   — bounded stdin preserves exact canonical bytes
ok   — stdin is refused immediately above the hard cap
ok   — invalid UTF-8 cannot cross the canonical boundary
ok   — the forced command rejects every caller-selected argument before configuration

buzz_policy_runner: all checks passed
ok   — socket activation creates one isolated process per request
ok   — socket and transaction have explicit resource ceilings
ok   — all transactions share a host-wide aggregate ceiling
ok   — only the ingress group can enter the policy socket
ok   — the credential-bearing transaction runs as the non-login policy identity
ok   — policy process can write only its journal
ok   — ordinary root-only sources enter through private systemd credential copies
ok   — operator-only recovery authority never enters a generic socket worker
ok   — service sandbox retains only required socket/network families
ok   — SSH ingress is forced, key-only, and has no forwarding or PTY
ok   — the forward edge has one compiled socket and imports no signer
ok   — the forward edge refuses caller argv
ok   — installer keeps key/config/code root-owned and journal policy-owned
ok   — installer seals and manifests the complete runtime closure
ok   — installer validates sshd before reload
ok   — installer does not arm the socket before policy and credentials exist
ok   — verifier checks credentials, complete immutable release, and active/enabled state
ok   — shadow ingress is a distinct fixed SSH and Unix-socket capability
ok   — shadow worker receives one policy credential and no signing or recovery authority
ok   — shadow worker is structurally networkless and has no writable filesystem path
ok   — bridge-side shadow SSH capability enters only as two read-only systemd credentials
ok   — shadow worker transitive closure (8 modules) has no signer, submitter, journal, or child-process capability
ok   — NEGATIVE CONTROL — the transitive scanner catches the writer-capable egress module
ok   — installer requires distinct live and derive-only ingress keys
ok   — NEGATIVE CONTROL — comments cannot disguise one SSH key as two capabilities
ok   — verifier requires the shadow policy and active derive-only socket
ok   — policy host pulls code without a GitHub-to-production SSH credential
ok   — only an exact commit with successful CI can promote
ok   — GitHub CI promotion requires the complete reported check-run set
ok   — release archive is a closed runtime list and excludes host policy and credentials
ok   — promotion stages an immutable release and retains an explicit rollback release
ok   — deployment watermark follows install, restart, and final verification
ok   — failed verification restores and verifies the previous release
ok   — systemd runs the pull runner locally and the timer is persistent
ok   — deploy fixture clones the exact reviewed repository
ok   — green exact commit promotes and verifies a staged release
ok   — successful promotion retains the prior release
ok   — successful promotion records the exact verified SHA
ok   — NEGATIVE CONTROL — a truncated successful check-run page fails closed
ok   — failed candidate exits nonzero and emits a rollback alarm
ok   — failed candidate restores the previously verified release
ok   — failed candidate cannot advance the verified deployment SHA
ok   — NEGATIVE CONTROL — writable code/config would be detected
ok   — NEGATIVE CONTROL — removing ForceCommand would be detected
ok   — NEGATIVE CONTROL — removing the aggregate slice is detected

policy_host_deploy: all checks passed
ok   — mode-0600 Bunker files create a remote signer for the URI identity
ok   — one credential file without the other is refused
ok   — group/world-readable Bunker URI is refused
ok   — a symlinked Bunker URI is refused
ok   — legacy local mode still signs as the configured bridge identity
ok   — legacy local mode retains NIP-44 encryption compatibility
ok   — Bunker mode signs through NIP-46 as the remote identity
ok   — Bunker mode encrypts through NIP-46 without the identity nsec
ok   — tripwire builds a valid gift wrap addressed only to the operator
ok   — tripwire seal is signed by the dedicated alarm identity
ok   — tripwire rumor binds recipient, alarm identity, and content
ok   — tripwire refuses a signer that changes policy-owned seal bytes
ok   — tripwire refuses signer-supplied fields outside the closed event schema

13/13 passed
ok   — `node src/bridge.mjs` boots and exits cleanly
ok   —   no module-resolution or import failure
ok   —   no uncaught exception during initialisation
ok   —   no FATAL
ok   —   reaches the banner (config parsed, recipients resolved)
ok   —   reaches the public-lane summary (PUB built, channels resolved)
ok   —   reaches the gate summary (rate caps + A7 wired)

boot: all checks passed
ok   — resolver asks only for the closed read verb
ok   — resolver read has a bounded CLI timeout
2026-08-06T03:22:13.060Z channel inbox: 'waggle-test' -> aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa
2026-08-06T03:22:13.060Z channel staging_inbox: 'waggle-test' -> aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa
2026-08-06T03:22:13.060Z channel relay_channel[0]: 'waggle-test' -> aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa
ok   — a transient channel-list failure is retried in-process
ok   — retry resolves every configured channel name to a UUID
ok   — command polling uses messages get
ok   — command polling has a bounded CLI timeout
ok   — a failed command read settles false rather than rejecting
ok   — backoff suppresses an immediate repeat read
ok   — command polling uses messages get
ok   — command polling has a bounded CLI timeout
ok   — the bounded backoff retries after its first delay
ok   — an in-flight command read suppresses an overlapping poll
ok   — the original in-flight poll can still settle cleanly

READ RESILIENCE PASS — non-fatal resolver + bounded command polling

-- INV-A3-5: every slot declares a closed type --
ok   — sealed_envelope: all slots declare a known type
ok   — channel_plaintext: all slots declare a known type
ok   — quarantine_header: all slots declare a known type
ok   — released_post: all slots declare a known type
ok   — a7_tombstone: all slots declare a known type
ok   — a7_tombstone_edit: all slots declare a known type
ok   — a7_delete: all slots declare a known type
ok   — console_ack: all slots declare a known type
ok   — console_ack_already: all slots declare a known type
ok   — watchlist_ack: all slots declare a known type
ok   — relay_action_reaction: all slots declare a known type
ok   — NEGATIVE CONTROL — a `detail: string` slot is caught as an unknown type
ok   — renderSlots refuses an undeclared slot the caller invents

-- Hostile values stay inside their frames --
ok   — released_post: hostile display_name cannot mint bold/emphasis
ok   — released_post: display_name keeps its readable text
ok   — released_post: body @mentions are defused when liveRefs is false
ok   — quarantine_header: body is quoted line-by-line
ok   — quarantine_header: body cannot open a fence at line start
ok   — quarantine_header: body cannot mint a heading at line start
ok   — quarantine_header: the approver mention is live (waking them is the point)
ok   — quarantine_header: hostile display_name cannot stack emphasis onto our chrome
ok   — quarantine_header: the clamp notice is rendered by the template, not a caller
ok   — console_ack: echo cannot close its code span
ok   — console_ack: echo cannot ping anyone
ok   — console_ack: echo stays inside one code span

-- INV-A3-4: wrapJson is single-line by contract --
ok   — single-line envelope JSON is accepted
ok   — NEGATIVE CONTROL — pretty-printed (multi-line) envelope JSON is REFUSED
ok   — sealed_envelope: exactly the template's own two fence lines reach column 0

-- Typed slots refuse what they are not --
ok   — id slot refuses a non-hex value
ok   — npub slot refuses prose
ok   — enum slot refuses a verb outside the closed set
ok   — a required slot cannot be omitted
ok   — handle defuses an injected mention
ok   — handle keeps the legitimate part of the name
ok   — handle accepts a legitimate Buzz name "My Dude"
ok   — handle accepts a legitimate Buzz name "Jean-Luc"
ok   — handle accepts a legitimate Buzz name "agent_1"
ok   — handle accepts a legitimate Buzz name "Ann O."
ok   — handle still refuses a name that sanitises to nothing
ok   — config check passes a clean config
ok   — config check names the offending entry
ok   — config check tolerates an absent approver_mention

-- emit(): the type has no field for a sentence (INV-A3-3) --
ok   — emit builds argv from the catalogue, not from a caller string
ok   — emit passes --reply-to for a reply action
ok   — emit sends exactly the template text
ok   — relay confirmation is a fixed thumbs-up reaction on the exact source event
ok   — NEGATIVE CONTROL — emit refuses a bare string descriptor
ok   — NEGATIVE CONTROL — emit refuses a template that is not in the catalogue

-- emit(): a recipient wake p-tag rides argv, never the body --
ok   — channel_plaintext with a recipient wakes the seat via --mention
ok   — the wake p-tag rides argv, not the de-fanged display body
ok   — channel_plaintext with no recipient p-tag carries no --mention (no wake-all storm)
ok   — NEGATIVE CONTROL — a non-pubkey mention is refused, never passed to argv

-- The Nostr transport catalogue (§2.5) --
ok   — relay_ack_ok: typed JSON with the buzz id
ok   — relay_ack_err: the over-cap reason renders byte-identically to the pre-A3 wire
ok   — NEGATIVE CONTROL — an ack reason outside the closed set is refused
ok   — NEGATIVE CONTROL — a carry reason outside the closed set is refused
ok   — NEGATIVE CONTROL — a template outside the Nostr catalogue is refused
ok   — return_carry (mention): byte-identical to the pre-A3 wire
ok   — return_carry (reply): byte-identical to the pre-A3 wire
ok   — return_carry: the community body is quoted, never waggle's own voice
ok   — return_carry: the handle is validated
ok   — return_carry: an injected handle is defused
ok   — return_carry: a legitimate spaced name still carries

egress_catalogue: all checks passed
ok   — the scan found source modules to police (24)
ok   — the scan includes the two chokepoints it exists to protect
-- Buzz transport: only egress.mjs may import child_process --
ok   — bridge.mjs: does not import child_process
ok   — buzz_policy_artifacts.mjs: does not import child_process
ok   — buzz_policy_client.mjs: does not import child_process
ok   — buzz_policy_core.mjs: does not import child_process
ok   — buzz_policy_projection.mjs: does not import child_process
ok   — buzz_policy_runner.mjs: does not import child_process
ok   — buzz_policy_service.mjs: does not import child_process
ok   — buzz_policy_shadow.mjs: does not import child_process
ok   — buzz_policy_shadow_client.mjs: does not import child_process
ok   — buzz_policy_shadow_runner.mjs: does not import child_process
ok   — concord_lib.mjs: does not import child_process
ok   — consent.mjs: does not import child_process
ok   — dm_relays.mjs: does not import child_process
ok   — egress.mjs: holds the transport (expected)
ok   — fanout.mjs: does not import child_process
ok   — lanes.mjs: does not import child_process
ok   — latency.mjs: does not import child_process
ok   — log.mjs: does not import child_process
ok   — nostr_egress.mjs: does not import child_process
ok   — nostr_signer.mjs: does not import child_process
ok   — policy_journal.mjs: does not import child_process
ok   — quarantine_projection.mjs: does not import child_process
ok   — render.mjs: does not import child_process
ok   — stores.mjs: does not import child_process
ok   — NEGATIVE CONTROL — a planted child_process import IS detected
ok   — NEGATIVE CONTROL — the ban is on the import, so an aliased spawn would still be caught
ok   — NEGATIVE CONTROL — the scan reaches into subdirectories
ok   — NEGATIVE CONTROL — and a violation planted there IS detected

-- Nostr transport: one semantic chokepoint plus one isolated signer backend (INV-A3-2) --
ok   — bridge.mjs: no finalizeEvent call site
ok   — bridge.mjs: cannot import the signer backend directly
ok   — buzz_policy_artifacts.mjs: no finalizeEvent call site
ok   — buzz_policy_artifacts.mjs: cannot import the signer backend directly
ok   — buzz_policy_client.mjs: no finalizeEvent call site
ok   — buzz_policy_client.mjs: cannot import the signer backend directly
ok   — buzz_policy_core.mjs: no finalizeEvent call site
ok   — buzz_policy_core.mjs: cannot import the signer backend directly
ok   — buzz_policy_projection.mjs: no finalizeEvent call site
ok   — buzz_policy_projection.mjs: cannot import the signer backend directly
ok   — buzz_policy_runner.mjs: no finalizeEvent call site
ok   — buzz_policy_runner.mjs: cannot import the signer backend directly
ok   — buzz_policy_service.mjs: no finalizeEvent call site
ok   — buzz_policy_service.mjs: cannot import the signer backend directly
ok   — buzz_policy_shadow.mjs: no finalizeEvent call site
ok   — buzz_policy_shadow.mjs: cannot import the signer backend directly
ok   — buzz_policy_shadow_client.mjs: no finalizeEvent call site
ok   — buzz_policy_shadow_client.mjs: cannot import the signer backend directly
ok   — buzz_policy_shadow_runner.mjs: no finalizeEvent call site
ok   — buzz_policy_shadow_runner.mjs: cannot import the signer backend directly
ok   — concord_lib.mjs: no finalizeEvent call site
ok   — concord_lib.mjs: cannot import the signer backend directly
ok   — consent.mjs: no finalizeEvent call site
ok   — consent.mjs: cannot import the signer backend directly
ok   — dm_relays.mjs: no finalizeEvent call site
ok   — dm_relays.mjs: cannot import the signer backend directly
ok   — egress.mjs: no finalizeEvent call site
ok   — egress.mjs: cannot import the signer backend directly
ok   — fanout.mjs: no finalizeEvent call site
ok   — fanout.mjs: cannot import the signer backend directly
ok   — lanes.mjs: no finalizeEvent call site
ok   — lanes.mjs: cannot import the signer backend directly
ok   — latency.mjs: no finalizeEvent call site
ok   — latency.mjs: cannot import the signer backend directly
ok   — log.mjs: no finalizeEvent call site
ok   — log.mjs: cannot import the signer backend directly
ok   — nostr_egress.mjs: has exactly one ephemeral-wrap signer call
ok   — nostr_egress.mjs: identity signing goes only through signExact
ok   — nostr_signer.mjs: has exactly the NIP-46 client and local-backend signer calls
ok   — nostr_signer.mjs: is not a closed-body/event-shape API
ok   — policy_journal.mjs: no finalizeEvent call site
ok   — policy_journal.mjs: cannot import the signer backend directly
ok   — quarantine_projection.mjs: no finalizeEvent call site
ok   — quarantine_projection.mjs: cannot import the signer backend directly
ok   — render.mjs: no finalizeEvent call site
ok   — render.mjs: cannot import the signer backend directly
ok   — stores.mjs: no finalizeEvent call site
ok   — stores.mjs: cannot import the signer backend directly
ok   — NEGATIVE CONTROL — the counter sees a planted signer call

egress_ban: all checks passed: pass
- 
> waggle@1.0.0 lint
> eslint src tools tests: pass

This is a focused prerequisite toward #54; it does not enable remote-only signing by itself.