### PR TITLE
Show verified Nvoy visibility for Waggle grants

### DIFF
--- a/console/index.html
+++ b/console/index.html
@@ -260,6 +260,7 @@
 // Local vendored bundle, resolved through the importmap — no CDN. A page that verifies
 // signatures must not fetch its verifier from a third party at load time.
 import { verifyEvent, nip19 } from 'nostr-tools'
+import { verifyNvoyVisibility } from './nvoy-visibility.mjs'
 const { decode } = nip19
 
 const $ = (id) => document.getElementById(id)
@@ -581,6 +582,27 @@ function publish(ev) {
   })))
 }
 
+async function reportNvoyVisibility(st, event) {
+  st.querySelector('.nvoy-retry')?.remove()
+  const result = await verifyNvoyVisibility({ relays: RELAYS, event, query, verify: verifyEvent })
+  if (result.visible > 0) {
+    st.className = 'status ok'
+    st.append(` · visible in Nvoy (${result.visible}/${result.total} relays cold-read the exact signed record)`)
+    return true
+  }
+  st.className = 'status err'
+  st.append(` · ⚠ not visible in Nvoy (${result.answered}/${result.total} relays answered; none returned the exact signed record) · `)
+  const retry = document.createElement('button')
+  retry.className = 'btn ghost nvoy-retry'
+  retry.textContent = 'Retry visibility check'
+  retry.onclick = async () => {
+    retry.disabled = true
+    try { await reportNvoyVisibility(st, event) } finally { retry.disabled = false }
+  }
+  st.append(retry)
+  return false
+}
+
 // Show the event, then sign it. Never the other way round: a page that pops a signer prompt
 // before displaying what it is asking for teaches approve-first-read-never, which is exactly
 // what an approval exists to prevent.
@@ -604,6 +626,8 @@ $('confirm-go').addEventListener('click', async () => {
     const okCount = results.filter(r => r.includes('accepted')).length
     st.className = 'status ' + (okCount ? 'ok' : 'err')
     st.textContent = `${okCount}/${results.length} relays accepted · ${results.join(' · ')}`
+    if (okCount && (signed.kind === KIND.grant || signed.kind === KIND.revocation))
+      await reportNvoyVisibility(st, signed)
     pendingTemplate = null
     // Re-read BOTH lists. Refreshing only the access list was the visible half of a bug: an
     // admitted request stayed on screen, so the operator could not tell the signature had taken.
@@ -845,6 +869,14 @@ async function loadRequests() {
     + (other.length ? ` · ${other.length} for Nvoy (no channel named)` : '')
     + (skipped ? ` · ${skipped} wrap(s) were not requests` : '')
     + (failed ? ` · ${failed} could not be read` : '')
+  if (other.length) {
+    st.append(' · ')
+    const exit = document.createElement('a')
+    exit.href = 'https://nvoy.nave.pub/console/#requests'
+    exit.target = '_blank'; exit.rel = 'noopener noreferrer'
+    exit.textContent = 'Open in Nvoy ↗'
+    st.append(exit)
+  }
 }
 
 $('go').addEventListener('click', async () => {

--- a/console/index.html
+++ b/console/index.html
@@ -265,6 +265,10 @@ const { decode } = nip19
 
 const $ = (id) => document.getElementById(id)
 const RELAYS = ['wss://nos.lol','wss://relay.primal.net','wss://relay.ditto.pub','wss://jskitty.com/nostr']
+// "Visible in Nvoy" is a claim about Nvoy's shipped discovery plane, not merely about one of
+// Waggle's wider publication relays. Keep this explicit until Nvoy publishes a signed/configurable
+// relay contract that the console can discover at runtime.
+const NVOY_RELAYS = ['wss://nos.lol','wss://relay.primal.net']
 const KIND = { grant: 440, revocation: 441 }
 const TAG = { scope: 'da-scope', cap: 'da-cap' }
 
@@ -584,7 +588,7 @@ function publish(ev) {
 
 async function reportNvoyVisibility(st, event) {
   st.querySelector('.nvoy-retry')?.remove()
-  const result = await verifyNvoyVisibility({ relays: RELAYS, event, query, verify: verifyEvent })
+  const result = await verifyNvoyVisibility({ relays: NVOY_RELAYS, event, query, verify: verifyEvent })
   if (result.visible > 0) {
     st.className = 'status ok'
     st.append(` · visible in Nvoy (${result.visible}/${result.total} relays cold-read the exact signed record)`)

--- a/console/nvoy-visibility.mjs
+++ b/console/nvoy-visibility.mjs
@@ -1,0 +1,14 @@
+// Nvoy's universal capability plane discovers Waggle's public 440/441 events directly.
+// There is no second index write for keyless capability grants: the proof is a cold, exact-id
+// relay read after publication. A relay OK is not enough; OK-and-drop is a known failure mode.
+
+export async function verifyNvoyVisibility({ relays, event, query, verify }) {
+  const reads = await Promise.all(relays.map(url => query(url, { ids: [event.id], limit: 1 })))
+  let visible = 0, answered = 0
+  for (const read of reads) {
+    if (read?.answered) answered++
+    if ((read?.out || []).some(found => found?.id === event.id && found.pubkey === event.pubkey &&
+        found.kind === event.kind && verify(found))) visible++
+  }
+  return { visible, answered, total: relays.length }
+}

--- a/tests/capabilities.mjs
+++ b/tests/capabilities.mjs
@@ -20,6 +20,8 @@
 import { readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { dirname, resolve, join } from 'node:path'
+import { finalizeEvent, generateSecretKey, verifyEvent } from 'nostr-tools'
+import { verifyNvoyVisibility } from '../console/nvoy-visibility.mjs'
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..')
 let pass = 0, fail = 0
@@ -113,6 +115,21 @@ for (const cap of ['task', 'task+act', 'task-relay']) {
   ok(`${cap} is NOT credited to this bridge — it is checked by the agent's runtime`,
     !bridgeHonours.includes(cap) && /runtime/.test(CAP_ENFORCER[cap]))
 }
+
+// ── Nvoy universal-plane visibility is a cold read, not a second fake data index ─────────────
+const visibilityEvent = JSON.parse(JSON.stringify(finalizeEvent({
+  kind: 440, created_at: 1, tags: [['p', 'a'.repeat(64)], ['da-cap', 'admit']], content: '',
+}, generateSecretKey())))
+const visibilityRelays = ['one', 'two', 'three']
+const visible = await verifyNvoyVisibility({ relays: visibilityRelays, event: visibilityEvent, verify: verifyEvent,
+  query: async url => ({ answered: true, out: url === 'two' ? [] : [visibilityEvent] }) })
+ok('an exact signed 440 cold-read from relays is honestly reported visible in Nvoy',
+  visible.visible === 2 && visible.answered === 3 && visible.total === 3)
+const forged = JSON.parse(JSON.stringify(visibilityEvent)); forged.content = 'changed'
+const absent = await verifyNvoyVisibility({ relays: visibilityRelays, event: visibilityEvent, verify: verifyEvent,
+  query: async url => ({ answered: url !== 'three', out: url === 'one' ? [forged] : [] }) })
+ok('absent, forged, and partial cold reads never claim Nvoy visibility',
+  absent.visible === 0 && absent.answered === 2 && absent.total === 3)
 
 console.log(`\n${pass}/${pass + fail} passed`)
 process.exit(fail ? 1 : 0)

--- a/tests/capabilities.mjs
+++ b/tests/capabilities.mjs
@@ -31,6 +31,10 @@ const consoleSrc = readFileSync(join(ROOT, 'console/index.html'), 'utf8')
 const grantSrc = readFileSync(join(ROOT, 'tools/grant.mjs'), 'utf8')
 const bridgeSrc = readFileSync(join(ROOT, 'src/bridge.mjs'), 'utf8')
 
+ok('the Nvoy visibility claim queries Nvoy default relays, not Waggle-only publication relays',
+  /const NVOY_RELAYS = \['wss:\/\/nos\.lol','wss:\/\/relay\.primal\.net'\]/.test(consoleSrc) &&
+  /verifyNvoyVisibility\(\{ relays: NVOY_RELAYS, event/.test(consoleSrc))
+
 // Pull the declarations out of the console page. It is a browser page with a DOM at load,
 // so evaluating the block is the practical way to read its real values.
 // Returns {} for a declaration that is absent, so a missing map reports as failed


### PR DESCRIPTION
Closes #283.

After issuing or revoking a public NIP-DA capability, the Waggle console now cold-reads the exact signed 440/441 from every configured relay before saying it is visible in Nvoy. Relay acknowledgement alone is not treated as proof; an absent record produces an explicit retry control. Pending Nvoy-only requests get an Open in Nvoy exit.

This deliberately does not fabricate an encrypted 10440 DATA grant index entry for keyless channel admission. Nvoy already discovers public capability grants directly; encrypted 10440 rotation state remains reserved for the future admit+read capability, when Waggle has real channel key and generation state to index.

Verification:
- npm test (51 suites)
- npm run lint
- positive exact signed cold-read
- negative absent, forged, and partial-relay controls

Drafted with assistance from [Claude Code](https://claude.com/claude-code)