### PR TITLE
Canonicalize tripwire systemd unit names

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -298,8 +298,10 @@ the bridge's own send-journal (`data/send-journal.log`). Any post authored by ou
 the journal does not contain was signed by something other than our process: theft, a
 second signer, an impersonation. That is the alarm.
 
-`deploy/tripwire.service` (oneshot) + `deploy/tripwire.timer` (30-min cadence) make
-detection a property of the **install**, not of anyone remembering to run a script.
+`deploy/tripwire.service` (oneshot) + `deploy/tripwire.timer` (30-min cadence), installed
+under the canonical names `waggle-tripwire.service` and `waggle-tripwire.timer`, make detection
+a property of the **install**, not of anyone remembering to run a script. Those installed names
+are load-bearing: the alarm credential drop-ins target `waggle-tripwire.service`.
 
 ### Two rules the unit exists to enforce
 
@@ -438,10 +440,11 @@ Then install the units (edit `WorkingDirectory`/`User`/paths in the unit files t
 host first):
 
 ```
-sudo cp deploy/tripwire.{service,timer} /etc/systemd/system/
+sudo install -m 0644 deploy/tripwire.service /etc/systemd/system/waggle-tripwire.service
+sudo install -m 0644 deploy/tripwire.timer /etc/systemd/system/waggle-tripwire.timer
 sudo systemctl daemon-reload
-sudo systemctl enable --now tripwire.timer
-systemctl list-timers tripwire.timer
+sudo systemctl enable --now waggle-tripwire.timer
+systemctl list-timers waggle-tripwire.timer
 ```
 
 Run the positive drill and confirm the sealed DM arrives at the operator identity before

--- a/deploy/tripwire.service
+++ b/deploy/tripwire.service
@@ -1,4 +1,5 @@
-# waggle tripwire unit (oneshot; driven by tripwire.timer). Out-of-process detection of
+# waggle tripwire unit (oneshot; install as waggle-tripwire.service and drive it with
+# waggle-tripwire.timer). Out-of-process detection of
 # unauthorized signing by the bridge POSTER key: tools/tripwire.mjs fetches the poster's
 # recent on-relay events and diffs them against the bridge send-journal (#33). Exit codes:
 #   0 = clean (every on-relay post came from our process)
@@ -37,7 +38,7 @@ User=bridge
 Group=bridge
 WorkingDirectory=/opt/waggle
 # --since-min 60 is deliberately WIDER than the 30-min timer cadence: overlapping windows
-# mean a single missed run never opens a detection gap (see tripwire.timer).
+# mean a single missed run never opens a detection gap (see waggle-tripwire.timer).
 ExecStart=/usr/bin/node tools/tripwire.mjs --since-min 60
 EnvironmentFile=/opt/waggle/tripwire.env
 Environment=PATH=/usr/local/bin:/usr/bin:/bin

--- a/deploy/tripwire.timer
+++ b/deploy/tripwire.timer
@@ -1,12 +1,15 @@
-# Drives tripwire.service on a fixed cadence, so detection is a property of the INSTALL,
+# Install this template as waggle-tripwire.timer. Its basename deliberately matches the
+# canonical waggle-tripwire.service target used by the alarm credential drop-ins and drill.
+# Drives waggle-tripwire.service on a fixed cadence, so detection is a property of the INSTALL,
 # not of operator diligence (the whole point of #34). The cadence (30 min) is shorter than
 # the service's poll window (--since-min 60) BY DESIGN: overlapping windows mean one missed
 # or delayed run never opens a gap a thief could slip a post through unseen.
 #
-#   sudo cp deploy/tripwire.{service,timer} /etc/systemd/system/
+#   sudo install -m 0644 deploy/tripwire.service /etc/systemd/system/waggle-tripwire.service
+#   sudo install -m 0644 deploy/tripwire.timer /etc/systemd/system/waggle-tripwire.timer
 #   sudo systemctl daemon-reload
-#   sudo systemctl enable --now tripwire.timer
-#   systemctl list-timers tripwire.timer      # confirm it is scheduled
+#   sudo systemctl enable --now waggle-tripwire.timer
+#   systemctl list-timers waggle-tripwire.timer      # confirm it is scheduled
 [Unit]
 Description=waggle tripwire — periodic out-of-process signing check (every 30 min)
 

--- a/tests/tripwire_detection.mjs
+++ b/tests/tripwire_detection.mjs
@@ -30,6 +30,7 @@ const BUNKER_INIT = resolve(ROOT, 'tools', 'tripwire-alarm-bunker-init.mjs')
 const DROP_IN = resolve(ROOT, 'deploy', 'tripwire-alarm.conf')
 const BUNKER_DROP_IN = resolve(ROOT, 'deploy', 'tripwire-alarm-bunker.conf')
 const BASE_UNIT = resolve(ROOT, 'deploy', 'tripwire.service')
+const TIMER_UNIT = resolve(ROOT, 'deploy', 'tripwire.timer')
 const DRILL_UNIT = resolve(ROOT, 'deploy', 'waggle-tripwire-drill.service')
 const POSTER = 'npub1s36nypljc6h88tey0kshf688eyd8myu636ctfs4e3d2w54nhsmnqfhaent'
 // Written per-run into the temp dir. The real log at data/tripwire-alarms.log is evidence an
@@ -277,10 +278,17 @@ try {
     dropIn.includes('Environment=ALARM_TO_FILE=%d/alarm.to') && !dropIn.includes('ExecStart='))
 
   const baseUnit = readFileSync(BASE_UNIT, 'utf8')
+  const timerUnit = readFileSync(TIMER_UNIT, 'utf8')
   check('the base detector unit contains no signer credential mode',
     !baseUnit.includes('LoadCredential=alarm.') &&
     !baseUnit.includes('Environment=ALARM_NSEC_FILE=') &&
     !baseUnit.includes('Environment=ALARM_BUNKER_URI_FILE='))
+  check('the shipped unit templates require the canonical waggle-tripwire installed names',
+    baseUnit.includes('install as waggle-tripwire.service') &&
+    timerUnit.includes('/etc/systemd/system/waggle-tripwire.service') &&
+    timerUnit.includes('/etc/systemd/system/waggle-tripwire.timer') &&
+    timerUnit.includes('enable --now waggle-tripwire.timer') &&
+    !timerUnit.includes('enable --now tripwire.timer'))
 
   const bunkerDropIn = readFileSync(BUNKER_DROP_IN, 'utf8')
   check('the preferred Bunker drop-in loads only pairing and recipient credential files',


### PR DESCRIPTION
Refs #263.

The shipped alarm credential drop-ins and drill target `waggle-tripwire.service`, while the generic install instructions previously installed `tripwire.service`/`tripwire.timer`. This makes the canonical installed names explicit everywhere and adds a regression that prevents the timer/service/drop-in names from diverging again.

Verification: exact current-main CI sequence passes (`npm run lint`; all 51 suites, with the documented example config).