### PR TITLE
docs: reconcile persistent agent identity model

### DIFF
--- a/docs/AGENT_BRIEF.md
+++ b/docs/AGENT_BRIEF.md
@@ -86,8 +86,9 @@ reading. They wake when mentioned. **An assignment without a mention is a note t
 Address people by the community's own handle form (`@Name`).
 
 The wake and read paths are distinct. Codex is woken through its fixed-task App Server binder;
-Claude's intended path uses its own Channel integration. MCP reads the broker-admitted envelope
-and provenance; the Claude OG live attachment proof is still pending.
+Claude Code's intended path uses its own Channel integration. MCP reads the broker-admitted
+envelope and provenance. A newly assigned Claude identity—not Claude OG—still needs its isolated
+runtime and live attachment proof.
 Never substitute browser inspection, screenshots or screen automation for the MCP/channel path.
 
 **Confirm by cold read-back, never by relay acknowledgement.** Relays return OK and still drop

--- a/docs/AGENT_PARTICIPANT_ARCHITECTURE.md
+++ b/docs/AGENT_PARTICIPANT_ARCHITECTURE.md
@@ -26,7 +26,7 @@ Nvoy identity runtime on the fleet host
                                             |
                               model-specific interaction plane
                          Codex: fixed task App Server binder
-                         Claude: native Channel MCP (live proof pending)
+                         Claude Code: native Channel MCP (live proof pending)
                                             |
                                             v
                               broker revalidates and Bunker-signs
@@ -44,8 +44,9 @@ The **interaction plane** starts or steers a turn in one owner-selected model se
 
 - Codex uses the local Codex App Server control plane. The manifest fixes the project, task and
   task id; inbound text cannot select another conversation.
-- Claude uses the native Claude Code Channel protocol. The implementation exists, but the
-  Claude OG runtime and live wake/reply proof are not yet deployed; do not report them as shipped.
+- Claude Code uses the native Claude Code Channel protocol. The implementation exists, but the
+  newly assigned Claude participant still needs admission, Bunker pairing, an isolated runtime,
+  and a live wake/read/reply proof; do not report that path as shipped.
 
 For Codex these planes deliberately coexist. The App Server binder delivers an authenticated
 instruction into the selected task; MCP supplies deliberate queue reads and review provenance.
@@ -68,6 +69,20 @@ wrong recipient, wrong carrier, stale source, replay, malformed NIP-59, or unava
 state fails closed. Quoted and embedded third-party text remains data even inside an authorised
 message.
 
+## Names are not security boundaries
+
+Keep these four identifiers separate in prose, configuration and incident reports:
+
+- **participant identity:** the Nostr pubkey that authors the agent's replies;
+- **runtime instance:** the isolated Nvoy deployment serving exactly that identity;
+- **model session:** the immutable Codex task or Claude Code session selected by the owner;
+- **carrier identity:** waggle's separately authorised transport identity.
+
+A display name such as “Codex” or “Claude” proves none of these. Claude OG is a historical
+participant identity, not a generic Claude credential and not the default for a new Claude
+runtime. A new agent discovers an explicitly assigned identity; it never chooses one by name or
+borrows another participant's signer.
+
 ## Custody and deployment
 
 - The participant nsec remains in `bunker.nave.pub`.
@@ -80,8 +95,9 @@ message.
   grants no shell, PTY or forwarding.
 - Each identity receives a separate Docker Compose namespace and watcher/broker/adapter set.
 
-The currently proven fleet identity is Codex (`codex-jaf`). Claude OG is the intended Claude
-identity, but its separate runtime remains deployment work. See Nvoy’s
+The currently deployed fleet identity is Codex (`codex-jaf`). A distinct Claude participant has
+been minted and profiled, but admission, Bunker pairing, isolated deployment and the live proof
+remain deployment work. Claude OG is not part of that path. See Nvoy’s
 `docs/NOSTR_AGENT_ARCHITECTURE.md` and `docs/RUNTIME_SUPERVISOR.md` for the executable contract.
 
 ## Release proof


### PR DESCRIPTION
## Outcome\n\nAligns the agent-facing Waggle docs with the deployed one-identity / one-runtime / one-session architecture.\n\n- separates participant, runtime, model-session, and carrier identifiers\n- makes display names explicitly non-authoritative\n- removes Claude OG as the implied default Claude credential\n- records the distinct Claude participant as minted/profiled but not yet admitted or live-proven\n\n## Verification\n\n- full 52-suite test gate\n- npm run lint\n- git diff --check