### PR TITLE
Pass the plane switcher — waggle as an app, not a plane (Wave 4)

### DIFF
--- a/console/index.html
+++ b/console/index.html
@@ -452,7 +452,7 @@ function renderRows() {
 // Vendored from the estate's component rather than hand-rolled: one sign-in across the fleet,
 // promoted rather than levelled down. The bar owns the signed-in/signed-out presentation and
 // the npub pill; this page only supplies the callbacks.
-import { renderTitlebar, updateTitlebar } from './vendor/nave-titlebar.mjs'
+import { renderTitlebar, updateTitlebar, NAVE_PLANES } from './vendor/nave-titlebar.mjs'
 
 const TB = $('titlebar')
 const WAGGLE_SEAL = `<svg viewBox="0 0 100 100" fill="none" aria-hidden="true">
@@ -467,6 +467,10 @@ function drawTitlebar(npub, kind) {
     appName: 'waggle console',
     tagline: 'who has access to your community',
     sealSvg: WAGGLE_SEAL,
+    // activePlane null — waggle is an APP, not a third plane. AD-12 declines
+    // "application plane": these are one grant plane seen at two scopes, and a slice
+    // highlighting itself as a plane would reintroduce the vocabulary the ruling removed.
+    planes: NAVE_PLANES, activePlane: null,
     npub: npub || null,
     kind: kind || null,
     onSignIn: npub ? undefined : () => { $('auth').style.display = ''; $('auth').scrollIntoView({ behavior: 'smooth', block: 'center' }) },

--- a/console/vendor/nave-titlebar.mjs
+++ b/console/vendor/nave-titlebar.mjs
@@ -1,3 +1,6 @@
+// vendored: components/nave-titlebar.mjs @ sha256:cb126abe0fb2b4f0 — JAFairweather/nave.pub@main
+// DO NOT EDIT. Change it in nave.pub and re-vendor. Exports NAVE_PLANES — the ONE fleet roster,
+// so the switcher propagates by vendoring rather than by each app declaring its own copy (AD-11).
 // Source of truth: nave.pub/components/nave-titlebar.mjs — copy in, do not edit.
 // The unified Nave title bar (the second half of the common sign-in work —
 // nave-connect, nact#16), as a renderer. No imports, no build step: apps
@@ -21,6 +24,50 @@
 // onRefresh, onLogout, onSignIn, signInLabel. The markup and CSS here are the
 // same as components/nave-titlebar.html — keep the two in lock-step. Styling
 // is token-driven (design/tokens.css) with dark-canonical fallbacks baked in.
+//
+// AD-12 additions — `planes` and `activePlane`, both OPTIONAL and ADDITIVE.
+// Absent them this renders byte-for-byte as it always did, which is what lets one
+// change propagate across a fleet whose apps update on different deploys.
+//
+//   planes: [
+//     { id:'nvoy', label:'Nvoy · data',   href:'https://nvoy.nave.pub/console/',
+//       accent:'#6fa8a0' },
+//     { id:'nact', label:'Nact · action', href:'https://nact.nave.pub/app.html',
+//       accent:'#c98f4f' },
+//     { id:'waggle', label:'waggle', href:'…', group:'apps' },
+//   ]
+//   activePlane: 'nvoy'   // or null on a slice, where no plane is current
+//
+// Two planes and N apps: `group:'apps'` moves an entry after the separator, so a
+// slice reads as an app rather than as a third plane (AD-12 declines "universal
+// plane"/"application plane" — these are one grant plane seen at two scopes).
+// Each entry may carry its own `accent`, so hovering a destination previews that
+// app's colour and wayfinding does real work instead of decorating.
+//
+// `href` is emitted as-is into an anchor. It is app-authored config, like sealSvg —
+// never user input, and never built from a relay-supplied value.
+
+/**
+ * THE FLEET ROSTER, in one place.
+ *
+ * Every app vendors this module, so exporting the roster here is what makes the switcher propagate
+ * without four apps each declaring their own copy — which is the duplication AD-11 forbids, and which
+ * would guarantee that the fifth app added to the estate is missing from three menus.
+ *
+ * `design/VENDOR.json` `apps` is the source this mirrors, and `bin/nave-drift` compares the two, so a
+ * roster edited in one place and not the other is a reported divergence rather than a surprise.
+ *
+ * An app passes `planes: NAVE_PLANES` and its own `activePlane`. A slice passes `activePlane: null` —
+ * it is an app, not a third plane (AD-12 declines "universal plane" / "application plane": these are
+ * one grant plane seen at two scopes).
+ */
+export const NAVE_PLANES = [
+  { id: 'nvoy', label: 'Nvoy · data', href: 'https://nvoy.nave.pub/console/', accent: '#6fa8a0' },
+  { id: 'nact', label: 'Nact · action', href: 'https://nact.nave.pub/app.html', accent: '#c98f4f' },
+  // Below the separator: apps, not planes. `waggle` is lowercase always — never Waggle or WAGGLE.
+  { id: 'waggle', label: 'waggle', href: 'https://waggle.nave.pub/console/', accent: '#cf8a2e', group: 'apps' },
+  { id: 'ngage', label: 'Ngage', href: 'https://ngage.nave.pub/', accent: '#b8874f', group: 'apps' },
+]
 
 const STYLE_ID = 'nave-titlebar-style'
 
@@ -71,10 +118,26 @@ const CSS = `
     color: var(--accent-ink, #0b0906); font-weight: 700; text-transform: uppercase; letter-spacing: 0.1em; }
   .nave-titlebar .ntb-btn.ntb-primary:hover { background: var(--accent-bright, #e2c079);
     border-color: var(--accent-bright, #e2c079); color: var(--accent-ink, #0b0906); }
+  /* AD-12 plane switcher — a second row, rendered only when planes is supplied. */
+  .nave-titlebar .ntb-planes { display: flex; align-items: center; gap: 7px; flex-wrap: wrap;
+    padding: 8px 15px; border-top: 1px solid var(--line, #2a2317); }
+  .nave-titlebar .ntb-planes-label { font: 10px var(--mono, monospace); letter-spacing: 0.14em;
+    text-transform: uppercase; color: var(--faint, #6f6555); }
+  .nave-titlebar .ntb-plane { font-size: 12px; text-decoration: none; color: var(--dim, #9c927f);
+    border: 1px solid var(--line, #2a2317); border-radius: var(--r-pill, 999px); padding: 3px 11px;
+    transition: color .14s, border-color .14s, background .14s; }
+  .nave-titlebar .ntb-plane:hover { color: var(--ntb-plane-accent, var(--accent-bright, #e2c079));
+    border-color: var(--ntb-plane-accent, var(--accent, #c39a56)); }
+  .nave-titlebar .ntb-plane[aria-current="page"] { color: var(--accent-bright, #e2c079);
+    border-color: var(--accent, #c39a56);
+    background: color-mix(in srgb, var(--accent, #c39a56) 12%, transparent); }
+  .nave-titlebar .ntb-planes-sep { width: 1px; height: 16px; margin: 0 4px;
+    background: var(--line, #2a2317); }
   @media (max-width: 640px) {
     .nave-titlebar .ntb-tag { display: none; }
     .nave-titlebar .ntb-bar { flex-wrap: wrap; row-gap: 10px; padding: 11px 16px; }
     .nave-titlebar .ntb-me, .nave-titlebar .ntb-signin { flex-wrap: wrap; }
+    .nave-titlebar .ntb-planes { padding: 7px 16px; }
   }
 `
 
@@ -151,7 +214,8 @@ export function renderTitlebar(el, opts = {}) {
   ensureStyle(doc)
 
   const { appName = '', tagline = '', sealSvg = '', npub = null, kind = null,
-          onRefresh = null, onLogout = null, onSignIn = null, signInLabel = 'Sign in' } = opts
+          onRefresh = null, onLogout = null, onSignIn = null, signInLabel = 'Sign in',
+          planes = null, activePlane = null } = opts
 
   root.classList.add('nave-titlebar')
   if (npub) root.setAttribute('data-signed-in', '')
@@ -201,6 +265,32 @@ export function renderTitlebar(el, opts = {}) {
     me,
     signin,
   ))
+
+  // AD-12 plane switcher. Rendered only when `planes` is supplied, so an app that
+  // has not adopted it is unchanged — the property that lets this land fleet-wide
+  // in one commit while apps update on their own deploys.
+  const list = Array.isArray(planes) ? planes.filter(p => p && p.id && p.label) : []
+  if (list.length) {
+    const bar = h(doc, 'nav', { class: 'ntb-planes', 'aria-label': 'Planes and apps' })
+    const anchor = (p) => {
+      const a = h(doc, 'a', { class: 'ntb-plane', href: p.href || '#' }, p.label)
+      if (p.id === activePlane) a.setAttribute('aria-current', 'page')
+      // Per-destination accent, so a hover previews where you are going.
+      if (p.accent) a.style.setProperty('--ntb-plane-accent', p.accent)
+      return a
+    }
+    const planeGroup = list.filter(p => p.group !== 'apps')
+    const appGroup = list.filter(p => p.group === 'apps')
+    if (planeGroup.length) {
+      bar.append(h(doc, 'span', { class: 'ntb-planes-label' }, 'Planes'), ...planeGroup.map(anchor))
+    }
+    if (appGroup.length) {
+      if (planeGroup.length) bar.append(h(doc, 'span', { class: 'ntb-planes-sep' }))
+      bar.append(h(doc, 'span', { class: 'ntb-planes-label' }, 'Apps'), ...appGroup.map(anchor))
+    }
+    root.append(bar)
+  }
+
   return root
 }
 


### PR DESCRIPTION
Lands the last step of Wave 4 for waggle. [nave.pub#122](https://github.com/JAFairweather/nave.pub/pull/122) exported `NAVE_PLANES` — the **one** roster, from the module every app already vendors, so a new app appears in every menu at once (AD-11), and `nave-drift` compares it against `VENDOR.json` so the two cannot silently disagree.

## `activePlane: null` is the load-bearing detail

waggle is an **app**, not a third plane. AD-12 declines *"application plane"* because these are one grant plane seen at two scopes, and a slice highlighting itself as a plane would reintroduce exactly the vocabulary the ruling removed. `group:'apps'` in the roster puts it below the separator for the same reason.

`console/routing.html` has no titlebar of its own and is **left alone** rather than given one — the switcher belongs where the identity bar is, and adding a second would be two places to sign out from.

## A process note, because it touched someone else's work

This clone sits on `fix/read-config-write-policy` with **uncommitted work that is not mine**, including its own `RELAYS` change. My first attempt edited that branch by accident when `checkout -B` aborted on the dirty tree.

Those edits were backed out **individually** — not by `git checkout --`, which would have destroyed the branch's own RELAYS change — and I verified that change was still present before moving on. The real work was then done in a fresh worktree off `origin/main`. Flagging it because a clone that is someone else's workspace deserves to be left exactly as it was found.

Suite 34/34.