### PR TITLE
Design the remote-agent lifecycle plane

### DIFF
--- a/docs/DESIGN_AGENT_LIFECYCLE_PLANE.md
+++ b/docs/DESIGN_AGENT_LIFECYCLE_PLANE.md
@@ -1,0 +1,187 @@
+# Design — the remote-agent lifecycle plane
+
+waggle/console is where a remote agent is created, granted, tuned, audited and retired. This
+document says how that is possible without inventing a transport, a vocabulary or a CLI role.
+
+Scope note: #305 installs **an owner, once**. This installs **an agent, repeatedly**, and keeps
+managing it for the rest of its life. They share machinery; they are not the same journey.
+
+---
+
+## The outcome
+
+An owner opens the console, adds a remote agent, and — without pasting JSON, editing a unit file,
+or being told to go read a runbook — ends with an agent that is admitted, wakeable, scoped, and
+visibly proven so. Later, the same surface is where they tune what that agent is allowed to see,
+watch what it actually did, and take its authority away.
+
+The agent's private key is never in the browser, never on the waggle host, and never in this
+repository.
+
+---
+
+## Two planes already exist. Lifecycle is a catalogue on them, not a third plane.
+
+**The projection plane (read).** #307 establishes it: mode-0600 private state holding no
+credentials → a validated, secret-free public receipt → the browser renders the receipt and
+nothing else. The browser has no access to private installer state and no write access to
+`config.json`.
+
+**The actuator plane (write).** `src/buzz_policy_*` is already a signed-command executor with the
+exact properties lifecycle needs, and they were hard-won rather than incidental:
+
+- a **closed catalogue** — `BUZZ_POLICY_OPERATIONS` is frozen; a caller *names* an operation, and
+  cannot supply rendered prose or choose a destination;
+- **evidence, not instructions** — the untrusted side contributes canonical signed evidence, and a
+  credential-free core decides independently;
+- a **forced-command runner** — deployment fixes the executable and config path; stdin is the only
+  caller-controlled input;
+- **journal idempotency** — `O_EXCL` claim, atomic rename completion, terminal across processes;
+- **hold, never fall back** — an unavailable policy service is a queue that waits. There is
+  deliberately no dead-letter limit, because "the service was down" must never become permission to
+  sign with a lesser key.
+
+Agent lifecycle is therefore **one more closed catalogue on the actuator plane, plus per-agent rows
+in the projection**. PR #307 states the governing constraint plainly — *no second setup vocabulary
+is introduced* — and this design is bound by it.
+
+That is the whole answer to "do we need a CLI role": for the **operations**, no. The console signs;
+the bridge verifies against `public.approvers`, dedups by id, applies one allowed change, and
+acknowledges in signed state. That is the mechanism that already moves a watchlist entry.
+
+---
+
+## Where the CLI genuinely survives
+
+The CLI is not retained for symmetry or preference. It survives at exactly two boundaries, and
+both are forced:
+
+1. **A secret generated locally.** A key minted in a browser tab exists in a JS heap the console
+   cannot prove it discarded, in a page whose origin already needed a `Host`-header defence against
+   DNS rebinding (#145). Generation happens in the CLI; only the npub and a Bunker URI cross over.
+2. **Anything that must touch the host** — filesystem, systemd, firewall. Already #305's territory.
+
+Everything else — grant, bind, tune, pause, audit, revoke — is console-signed.
+
+---
+
+## Three doors, one gate
+
+The three key-provenance flows differ *only* in where the secret is born. They converge on a single
+acceptance test.
+
+| Flow | Where the nsec is born | What waggle receives |
+|---|---|---|
+| **Mint** (the simple option) | in `bunker.nave.pub`, in custody | a Bunker URI + revocable NIP-46 client key |
+| **BYOK** | already yours, already in a signer | a Bunker URI + revocable client key |
+| **Make your own** (guided CLI prompts) | locally, in the CLI | an npub, then a Bunker URI once paired |
+
+**Mint must mint into the signer, never onto the box.** waggle holds exactly one private key — its
+own. An agent nsec written to the waggle host would give it a second, and would break the single
+claim this project protects hardest. Minting into custody keeps the invariant intact, which is why
+"mint for simplicity" remains available rather than being traded away.
+
+**The one gate: challenge-sign a fresh nonce.** The console never accepts a pasted npub as proof of
+control, and never accepts possession of a Bunker URI as proof either — a URI can be stale,
+revoked, or already spent. The agent proves control by signing a nonce the console generated this
+session. Same test for all three doors; provenance changes the setup, never the standard.
+
+---
+
+## Traps this plane must treat as first-class
+
+Each of these has produced a wrong green somewhere in this project's history.
+
+- **Possessing a Bunker URI ≠ control.** Only a fresh challenge-sign shows it.
+- **The NIP-46 pairing secret is effectively single-use.** A spent one presents as
+  `Unknown client` — which reads like a misconfiguration and is actually a *used* credential. Name
+  it in the UI, or the owner will re-paste and re-fail.
+- **Empty ≠ absent.** A grant list that renders empty because the query failed looks identical to
+  one that is genuinely empty. Run the negative control *inside* the wizard: query a subject known
+  to have nothing, confirm it says so, and only then trust the real query. If state cannot be
+  verified, render `unavailable` — never a plausible empty list.
+- **Reachable ≠ attached.** A broker answering `NVOY_NOT_DELIVERED` proves the broker is reachable
+  and proves nothing about attachment.
+- **Admitted ≠ wakeable.** `admit`, `task` and `task-relay` are separate authorities on purpose. An
+  `admit` grant alone cannot wake an agent, and an agent that looks admitted but never answers is
+  the predictable result of showing one and implying the others.
+- **Write ≠ read.** A granted participant posts in as a first-class member. What comes back is the
+  return lane — **mentions only** — because the community relay will not serve an external key. The
+  console must not draw a symmetrical arrow.
+
+### Resumable state vs. re-derived truth
+
+These are not in tension, but the boundary has to be explicit or the wizard will lie after a
+reboot. #307 stores *evidence-bound* transitions, which is the right primitive. The rule:
+
+> Saved state may record **that** a proof passed and **what evidence** proved it. It may never be
+> the authority for a **live** property.
+
+Grant active, bunker responsive, unit running, relay serving — all re-derived on view, every time.
+A saved `passed` renders as *"passed at T, on this evidence"*, never as *"is currently true"*. #308
+was exactly this failure: saved progress that no longer matched the world.
+
+---
+
+## The lifecycle catalogue
+
+Closed, named, signed by an approver, executed by the bridge, acknowledged in signed state:
+
+| Operation | Effect | Reversible |
+|---|---|---|
+| `agent_register` | bind an npub + Bunker reference to an agent row | yes |
+| `agent_bind_runtime` | associate one isolated runtime/MCP namespace | yes |
+| `agent_set_visibility` | tune what community traffic the agent may see | yes |
+| `agent_set_relay_policy` | per-agent relay/rebroadcast configuration | yes |
+| `agent_pause` / `agent_resume` | stop delivery without touching custody | yes |
+| `agent_revoke` | withdraw authority | yes — re-grant |
+| `agent_destroy_unit` | destroy the deployed unit | **no** |
+
+**Retire is two operations, not one, because they have opposite reversibility.** Revoking authority
+is instant, safe, and console-signed: the agent stops being able to act, and nothing is lost.
+Destroying the unit is irreversible — `broker_credentials` is `reRenderable: false`, so it forces a
+Bunker re-pair — and must carry an explicit confirmation token in the signed command rather than
+being a button next to `pause`. The console should make revoke the obvious action and destroy the
+deliberate one.
+
+---
+
+## What the console must never gain
+
+- write access to `config.json` (the actuator exists precisely so it does not need it);
+- any private key, of any agent, at any point, including transiently;
+- the ability to name a destination or supply rendered prose to the bridge;
+- a signed-state summary containing channel UUIDs, host addresses, credentials, message content,
+  consent-record ids, or grant detail. Publication stays off by default
+  (`public.control_state_publish: false`).
+
+---
+
+## Build order
+
+This stacks on PR #307 and must not be built before it lands — a stacked branch whose base is
+squash-merged gets orphaned, and today one was auto-**closed** that way.
+
+1. Extend the projection with per-agent rows and their re-derived live checks (read-only; ships
+   value alone, since an owner can then *see* agents before managing any).
+2. Add the lifecycle catalogue to the actuator, verify-and-journal path first, with negative
+   controls asserting **both** directions — that a non-approver signature is refused *and* that a
+   legitimate approver still gets through. A guard asserted only to reject cannot be told apart
+   from one that rejects everything; that exact gap shipped a silent outage on 2026-08-01.
+3. Challenge-sign verification, shared by all three provenance doors.
+4. The three doors in the console, with the CLI hand-off for make-your-own.
+5. Revoke, then destroy behind its confirmation token.
+
+Steps 1 and 2 are independently useful and independently reviewable, which is the point of the
+split.
+
+---
+
+## Close condition
+
+An owner adds a remote agent through the console, using any of the three key flows, and reaches a
+state where every claim on screen is backed by a live re-derived check or is explicitly marked
+unproven. They can later change what that agent sees, and revoke it, without a terminal. The one
+manual step that remains is the Bunker approval, because a person must approve custody — and the
+guided CLI prompts for make-your-own, because a locally generated secret must not pass through a
+browser.

--- a/docs/DESIGN_AGENT_LIFECYCLE_PLANE.md
+++ b/docs/DESIGN_AGENT_LIFECYCLE_PLANE.md
@@ -1,7 +1,11 @@
 # Design — the remote-agent lifecycle plane
 
-waggle/console is where a remote agent is created, granted, tuned, audited and retired. This
-document says how that is possible without inventing a transport, a vocabulary or a CLI role.
+> **Status: design only. Nothing described here is built.** It stacks on PR #307 (open, unmerged).
+> Step 3 of the build order — the challenge gate — is in PR #311 (open). Everything else is a
+> proposal, and the section below on the actuator is an untested one.
+
+waggle/console **should be** where a remote agent is created, granted, tuned, audited and retired.
+This document argues that is possible without inventing a transport, a vocabulary or a CLI role.
 
 Scope note: #305 installs **an owner, once**. This installs **an agent, repeatedly**, and keeps
 managing it for the rest of its life. They share machinery; they are not the same journey.
@@ -15,20 +19,28 @@ or being told to go read a runbook — ends with an agent that is admitted, wake
 visibly proven so. Later, the same surface is where they tune what that agent is allowed to see,
 watch what it actually did, and take its authority away.
 
-The agent's private key is never in the browser, never on the waggle host, and never in this
+The agent's private key **must never be** in the browser, on the waggle host, or in this
 repository.
 
 ---
 
-## Two planes already exist. Lifecycle is a catalogue on them, not a third plane.
+## Two planes are already designed. Lifecycle is a catalogue on them, not a third plane.
 
-**The projection plane (read).** #307 establishes it: mode-0600 private state holding no
+**The projection plane (read).** #307 *proposes* it — open and unmerged: mode-0600 private state holding no
 credentials → a validated, secret-free public receipt → the browser renders the receipt and
 nothing else. The browser has no access to private installer state and no write access to
 `config.json`.
 
-**The actuator plane (write).** `src/buzz_policy_*` is already a signed-command executor with the
-exact properties lifecycle needs, and they were hard-won rather than incidental:
+**The actuator plane (write).** Two distinct mechanisms exist, and an earlier draft of this
+document merged them. They are not the same lane, and the difference decides where lifecycle goes:
+
+- **The approver-signed control-command lane** (`handleWatchlistControlCommand` in `src/bridge.mjs`,
+  kind `CONTROL_COMMAND_KIND` filtered on `authors: PUB.approvers` and a `d` tag). This is what
+  moves a watchlist entry today. Its input is the **owner's intent**, signed.
+- **The off-box policy service** (`src/buzz_policy_*`) — a forced-command runner over stdin whose
+  input is **canonical third-party evidence**, decided by a credential-free core.
+
+The policy service has the stronger properties, and they were hard-won rather than incidental:
 
 - a **closed catalogue** — `BUZZ_POLICY_OPERATIONS` is frozen; a caller *names* an operation, and
   cannot supply rendered prose or choose a destination;
@@ -41,13 +53,22 @@ exact properties lifecycle needs, and they were hard-won rather than incidental:
   deliberately no dead-letter limit, because "the service was down" must never become permission to
   sign with a lesser key.
 
-Agent lifecycle is therefore **one more closed catalogue on the actuator plane, plus per-agent rows
-in the projection**. PR #307 states the governing constraint plainly — *no second setup vocabulary
-is introduced* — and this design is bound by it.
+But the property that makes the policy service strong is the one that does **not** transfer.
+`agent_pause` has no third-party signed evidence behind it; the owner's intent *is* the input. That
+is instructions, which is precisely what the policy core exists to refuse — and its catalogue is
+frozen at two operations (`quarantine_header`, `standing_trusted_reply`), both of which are Buzz
+*rendering* rather than configuration.
 
-That is the whole answer to "do we need a CLI role": for the **operations**, no. The console signs;
-the bridge verifies against `public.approvers`, dedups by id, applies one allowed change, and
-acknowledges in signed state. That is the mechanism that already moves a watchlist entry.
+So the proposal is: agent lifecycle **could be** one more closed catalogue, and the
+**control-command lane is the likelier home**, with per-agent rows in the projection. The console
+signs; the bridge verifies against `public.approvers`, dedups by id, applies one allowed change, and
+acknowledges in signed state — the shape that already moves a watchlist entry. Whether the off-box
+policy actuator has any role here is **open**, and is the first thing a reviewer should attack.
+
+PR #307 states the governing constraint plainly — *no second setup vocabulary is introduced* — and
+this design is bound by it either way.
+
+That is the answer to "do we need a CLI role": for the **operations**, no.
 
 ---
 
@@ -61,7 +82,9 @@ both are forced:
    DNS rebinding (#145). Generation happens in the CLI; only the npub and a Bunker URI cross over.
 2. **Anything that must touch the host** — filesystem, systemd, firewall. Already #305's territory.
 
-Everything else — grant, bind, tune, pause, audit, revoke — is console-signed.
+Everything else — grant, bind, tune, pause, audit, revoke — is console-signed. `agent_destroy_unit`
+straddles the line and is called out in the catalogue below: the *intent* is console-signed, the
+*execution* removes a runtime and its namespace and so belongs to boundary 2.
 
 ---
 
@@ -119,7 +142,8 @@ reboot. #307 stores *evidence-bound* transitions, which is the right primitive. 
 
 Grant active, bunker responsive, unit running, relay serving — all re-derived on view, every time.
 A saved `passed` renders as *"passed at T, on this evidence"*, never as *"is currently true"*. #308
-was exactly this failure: saved progress that no longer matched the world.
+is the live instance and is still **open**: it exists because "implemented", "deployed", "attached"
+and "live-proven" had been collapsed into a single saved "pending" more than once.
 
 ---
 
@@ -131,11 +155,11 @@ Closed, named, signed by an approver, executed by the bridge, acknowledged in si
 |---|---|---|
 | `agent_register` | bind an npub + Bunker reference to an agent row | yes |
 | `agent_bind_runtime` | associate one isolated runtime/MCP namespace | yes |
-| `agent_set_visibility` | tune what community traffic the agent may see | yes |
+| `agent_set_visibility` | tune what the return lane carries out to this agent | yes |
 | `agent_set_relay_policy` | per-agent relay/rebroadcast configuration | yes |
 | `agent_pause` / `agent_resume` | stop delivery without touching custody | yes |
 | `agent_revoke` | withdraw authority | yes — re-grant |
-| `agent_destroy_unit` | destroy the deployed unit | **no** |
+| `agent_destroy_unit` | destroy the deployed unit — **host-touching: console-signed intent, CLI/#305 execution** | **no** |
 
 **Retire is two operations, not one, because they have opposite reversibility.** Revoking authority
 is instant, safe, and console-signed: the agent stops being able to act, and nothing is lost.
@@ -168,7 +192,7 @@ squash-merged gets orphaned, and today one was auto-**closed** that way.
    controls asserting **both** directions — that a non-approver signature is refused *and* that a
    legitimate approver still gets through. A guard asserted only to reject cannot be told apart
    from one that rejects everything; that exact gap shipped a silent outage on 2026-08-01.
-3. Challenge-sign verification, shared by all three provenance doors.
+3. Challenge-sign verification, shared by all three provenance doors — **in PR #311 (open)**.
 4. The three doors in the console, with the CLI hand-off for make-your-own.
 5. Revoke, then destroy behind its confirmation token.
 

--- a/docs/DESIGN_AGENT_LIFECYCLE_PLANE.md
+++ b/docs/DESIGN_AGENT_LIFECYCLE_PLANE.md
@@ -97,7 +97,15 @@ acceptance test.
 |---|---|---|
 | **Mint** (the simple option) | in `bunker.nave.pub`, in custody | a Bunker URI + revocable NIP-46 client key |
 | **BYOK** | already yours, already in a signer | a Bunker URI + revocable client key |
-| **Make your own** (guided CLI prompts) | locally, in the CLI | an npub, then a Bunker URI once paired |
+| **Make your own** (guided CLI prompts) | on the owner's own machine, in the CLI | an npub, then a Bunker URI once paired |
+
+**Where the connection credential lives — and why it does not dent the one-key claim.** A NIP-46
+client key *is* a private key, and a Bunker URI embeds a pairing secret. So "waggle receives a
+Bunker URI + revocable client key" has to say *which* waggle. It is not the bridge and not the
+console: those credentials seat directly into the **agent's own runtime unit**, across the CLI /
+#305 boundary, and never transit console or bridge state. An agent row in the projection holds a
+**reference** to that unit's credential, never the credential. The bridge still holds exactly one
+private key — its own — and each agent runtime holds only its own revocable connection.
 
 **Mint must mint into the signer, never onto the box.** waggle holds exactly one private key — its
 own. An agent nsec written to the waggle host would give it a second, and would break the single
@@ -158,12 +166,19 @@ Closed, named, signed by an approver, executed by the bridge, acknowledged in si
 | `agent_set_visibility` | tune what the return lane carries out to this agent | yes |
 | `agent_set_relay_policy` | per-agent relay/rebroadcast configuration | yes |
 | `agent_pause` / `agent_resume` | stop delivery without touching custody | yes |
-| `agent_revoke` | withdraw authority | yes — re-grant |
+| `agent_revoke` | withdraw **bridge-side admission**, which the bridge issued and can revoke | yes — re-grant |
 | `agent_destroy_unit` | destroy the deployed unit — **host-touching: console-signed intent, CLI/#305 execution** | **no** |
+
+**`agent_revoke` withdraws only what the bridge itself granted.** A grantor-signed data grant is
+not the bridge's to withdraw — only its issuer can relinquish or revoke it. The console must
+therefore show admission and data grants as separate rows with separate remedies, or an owner will
+press revoke, watch the admission drop, and reasonably conclude the agent has lost an access it
+still holds.
 
 **Retire is two operations, not one, because they have opposite reversibility.** Revoking authority
 is instant, safe, and console-signed: the agent stops being able to act, and nothing is lost.
-Destroying the unit is irreversible — `broker_credentials` is `reRenderable: false`, so it forces a
+Destroying the unit is irreversible — `broker_credentials` is `reRenderable: false` (nvoy #160, and
+the re-pair cost rests on the spent pairing secret), so it forces a
 Bunker re-pair — and must carry an explicit confirmation token in the signed command rather than
 being a button next to `pause`. The console should make revoke the obvious action and destroy the
 deliberate one.

--- a/docs/wireframes/console-agent-lifecycle.html
+++ b/docs/wireframes/console-agent-lifecycle.html
@@ -1,0 +1,754 @@
+<title>waggle console — remote-agent lifecycle wireframes</title>
+<style>
+  /* Tokens lifted verbatim from console/index.html. These wireframes are meant to be argued with
+     as the console, not as a parallel design language, so nothing here invents a palette. */
+  :root {
+    --ground:#0b0906; --panel:#14100a; --panel-2:#1b1409; --line:#2a2317; --line-strong:#3a3020;
+    --field:#0d0a06; --text:#f4efe4; --dim:#9c927f; --faint:#6f6555;
+    --gold:#c39a56; --gold-bright:#e2c079;
+    --accent:#cf8a2e; --accent-bright:#e8a545; --accent-ink:#0b0906;
+    --good:#8fae6a; --warn:#d9a648; --critical:#c0705a;
+    --sans:-apple-system,BlinkMacSystemFont,"Segoe UI","Inter",Roboto,"Helvetica Neue",Arial,sans-serif;
+    --mono:ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Roboto Mono",monospace;
+    --display:"Iowan Old Style","Palatino Linotype",Palatino,Georgia,serif;
+    --r-sm:6px; --r-md:10px;
+  }
+  @media (prefers-color-scheme: light){ :root:not([data-theme="dark"]){
+    --ground:#f5f0e4; --panel:#fffdf7; --panel-2:#ece4d2; --line:#ddd2ba; --line-strong:#c8b89a;
+    --field:#fffdf7; --text:#241d12; --dim:#6f6553; --faint:#8a7f66;
+    --gold:#8a6a24; --gold-bright:#6d5316;
+    --accent:#8a5a14; --accent-bright:#a86f1e; --accent-ink:#fffdf7;
+    --good:#4f7a34; --warn:#9a6a12; --critical:#a2482f; } }
+  :root[data-theme="light"]{ --ground:#f5f0e4; --panel:#fffdf7; --panel-2:#ece4d2; --line:#ddd2ba;
+    --line-strong:#c8b89a; --field:#fffdf7; --text:#241d12; --dim:#6f6553; --faint:#8a7f66;
+    --gold:#8a6a24; --gold-bright:#6d5316;
+    --accent:#8a5a14; --accent-bright:#a86f1e; --accent-ink:#fffdf7;
+    --good:#4f7a34; --warn:#9a6a12; --critical:#a2482f; }
+
+  *{box-sizing:border-box}
+  body{margin:0;background:var(--ground);color:var(--text);font-family:var(--sans);line-height:1.55;
+    -webkit-font-smoothing:antialiased}
+  main{max-width:1180px;margin:0 auto;padding:0 22px 80px}
+  code,.mono{font-family:var(--mono)}
+
+  /* ---- document furniture ---------------------------------------------------------------- */
+  .doc-head{padding:44px 0 12px;border-bottom:1px solid var(--line);margin-bottom:34px}
+  .eyebrow{font-family:var(--mono);font-size:11px;text-transform:uppercase;letter-spacing:.16em;
+    color:var(--gold);margin:0 0 12px}
+  h1{font-family:var(--display);font-size:38px;font-weight:600;margin:0 0 14px;text-wrap:balance;
+    line-height:1.15}
+  .standfirst{color:var(--dim);font-size:16px;max-width:68ch;margin:0 0 20px}
+  .standfirst strong{color:var(--text);font-weight:600}
+  .meta{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 6px}
+  .meta span{font-family:var(--mono);font-size:11px;color:var(--dim);border:1px solid var(--line);
+    border-radius:var(--r-sm);padding:4px 9px}
+
+  /* ---- screen block ---------------------------------------------------------------------- */
+  .screen{margin:0 0 52px;scroll-margin-top:20px}
+  .screen-head{display:flex;align-items:baseline;gap:12px;flex-wrap:wrap;margin:0 0 4px;
+    padding-bottom:10px;border-bottom:1px solid var(--line)}
+  .screen-num{font-family:var(--mono);font-size:12px;color:var(--accent);letter-spacing:.1em;
+    font-weight:700}
+  .screen-head h2{font-family:var(--display);font-size:25px;font-weight:600;margin:0;flex:1;
+    min-width:min(100%,320px)}
+  .screen-route{font-family:var(--mono);font-size:11.5px;color:var(--faint)}
+  .screen-intro{color:var(--dim);font-size:14.5px;max-width:72ch;margin:12px 0 18px}
+
+  .split{display:grid;grid-template-columns:minmax(0,1fr) 300px;gap:20px;align-items:start}
+  @media (max-width:900px){ .split{grid-template-columns:minmax(0,1fr)} }
+
+  /* ---- the mock frame: real console components ------------------------------------------- */
+  .frame{background:var(--panel);border:1px solid var(--line-strong);border-radius:var(--r-md);
+    overflow:hidden}
+  .frame-bar{display:flex;align-items:center;gap:9px;padding:9px 14px;background:var(--panel-2);
+    border-bottom:1px solid var(--line)}
+  .frame-bar .dot{width:9px;height:9px;border-radius:50%;background:var(--line-strong);flex:none}
+  .frame-bar .where{font-family:var(--mono);font-size:11px;color:var(--faint);margin-left:6px}
+  .frame-body{padding:18px}
+
+  .wordmark{font-family:var(--display);font-size:17px;font-weight:600}
+  .wordmark span{color:var(--dim);font-weight:400;font-size:13px;font-family:var(--sans)}
+
+  h3.sec{font-family:var(--mono);font-size:11px;text-transform:uppercase;letter-spacing:.14em;
+    color:var(--dim);margin:0 0 11px;font-weight:600}
+  .card{background:var(--panel-2);border:1px solid var(--line);border-radius:var(--r-sm);
+    padding:13px 15px}
+  .stack{display:flex;flex-direction:column;gap:11px}
+  .rowflex{display:flex;gap:11px;flex-wrap:wrap;align-items:center}
+  .grow{flex:1;min-width:0}
+
+  /* agent row */
+  .agent-name{font-family:var(--display);font-size:17px;font-weight:600;line-height:1.2}
+  .npub{font-family:var(--mono);font-size:11.5px;color:var(--faint);word-break:break-all}
+
+  /* pills: state encoded in form as well as colour */
+  .pill{display:inline-flex;align-items:center;gap:5px;font-family:var(--mono);font-size:10.5px;
+    text-transform:uppercase;letter-spacing:.08em;padding:3px 8px;border-radius:999px;
+    border:1px solid var(--line-strong);color:var(--dim);white-space:nowrap}
+  .pill::before{content:"";width:6px;height:6px;border-radius:50%;background:currentColor;flex:none}
+  .pill.on{color:var(--good);border-color:color-mix(in srgb,var(--good) 45%,transparent)}
+  .pill.off{color:var(--faint);border-style:dashed}
+  .pill.off::before{background:transparent;box-shadow:inset 0 0 0 1px currentColor}
+  .pill.unk{color:var(--warn);border-color:color-mix(in srgb,var(--warn) 45%,transparent)}
+  .pill.unk::before{border-radius:1px;transform:rotate(45deg)}
+  .pill.bad{color:var(--critical);border-color:color-mix(in srgb,var(--critical) 50%,transparent)}
+
+  .evidence{font-family:var(--mono);font-size:10.5px;color:var(--faint);margin-top:5px}
+
+  /* buttons */
+  .btn{background:var(--accent);color:var(--accent-ink);border:1px solid var(--accent);
+    border-radius:var(--r-sm);padding:8px 15px;font-weight:700;font-size:13px;font-family:inherit;
+    cursor:pointer}
+  .btn.ghost{background:transparent;color:var(--text);border-color:var(--line-strong);font-weight:600}
+  .btn.danger{background:transparent;color:var(--critical);
+    border-color:color-mix(in srgb,var(--critical) 55%,transparent)}
+  .btn:focus-visible{outline:2px solid var(--gold-bright);outline-offset:2px}
+
+  label.f{display:block;font-family:var(--mono);font-size:10.5px;color:var(--dim);
+    margin:0 0 5px;text-transform:uppercase;letter-spacing:.1em}
+  .input{background:var(--field);border:1px solid var(--line);border-radius:var(--r-sm);
+    padding:9px 11px;font-family:var(--mono);font-size:12.5px;color:var(--faint)}
+
+  /* door cards */
+  .doors{display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:11px}
+  .door{background:var(--panel-2);border:1px solid var(--line);border-radius:var(--r-sm);
+    padding:14px;display:flex;flex-direction:column;gap:7px}
+  .door.sel{border-color:var(--accent);box-shadow:inset 0 0 0 1px var(--accent)}
+  .door h4{margin:0;font-family:var(--display);font-size:16px;font-weight:600}
+  .door p{margin:0;font-size:12.5px;color:var(--dim)}
+  .door .where-born{font-family:var(--mono);font-size:10px;text-transform:uppercase;
+    letter-spacing:.08em;color:var(--gold);margin-top:auto;padding-top:6px}
+
+  /* the honest asymmetry diagram */
+  .lanes{display:flex;flex-direction:column;gap:8px}
+  .lane{display:grid;grid-template-columns:74px 1fr;gap:11px;align-items:center;
+    background:var(--panel-2);border:1px solid var(--line);border-radius:var(--r-sm);padding:10px 13px}
+  .lane-dir{font-family:var(--mono);font-size:10.5px;text-transform:uppercase;letter-spacing:.08em;
+    color:var(--gold)}
+  .lane-what{font-size:13px}
+  .lane-what b{font-weight:600}
+  .lane-what em{color:var(--dim);font-style:normal;font-size:12px;display:block;margin-top:2px}
+
+  /* annotation rail */
+  .rail{display:flex;flex-direction:column;gap:13px;position:sticky;top:16px}
+  .note{border-left:2px solid var(--line-strong);padding:0 0 0 12px}
+  .note h5{margin:0 0 4px;font-family:var(--mono);font-size:10.5px;text-transform:uppercase;
+    letter-spacing:.1em;color:var(--gold);font-weight:600}
+  .note p{margin:0;font-size:12.5px;color:var(--dim);line-height:1.5}
+  .note p + p{margin-top:6px}
+  .note code{font-size:11.5px;color:var(--text);background:var(--panel-2);padding:1px 4px;
+    border-radius:3px}
+  .note.trap{border-left-color:var(--critical)}
+  .note.trap h5{color:var(--critical)}
+
+  .refuses{margin-top:16px;background:var(--panel);border:1px solid var(--line);
+    border-left:2px solid var(--gold);border-radius:var(--r-sm);padding:12px 15px}
+  .refuses h5{margin:0 0 7px;font-family:var(--mono);font-size:10.5px;text-transform:uppercase;
+    letter-spacing:.1em;color:var(--gold);font-weight:600}
+  .refuses ul{margin:0;padding-left:17px;font-size:13px;color:var(--dim)}
+  .refuses li{margin-bottom:3px}
+  .refuses li::marker{color:var(--faint)}
+
+  .open-qs{border-top:1px solid var(--line);margin-top:20px;padding-top:26px}
+  .open-qs h2{font-family:var(--display);font-size:25px;margin:0 0 6px;font-weight:600}
+  .qs{display:grid;grid-template-columns:repeat(auto-fit,minmax(270px,1fr));gap:13px;margin-top:18px}
+  .q{background:var(--panel);border:1px solid var(--line);border-radius:var(--r-sm);padding:14px 16px}
+  .q h5{margin:0 0 6px;font-family:var(--mono);font-size:10.5px;text-transform:uppercase;
+    letter-spacing:.1em;color:var(--accent);font-weight:600}
+  .q p{margin:0;font-size:13px;color:var(--dim)}
+  .foot{margin-top:34px;padding-top:16px;border-top:1px solid var(--line);font-size:12.5px;
+    color:var(--faint);max-width:74ch}
+  @media (prefers-reduced-motion: reduce){ *{animation:none!important;transition:none!important} }
+</style>
+
+<main>
+  <header class="doc-head">
+    <p class="eyebrow">waggle · wireframes · issue #309 · design PR #310</p>
+    <h1>The remote-agent lifecycle, as a console</h1>
+    <p class="standfirst">
+      Five screens covering an agent's whole life — create, prove, tune, audit, retire. They are drawn
+      in the console's own tokens rather than a wireframe kit, because the argument worth having is
+      about <strong>what each screen claims and how it proves it</strong>, not about spacing.
+      Every screen carries a note on what it <strong>refuses</strong> to do; in this project that
+      has usually been the load-bearing half.
+    </p>
+    <div class="meta">
+      <span>stacks on PR #307</span>
+      <span>no new transport</span>
+      <span>no CLI role for operations</span>
+      <span>reviewers: kerouac · mydude</span>
+    </div>
+  </header>
+
+  <!-- ============================================================ 1 -->
+  <section class="screen">
+    <div class="screen-head">
+      <span class="screen-num">01</span>
+      <h2>Agents</h2>
+      <span class="screen-route">/console/agents</span>
+    </div>
+    <p class="screen-intro">
+      The index is the honest one. Each row re-derives its live properties on view; nothing here is
+      read back from saved progress. The three authorities are shown separately because they
+      <em>are</em> separate — collapsing them into one “admitted” badge is how you ship an agent that
+      looks fine and never wakes.
+    </p>
+
+    <div class="split">
+      <div class="frame">
+        <div class="frame-bar">
+          <span class="dot"></span><span class="dot"></span><span class="dot"></span>
+          <span class="where">waggle console — agents</span>
+        </div>
+        <div class="frame-body">
+          <div class="rowflex" style="margin-bottom:16px">
+            <div class="grow"><span class="wordmark">waggle <span>· agents</span></span></div>
+            <button class="btn">Add agent</button>
+          </div>
+
+          <h3 class="sec">Three agents · checked just now</h3>
+          <div class="stack">
+
+            <div class="card">
+              <div class="rowflex">
+                <div class="grow">
+                  <div class="agent-name">kerouac</div>
+                  <div class="npub">npub1q9v…7t2x</div>
+                </div>
+                <span class="pill on">admit</span>
+                <span class="pill on">task</span>
+                <span class="pill on">task-relay</span>
+              </div>
+              <div class="evidence">
+                custody: bunker responding · 240 ms &nbsp;·&nbsp; runtime bound: <code>nvoy/kerouac</code>
+                &nbsp;·&nbsp; challenge signed 14:22Z, nonce 3f9a…c1
+              </div>
+            </div>
+
+            <div class="card">
+              <div class="rowflex">
+                <div class="grow">
+                  <div class="agent-name">dennis</div>
+                  <div class="npub">npub1x4k…9m0d</div>
+                </div>
+                <span class="pill on">admit</span>
+                <span class="pill off">task</span>
+                <span class="pill off">task-relay</span>
+              </div>
+              <div class="evidence">
+                custody: bunker responding · 310 ms &nbsp;·&nbsp; runtime bound: <code>nvoy/dennis</code>
+              </div>
+              <div class="evidence" style="color:var(--warn)">
+                admitted, not wakeable — this agent can be spoken about but cannot be woken.
+                Request <code>task</code> to change that.
+              </div>
+            </div>
+
+            <div class="card">
+              <div class="rowflex">
+                <div class="grow">
+                  <div class="agent-name">neil</div>
+                  <div class="npub">npub1h7c…2b8s</div>
+                </div>
+                <span class="pill unk">admit ?</span>
+                <span class="pill unk">task ?</span>
+                <span class="pill unk">task-relay ?</span>
+              </div>
+              <div class="evidence" style="color:var(--warn)">
+                grant state unavailable — the relay query failed at 14:24Z. This is not “no grants”.
+                Last known good: all three active, 13:58Z. <a href="#" style="color:var(--gold-bright)">Retry</a>
+              </div>
+            </div>
+
+          </div>
+        </div>
+      </div>
+
+      <aside class="rail">
+        <div class="note trap">
+          <h5>Trap · admitted ≠ wakeable</h5>
+          <p><code>admit</code>, <code>task</code> and <code>task-relay</code> are deliberately
+            separate authorities. An <code>admit</code> grant alone cannot wake an agent.</p>
+          <p>Dennis's row shows the exact failure an owner would otherwise spend an afternoon on:
+            everything looks granted, nothing answers.</p>
+        </div>
+        <div class="note trap">
+          <h5>Trap · empty ≠ absent</h5>
+          <p>Neil's row is the one that matters. A failed query and a genuinely empty grant list
+            render identically unless you force them apart.</p>
+          <p>So the plane renders <b>unavailable</b> in warn, keeps the last known good with its
+            timestamp, and never draws an empty list it cannot vouch for.</p>
+        </div>
+        <div class="note">
+          <h5>Evidence, not checkmarks</h5>
+          <p>Each row states <em>what</em> proved it and <em>when</em> — “challenge signed 14:22Z,
+            nonce 3f9a…c1”, not a green tick. A tick is a claim; a nonce is a receipt.</p>
+        </div>
+      </aside>
+    </div>
+
+    <div class="refuses">
+      <h5>What this screen refuses to do</h5>
+      <ul>
+        <li>Render a green state from saved progress — every pill on this page is re-derived on view.</li>
+        <li>Show an empty list when it means “I could not tell”.</li>
+        <li>Collapse three authorities into one badge.</li>
+        <li>Display a channel UUID, host address, or any grant detail beyond presence.</li>
+      </ul>
+    </div>
+  </section>
+
+  <!-- ============================================================ 2 -->
+  <section class="screen">
+    <div class="screen-head">
+      <span class="screen-num">02</span>
+      <h2>Add an agent — three doors</h2>
+      <span class="screen-route">/console/agents/new</span>
+    </div>
+    <p class="screen-intro">
+      The doors differ in exactly one respect: where the private key is born. Everything downstream
+      is identical, so the screen says that plainly instead of presenting three unrelated-looking
+      workflows.
+    </p>
+
+    <div class="split">
+      <div class="frame">
+        <div class="frame-bar">
+          <span class="dot"></span><span class="dot"></span><span class="dot"></span>
+          <span class="where">waggle console — add agent · step 1 of 3</span>
+        </div>
+        <div class="frame-body">
+          <h3 class="sec">Where should this agent's key live?</h3>
+          <div class="doors">
+            <div class="door sel">
+              <h4>Mint one for me</h4>
+              <p>waggle asks the signer to create a new identity and pairs to it. Simplest path.</p>
+              <p class="where-born">born in bunker.nave.pub</p>
+            </div>
+            <div class="door">
+              <h4>I already have one</h4>
+              <p>Paste a Bunker connection you control. Nothing about your key leaves your signer.</p>
+              <p class="where-born">already in your signer</p>
+            </div>
+            <div class="door">
+              <h4>Make my own</h4>
+              <p>Generate it yourself at the terminal. The console hands you a command and waits.</p>
+              <p class="where-born">born on your machine</p>
+            </div>
+          </div>
+
+          <div class="card" style="margin-top:16px">
+            <h3 class="sec" style="margin-bottom:8px">Minting into custody</h3>
+            <p style="margin:0;font-size:13px;color:var(--dim)">
+              The new key is created inside the signer and stays there. waggle receives a connection
+              string and a revocable client key — never the key itself. waggle holds exactly one
+              private key, its own, and minting must not give it a second.
+            </p>
+          </div>
+
+          <div class="rowflex" style="margin-top:16px">
+            <button class="btn ghost">Back</button>
+            <div class="grow"></div>
+            <button class="btn">Continue to proof</button>
+          </div>
+        </div>
+      </div>
+
+      <aside class="rail">
+        <div class="note">
+          <h5>Why mint stays on the menu</h5>
+          <p>Simplicity was worth keeping, and it costs nothing — <em>provided</em> the key is born
+            in the signer rather than on the box.</p>
+          <p>A minted nsec written to the waggle host would give waggle a second private key and
+            break the claim this project protects hardest.</p>
+        </div>
+        <div class="note">
+          <h5>Why the third door is a terminal</h5>
+          <p>A key generated in a browser tab lives in a JS heap the console cannot prove it
+            discarded, in an origin that already needed a <code>Host</code>-header defence against
+            DNS rebinding.</p>
+          <p>So the CLI is not a leftover here. It is the only place this flow can honestly happen.</p>
+        </div>
+        <div class="note">
+          <h5>One vocabulary</h5>
+          <p>All three doors converge on step 2. The console does not grow three parallel state
+            machines — PR #307's rule is that no second setup vocabulary gets introduced.</p>
+        </div>
+      </aside>
+    </div>
+
+    <div class="refuses">
+      <h5>What this screen refuses to do</h5>
+      <ul>
+        <li>Accept a pasted <code>nsec</code>, in any door, ever.</li>
+        <li>Generate key material in the browser.</li>
+        <li>Write an agent key to the waggle host.</li>
+        <li>Treat the choice of door as changing what counts as proof.</li>
+      </ul>
+    </div>
+  </section>
+
+  <!-- ============================================================ 3 -->
+  <section class="screen">
+    <div class="screen-head">
+      <span class="screen-num">03</span>
+      <h2>Prove control</h2>
+      <span class="screen-route">/console/agents/new · step 2</span>
+    </div>
+    <p class="screen-intro">
+      One gate, identical for all three doors. The agent signs a nonce this session generated. A
+      pasted npub proves nothing, and possession of a connection string proves nothing either — it
+      can be stale, revoked, or already spent.
+    </p>
+
+    <div class="split">
+      <div class="frame">
+        <div class="frame-bar">
+          <span class="dot"></span><span class="dot"></span><span class="dot"></span>
+          <span class="where">waggle console — add agent · step 2 of 3</span>
+        </div>
+        <div class="frame-body">
+          <h3 class="sec">Challenge</h3>
+          <div class="card">
+            <label class="f">nonce · generated 14:31:07Z · expires in 4:52</label>
+            <div class="input">3f9a1c07d4e28b6a5510cc9e17ff20bd</div>
+            <div class="evidence" style="margin-top:9px">
+              Approve the signing request in your signer. waggle is waiting for a signature over this
+              exact value.
+            </div>
+          </div>
+
+          <h3 class="sec" style="margin-top:18px">Result</h3>
+          <div class="stack">
+            <div class="card">
+              <div class="rowflex">
+                <span class="pill on">signature verified</span>
+                <div class="grow"></div>
+                <span class="evidence">14:31:22Z</span>
+              </div>
+              <div class="evidence" style="margin-top:7px">
+                signed by <code>npub1q9v…7t2x</code> — matches the identity this connection claims.
+              </div>
+            </div>
+
+            <div class="card">
+              <div class="rowflex">
+                <span class="pill on">negative control passed</span>
+                <div class="grow"></div>
+                <span class="evidence">14:31:23Z</span>
+              </div>
+              <div class="evidence" style="margin-top:7px">
+                a deliberately wrong nonce was rejected — so this check can fail, and does.
+              </div>
+            </div>
+          </div>
+
+          <div class="card" style="margin-top:14px;border-color:color-mix(in srgb,var(--warn) 40%,var(--line))">
+            <div class="rowflex" style="margin-bottom:6px">
+              <span class="pill bad">pairing rejected</span>
+              <span class="evidence">if you see “Unknown client”</span>
+            </div>
+            <p style="margin:0;font-size:12.5px;color:var(--dim)">
+              That message usually means the pairing secret has already been used — not that
+              anything is misconfigured. Pairing secrets are effectively single-use. Issue a fresh
+              one in your signer rather than re-pasting this one.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <aside class="rail">
+        <div class="note trap">
+          <h5>Trap · possessing ≠ controlling</h5>
+          <p>Holding a Bunker URI is not evidence of control. Only a signature over a nonce the
+            console generated <em>this session</em> is.</p>
+        </div>
+        <div class="note trap">
+          <h5>Trap · the spent pairing secret</h5>
+          <p>A used secret presents as <code>Unknown client</code>, which reads like a
+            misconfiguration and is actually a consumed credential.</p>
+          <p>Owners re-paste it, fail again, and conclude the product is broken. So the screen names
+            the real cause where the error appears.</p>
+        </div>
+        <div class="note">
+          <h5>The negative control is on screen</h5>
+          <p>A check that has only ever passed proves nothing. This one deliberately fails once, in
+            front of the owner, and shows that it failed.</p>
+          <p>That is the difference between an alarm that works and an alarm nobody has tested.</p>
+        </div>
+      </aside>
+    </div>
+
+    <div class="refuses">
+      <h5>What this screen refuses to do</h5>
+      <ul>
+        <li>Accept an npub as proof of control.</li>
+        <li>Accept a connection string's existence as proof it still works.</li>
+        <li>Pass without having demonstrated it can fail.</li>
+        <li>Reuse a nonce, or accept one it did not generate.</li>
+      </ul>
+    </div>
+  </section>
+
+  <!-- ============================================================ 4 -->
+  <section class="screen">
+    <div class="screen-head">
+      <span class="screen-num">04</span>
+      <h2>Tune what the agent sees</h2>
+      <span class="screen-route">/console/agents/kerouac</span>
+    </div>
+    <p class="screen-intro">
+      The ongoing surface: what community traffic reaches this agent, and what it may do. This is
+      also where the console has to be honest about an asymmetry that is easy to draw wrongly — the
+      agent posts in as a full member, but what comes back to it is <em>mentions only</em>.
+    </p>
+
+    <div class="split">
+      <div class="frame">
+        <div class="frame-bar">
+          <span class="dot"></span><span class="dot"></span><span class="dot"></span>
+          <span class="where">waggle console — kerouac</span>
+        </div>
+        <div class="frame-body">
+          <div class="rowflex" style="margin-bottom:15px">
+            <div class="grow">
+              <div class="agent-name">kerouac</div>
+              <div class="npub">npub1q9v…7t2x</div>
+            </div>
+            <span class="pill on">active</span>
+          </div>
+
+          <h3 class="sec">How traffic actually flows</h3>
+          <div class="lanes">
+            <div class="lane">
+              <span class="lane-dir">agent → us</span>
+              <span class="lane-what">
+                <b>Posts as a first-class member</b>
+                <em>signed with its own key. waggle routes; it does not author.</em>
+              </span>
+            </div>
+            <div class="lane">
+              <span class="lane-dir">us → agent</span>
+              <span class="lane-what">
+                <b>Receives mentions only</b>
+                <em>the community relay will not serve an external key, so the return lane carries
+                  mentions — not the channel.</em>
+              </span>
+            </div>
+          </div>
+
+          <h3 class="sec" style="margin-top:18px">What gets carried out to this agent</h3>
+          <div class="stack">
+            <div class="card">
+              <div class="rowflex">
+                <span class="grow" style="font-size:13.5px">Direct mentions of <code>@kerouac</code></span>
+                <span class="pill on">always</span>
+              </div>
+            </div>
+            <div class="card">
+              <div class="rowflex">
+                <span class="grow" style="font-size:13.5px">Replies to anything it posted</span>
+                <span class="pill on">on</span>
+              </div>
+            </div>
+            <div class="card">
+              <div class="rowflex">
+                <span class="grow" style="font-size:13.5px">Relevance calls — waggle judges what relates to its current work</span>
+                <span class="pill off">off</span>
+              </div>
+              <div class="evidence" style="margin-top:6px">
+                When on, waggle may carry a message nobody addressed to this agent, and may pull it
+                into a thread. Every such decision is logged with its reason.
+              </div>
+            </div>
+            <div class="card">
+              <div class="rowflex">
+                <span class="grow" style="font-size:13.5px">Approved public posts from outside</span>
+                <span class="pill on">on</span>
+              </div>
+              <div class="evidence" style="margin-top:6px">
+                consent-gated · 3 sources approved · quarantine remains default-closed
+              </div>
+            </div>
+          </div>
+
+          <div class="rowflex" style="margin-top:16px">
+            <button class="btn">Sign changes</button>
+            <span class="evidence" style="align-self:center">
+              signs one namespaced command · bridge verifies against approvers, dedups, applies
+            </span>
+          </div>
+        </div>
+      </div>
+
+      <aside class="rail">
+        <div class="note trap">
+          <h5>Trap · write ≠ read</h5>
+          <p>The write half is exact: a granted participant posts in as a first-class member. The
+            read half is not — the community relay will not serve an external key.</p>
+          <p>Any UI that draws a symmetrical arrow here is claiming something untrue. Hence two
+            visibly different lanes rather than one bidirectional one.</p>
+        </div>
+        <div class="note">
+          <h5>“Sign changes”, not “Save”</h5>
+          <p>The button names what happens. The console signs a command; the bridge verifies the
+            signature against <code>public.approvers</code>, dedups by id, changes the one allowed
+            field, and acknowledges in signed state.</p>
+          <p>The browser never gets write access to <code>config.json</code>. That is what makes
+            this a console rather than an admin panel.</p>
+        </div>
+        <div class="note">
+          <h5>Relevance is a real decision</h5>
+          <p>Off by default, and labelled as judgement rather than filtering — because when it is
+            on, waggle is choosing to carry something nobody addressed to the agent.</p>
+        </div>
+      </aside>
+    </div>
+
+    <div class="refuses">
+      <h5>What this screen refuses to do</h5>
+      <ul>
+        <li>Draw a symmetrical arrow between the community and an external agent.</li>
+        <li>Take write access to <code>config.json</code>.</li>
+        <li>Send prose or a destination to the bridge — it names one operation from a closed set.</li>
+        <li>Turn relevance-carrying on quietly, or carry without logging the reason.</li>
+      </ul>
+    </div>
+  </section>
+
+  <!-- ============================================================ 5 -->
+  <section class="screen">
+    <div class="screen-head">
+      <span class="screen-num">05</span>
+      <h2>Retire</h2>
+      <span class="screen-route">/console/agents/kerouac/retire</span>
+    </div>
+    <p class="screen-intro">
+      Two operations with opposite reversibility, so they are not two buttons side by side. Revoking
+      authority is instant and undoable. Destroying the unit is not — it forces a fresh custody
+      pairing, and there is no path back.
+    </p>
+
+    <div class="split">
+      <div class="frame">
+        <div class="frame-bar">
+          <span class="dot"></span><span class="dot"></span><span class="dot"></span>
+          <span class="where">waggle console — kerouac · retire</span>
+        </div>
+        <div class="frame-body">
+          <h3 class="sec">Stop this agent acting</h3>
+          <div class="card">
+            <div class="rowflex">
+              <div class="grow">
+                <div style="font-size:14px;font-weight:600;margin-bottom:3px">Revoke authority</div>
+                <div style="font-size:12.5px;color:var(--dim)">
+                  The agent immediately stops being able to post or be woken. Its identity, custody
+                  pairing and history are untouched. You can grant it again at any time.
+                </div>
+              </div>
+              <button class="btn">Revoke</button>
+            </div>
+          </div>
+
+          <div style="margin-top:26px;padding-top:18px;border-top:1px solid var(--line)">
+            <h3 class="sec" style="color:var(--critical)">Irreversible</h3>
+            <div class="card" style="border-color:color-mix(in srgb,var(--critical) 35%,var(--line))">
+              <div style="font-size:14px;font-weight:600;margin-bottom:3px">Destroy the deployed unit</div>
+              <div style="font-size:12.5px;color:var(--dim);margin-bottom:11px">
+                Removes the runtime, its broker credentials and its namespace. Broker credentials
+                cannot be re-rendered, so bringing this agent back means pairing custody again from
+                scratch. Revoking is almost always what you want instead.
+              </div>
+              <label class="f">type the agent's name to confirm</label>
+              <div class="input" style="margin-bottom:11px">kerouac</div>
+              <button class="btn danger">Destroy unit — cannot be undone</button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <aside class="rail">
+        <div class="note">
+          <h5>Reversibility sets the layout</h5>
+          <p>Revoke sits at the top with an ordinary button. Destroy sits below a rule, in its own
+            section, behind a typed confirmation.</p>
+          <p>They are not peers, so the screen does not present them as peers. The confirmation
+            token is carried in the signed command itself, not just in the UI.</p>
+        </div>
+        <div class="note trap">
+          <h5>Why destroy is truly terminal</h5>
+          <p>Broker credentials are <code>reRenderable: false</code>. Destroying the unit therefore
+            forces a fresh Bunker pairing — the owner cannot simply recreate what they had.</p>
+        </div>
+        <div class="note">
+          <h5>Revoke first, ask later</h5>
+          <p>An owner who suspects trouble should have a safe, instant, undoable lever within reach.
+            Making the dangerous one convenient would be the error.</p>
+        </div>
+      </aside>
+    </div>
+
+    <div class="refuses">
+      <h5>What this screen refuses to do</h5>
+      <ul>
+        <li>Put revoke and destroy next to each other as equivalent choices.</li>
+        <li>Destroy on a single click, or without a token inside the signed command.</li>
+        <li>Imply a destroyed unit can be restored.</li>
+        <li>Touch custody when the owner asked only to revoke.</li>
+      </ul>
+    </div>
+  </section>
+
+  <!-- ============================================================ questions -->
+  <section class="open-qs">
+    <h2>Open questions for review</h2>
+    <p class="standfirst" style="margin-bottom:0">
+      These are the places I am least confident, and the reason this is a wireframe rather than a
+      branch.
+    </p>
+    <div class="qs">
+      <div class="q">
+        <h5>for mydude · scope creep</h5>
+        <p>Screen 04 signs per-agent visibility and relay policy. Does that fit the existing closed
+          catalogue without widening what the console is trusted with — or does “per-agent relay
+          policy” quietly need destination-naming, which the actuator forbids by design?</p>
+      </div>
+      <div class="q">
+        <h5>for mydude · re-derive cost</h5>
+        <p>Screen 01 re-derives every property on view. With a dozen agents that is a lot of live
+          relay work per page load. Is a short verified cache acceptable, and if so, what makes it
+          different from the saved progress #308 taught us not to trust?</p>
+      </div>
+      <div class="q">
+        <h5>for kerouac · claim precision</h5>
+        <p>Does any screen state something as shipped that is only designed? Screens 02–05 describe
+          operations that do not exist yet; the wireframe frame is meant to carry that, but the
+          copy inside may not.</p>
+      </div>
+      <div class="q">
+        <h5>for kerouac · the honest arrow</h5>
+        <p>Screen 04's two lanes are my attempt to render write-vs-read asymmetry without claiming
+          read. Does the wording hold, particularly “receives mentions only”?</p>
+      </div>
+      <div class="q">
+        <h5>either · the fourth door</h5>
+        <p>#141's ephemeral pattern — mint, act, burn, hold nothing — is arguably a fourth door and
+          is deliberately absent here. Should a disposable session be a first-class option on
+          screen 02, or does surfacing it invite standing use of a burner?</p>
+      </div>
+      <div class="q">
+        <h5>either · relevance judgement</h5>
+        <p>Screen 04 offers waggle judging what to carry. That is a model making a routing call on a
+          member's behalf. Is a per-agent toggle the right granularity, or does it need its own
+          consent surface?</p>
+      </div>
+    </div>
+
+    <p class="foot">
+      Wireframes only — nothing depicted is built. Drawn in the console's existing tokens so the
+      review is about behaviour rather than styling. Build order stacks on PR #307 and does not
+      start before it lands. Design: <code>docs/DESIGN_AGENT_LIFECYCLE_PLANE.md</code> · issue #309 ·
+      PR #310.
+    </p>
+  </section>
+</main>

--- a/docs/wireframes/console-agent-lifecycle.html
+++ b/docs/wireframes/console-agent-lifecycle.html
@@ -35,6 +35,9 @@
   .doc-head{padding:44px 0 12px;border-bottom:1px solid var(--line);margin-bottom:34px}
   .eyebrow{font-family:var(--mono);font-size:11px;text-transform:uppercase;letter-spacing:.16em;
     color:var(--gold);margin:0 0 12px}
+  /* waggle is always lowercase, including UI wordmarks — so it opts out of the uppercase transform
+     its own eyebrow applies. Checked in RENDERED output, which is where this drifts. */
+  .lc{text-transform:none}
   h1{font-family:var(--display);font-size:38px;font-weight:600;margin:0 0 14px;text-wrap:balance;
     line-height:1.15}
   .standfirst{color:var(--dim);font-size:16px;max-width:68ch;margin:0 0 20px}
@@ -64,6 +67,13 @@
     border-bottom:1px solid var(--line)}
   .frame-bar .dot{width:9px;height:9px;border-radius:50%;background:var(--line-strong);flex:none}
   .frame-bar .where{font-family:var(--mono);font-size:11px;color:var(--faint);margin-left:6px}
+  .frame-bar .mock{font-family:var(--mono);font-size:9.5px;text-transform:uppercase;
+    letter-spacing:.1em;color:var(--warn);border:1px solid color-mix(in srgb,var(--warn) 45%,transparent);
+    border-radius:999px;padding:2px 7px}
+  .notbuilt{background:var(--panel);border:1px solid color-mix(in srgb,var(--warn) 45%,var(--line));
+    border-left:3px solid var(--warn);border-radius:var(--r-sm);padding:13px 16px;margin:0 0 30px;
+    font-size:13.5px;color:var(--dim)}
+  .notbuilt strong{color:var(--text);font-weight:600}
   .frame-body{padding:18px}
 
   .wordmark{font-family:var(--display);font-size:17px;font-weight:600}
@@ -128,6 +138,10 @@
   .lane-what{font-size:13px}
   .lane-what b{font-weight:600}
   .lane-what em{color:var(--dim);font-style:normal;font-size:12px;display:block;margin-top:2px}
+  .widen{background:var(--panel-2);border:1px solid color-mix(in srgb,var(--warn) 40%,var(--line));
+    border-left:2px solid var(--warn);border-radius:var(--r-sm);padding:10px 13px;margin:0 0 11px;
+    font-size:12.5px;color:var(--dim)}
+  .widen strong{color:var(--text);font-weight:600}
 
   /* annotation rail */
   .rail{display:flex;flex-direction:column;gap:13px;position:sticky;top:16px}
@@ -163,7 +177,7 @@
 
 <main>
   <header class="doc-head">
-    <p class="eyebrow">waggle · wireframes · issue #309 · design PR #310</p>
+    <p class="eyebrow"><span class="lc">waggle</span> · wireframes · issue #309 · design PR #310</p>
     <h1>The remote-agent lifecycle, as a console</h1>
     <p class="standfirst">
       Five screens covering an agent's whole life — create, prove, tune, audit, retire. They are drawn
@@ -179,6 +193,12 @@
       <span>reviewers: kerouac · mydude</span>
     </div>
   </header>
+
+  <div class="notbuilt">
+    <strong>Wireframes. None of these operations exist.</strong> Every value shown — timings,
+    grant states, counts, nonces — is invented, not observed. The only part of this in code is the
+    challenge gate of screen 03, in open PR #311.
+  </div>
 
   <!-- ============================================================ 1 -->
   <section class="screen">
@@ -198,7 +218,7 @@
       <div class="frame">
         <div class="frame-bar">
           <span class="dot"></span><span class="dot"></span><span class="dot"></span>
-          <span class="where">waggle console — agents</span>
+          <span class="mock">illustrative</span><span class="where">waggle console — agents</span>
         </div>
         <div class="frame-body">
           <div class="rowflex" style="margin-bottom:16px">
@@ -221,7 +241,7 @@
               </div>
               <div class="evidence">
                 custody: bunker responding · 240 ms &nbsp;·&nbsp; runtime bound: <code>nvoy/kerouac</code>
-                &nbsp;·&nbsp; challenge signed 14:22Z, nonce 3f9a…c1
+                &nbsp;·&nbsp; challenge signed 14:31:22Z, nonce 3f9a1c07…
               </div>
             </div>
 
@@ -281,7 +301,7 @@
         </div>
         <div class="note">
           <h5>Evidence, not checkmarks</h5>
-          <p>Each row states <em>what</em> proved it and <em>when</em> — “challenge signed 14:22Z,
+          <p>Each row states <em>what</em> proved it and <em>when</em> — “challenge signed 14:31:22Z,
             nonce 3f9a…c1”, not a green tick. A tick is a claim; a nonce is a receipt.</p>
         </div>
       </aside>
@@ -315,7 +335,7 @@
       <div class="frame">
         <div class="frame-bar">
           <span class="dot"></span><span class="dot"></span><span class="dot"></span>
-          <span class="where">waggle console — add agent · step 1 of 3</span>
+          <span class="mock">illustrative</span><span class="where">waggle console — add agent · step 1 of 3</span>
         </div>
         <div class="frame-body">
           <h3 class="sec">Where should this agent's key live?</h3>
@@ -323,7 +343,7 @@
             <div class="door sel">
               <h4>Mint one for me</h4>
               <p>waggle asks the signer to create a new identity and pairs to it. Simplest path.</p>
-              <p class="where-born">born in bunker.nave.pub</p>
+              <p class="where-born">born in <span class="lc">bunker.nave.pub</span></p>
             </div>
             <div class="door">
               <h4>I already have one</h4>
@@ -405,7 +425,7 @@
       <div class="frame">
         <div class="frame-bar">
           <span class="dot"></span><span class="dot"></span><span class="dot"></span>
-          <span class="where">waggle console — add agent · step 2 of 3</span>
+          <span class="mock">illustrative</span><span class="where">waggle console — add agent · step 2 of 3</span>
         </div>
         <div class="frame-body">
           <h3 class="sec">Challenge</h3>
@@ -494,11 +514,11 @@
   <section class="screen">
     <div class="screen-head">
       <span class="screen-num">04</span>
-      <h2>Tune what the agent sees</h2>
+      <h2>Tune what is carried out to this agent</h2>
       <span class="screen-route">/console/agents/kerouac</span>
     </div>
     <p class="screen-intro">
-      The ongoing surface: what community traffic reaches this agent, and what it may do. This is
+      The ongoing surface: what the return lane carries out to this agent, and what it may do. This is
       also where the console has to be honest about an asymmetry that is easy to draw wrongly — the
       agent posts in as a full member, but what comes back to it is <em>mentions only</em>.
     </p>
@@ -507,7 +527,7 @@
       <div class="frame">
         <div class="frame-bar">
           <span class="dot"></span><span class="dot"></span><span class="dot"></span>
-          <span class="where">waggle console — kerouac</span>
+          <span class="mock">illustrative</span><span class="where">waggle console — kerouac</span>
         </div>
         <div class="frame-body">
           <div class="rowflex" style="margin-bottom:15px">
@@ -538,6 +558,12 @@
           </div>
 
           <h3 class="sec" style="margin-top:18px">What gets carried out to this agent</h3>
+          <div class="widen">
+            <strong>Only the first of these is “mentions”.</strong> The three below it widen the
+            return lane past what the community relay serves today. That is a deliberate change to
+            the <em>mentions only</em> claim, not a preference — it needs its own decision before any
+            of it is built, and it is an open question rather than something settled here.
+          </div>
           <div class="stack">
             <div class="card">
               <div class="rowflex">
@@ -633,7 +659,7 @@
       <div class="frame">
         <div class="frame-bar">
           <span class="dot"></span><span class="dot"></span><span class="dot"></span>
-          <span class="where">waggle console — kerouac · retire</span>
+          <span class="mock">illustrative</span><span class="where">waggle console — kerouac · retire</span>
         </div>
         <div class="frame-body">
           <h3 class="sec">Stop this agent acting</h3>
@@ -706,6 +732,13 @@
       These are the places I am least confident, and the reason this is a wireframe rather than a
       branch.
     </p>
+    <p class="standfirst" style="margin-bottom:0;margin-top:12px">
+      <strong>Not drawn, deliberately:</strong> the third step of the add-agent flow, where
+      <code>agent_register</code> and <code>agent_bind_runtime</code> would live;
+      <code>agent_set_relay_policy</code>; and <code>agent_pause</code> / <code>agent_resume</code>.
+      The catalogue in the design doc is wider than these five screens, and screens 02–03 are
+      labelled “of 3” against a third step that does not exist yet.
+    </p>
     <div class="qs">
       <div class="q">
         <h5>for mydude · scope creep</h5>
@@ -729,6 +762,13 @@
         <h5>for kerouac · the honest arrow</h5>
         <p>Screen 04's two lanes are my attempt to render write-vs-read asymmetry without claiming
           read. Does the wording hold, particularly “receives mentions only”?</p>
+      </div>
+      <div class="q">
+        <h5>either · widening the return lane</h5>
+        <p>Three of screen 04's four toggles carry more than mentions. The community relay will not
+          serve an external key, so that is a change to the <em>mentions only</em> claim, not a
+          setting. Should this design propose it at all, or should screen 04 ship mentions-only and
+          the widening go to its own issue with its own consent surface?</p>
       </div>
       <div class="q">
         <h5>either · the fourth door</h5>

--- a/docs/wireframes/console-agent-lifecycle.html
+++ b/docs/wireframes/console-agent-lifecycle.html
@@ -1,3 +1,4 @@
+<meta charset="utf-8">
 <title>waggle console — remote-agent lifecycle wireframes</title>
 <style>
   /* Tokens lifted verbatim from console/index.html. These wireframes are meant to be argued with


### PR DESCRIPTION
## Outcome

Design only — no code. Establishes waggle/console as the surface that owns a remote agent's whole life: create, grant, bind, tune, audit, pause, revoke, destroy.

## The load-bearing claim

**No new plane is needed.** Both halves are already built and already carry the properties lifecycle requires:

- **Projection (read)** — #307: private mode-0600 state with no credentials → validated secret-free public receipt → the browser renders that and nothing else.
- **Actuator (write)** — `src/buzz_policy_*`: frozen closed catalogue, evidence-not-prose, credential-free decision core, forced-command runner, `O_EXCL` journal idempotency, and hold-never-fall-back on an unavailable service.

Lifecycle becomes **one more closed catalogue on the actuator, plus per-agent rows in the projection**. #307's *"no second setup vocabulary is introduced"* is treated as binding.

Consequence: for the lifecycle **operations** there is no CLI role. The CLI is retained at exactly two forced boundaries — a locally generated secret (a key minted in a browser tab sits in a JS heap the console cannot prove it discarded, in an origin that already needed a `Host` defence against DNS rebinding, #145), and host filesystem/systemd work.

## Three doors, one gate

Mint / BYOK / make-your-own differ only in where the nsec is born, and converge on one acceptance test: **challenge-sign a fresh nonce**. Mint goes **into `bunker.nave.pub`, never onto the box** — waggle holds exactly one private key, its own, and minting onto the host would give it a second. Keeping mint in custody is what lets "mint for simplicity" stay on the menu instead of being traded away.

## Worth a reviewer's attention

- **Revoke and destroy are split** because their reversibility is opposite. Revoke is instant and safe; destroy forces a Bunker re-pair (`broker_credentials` is `reRenderable: false`) and carries a confirmation token. They must not be adjacent buttons.
- **Resumable state vs re-derived truth** is stated as an explicit boundary rather than left implicit: saved state may record *that* a proof passed and *what evidence* proved it, never that a live property *is currently true*. #308 was that failure.
- **Traps as first-class**, each of which has produced a wrong green here: possessing a Bunker URI ≠ control; a spent NIP-46 pairing secret presents as `Unknown client`; empty ≠ absent (negative control runs *inside* the wizard); reachable ≠ attached; admitted ≠ wakeable (`admit`/`task`/`task-relay` are separate on purpose); write ≠ read (the return lane carries **mentions only**).
- **Build order stacks on #307 and must not start before it lands** — a stacked branch whose base is squash-merged gets orphaned, and one was auto-closed that way today.

## Verification

Docs-only; no source or test change. Note #162: even a docs-only merge triggers a deploy tick.

## Review

Worth a read from **kerouac** (spec/prose precision, and whether the claim vocabulary drifts anywhere) and **mydude** (whether the actuator really can carry this catalogue without widening what the console is trusted with). I wrote it, so I should not be the one certifying it.

Refs #309, #305, #307.

Drafted with assistance from [Claude Code](https://claude.com/claude-code)