### PR TITLE
fix(console): two Connect choices demanded a party the page never asked for

### DIFF
--- a/console/connect-plan.mjs
+++ b/console/connect-plan.mjs
@@ -79,6 +79,36 @@ export const INTENTS = {
 
 export const INTENT_KEYS = Object.keys(INTENTS)
 
+// ── The party slots, in the operator's words ─────────────────────────────────────────────────
+//
+// `owner`, `agent`, `other` and `carrier` are variable names. They are meaningful to the code and
+// meaningless to the person signing, and for a while this module leaked them straight onto the
+// screen — "Missing other — this is required by one of the things you chose." That sentence names
+// no field the operator can see, no choice that caused it, and nothing they can do about it.
+//
+// So the vocabulary lives HERE, next to the slots it names, rather than in the page. A surface
+// that renders a slot renders its `prompt`; a message that mentions a slot uses its `label`. The
+// suite asserts that every slot an intent can require has an entry, which is what stops a new
+// intent from introducing a party no screen can ask for and no message can name.
+export const PARTY = {
+  owner: { label: 'your public key', prompt: 'Your public key', kind: 'key',
+    note: 'The key that signs these approvals.' },
+  agent: { label: "the agent's public key", prompt: 'Its public key', kind: 'key',
+    note: 'The identity being connected.' },
+  channel: { label: 'the channel', prompt: 'Channel', kind: 'channel',
+    note: 'Stored as a salted hash — the id itself never rides publicly.' },
+  other: { label: 'the agent it may instruct', prompt: 'The agent it may instruct', kind: 'key',
+    note: 'A second agent, the one receiving instructions. Not you, and not the agent above.' },
+  carrier: { label: 'the carrier', prompt: 'The carrier', kind: 'key',
+    note: 'Whoever transports the message. Carrying is not authoring — a carried instruction is actionable only if its original signer separately holds a grant.' },
+}
+
+// Slots that no fixed field covers, derived from the intent table rather than hand-listed — the
+// same rule the plane rendering follows. Hand-listing is exactly how `other` and `carrier` came to
+// be required by two intents while no input for either existed anywhere on the page: the planner
+// asked for them, the surface never offered them, and the flow dead-ended with the choice ticked.
+export const EXTRA_PARTIES = [...new Set(Object.values(INTENTS).flatMap(i => i.needs || []))]
+
 // A party is either a 64-hex pubkey or a channel uuid. Names are display only and never reach a
 // grant, because a grant binds to a key — a surface that let a typo'd name through would produce
 // a grant that verifies and admits nobody.
@@ -123,22 +153,31 @@ export function planConnection({ intents: rawIntents = [], parties: rawParties =
   if (!chosen.length) problems.push('Choose at least one thing this agent may do — an agent with no grants is admitted to nothing.')
   for (const key of chosen) if (!INTENTS[key]) problems.push(`"${key}" is not something this surface knows how to grant.`)
 
-  const need = new Set(['owner', 'agent'])
+  // party -> the choice that made it necessary, or null when every approval needs it. Carrying the
+  // reason is what turns "something is missing" into a sentence the operator can act on, because
+  // the fix is always either "fill this in" or "untick that".
+  const need = new Map([['owner', null], ['agent', null]])
   for (const key of chosen) {
     const intent = INTENTS[key]
     if (!intent) continue
-    if (capSubject(intent.cap) === 'channel') need.add('channel')
-    for (const extra of intent.needs || []) need.add(extra)
+    if (capSubject(intent.cap) === 'channel' && !need.has('channel')) need.set('channel', intent.question)
+    for (const extra of intent.needs || []) if (!need.has(extra)) need.set(extra, intent.question)
   }
-  for (const party of need) {
+  for (const [party, because] of need) {
+    const what = PARTY[party]?.label || party
     const value = parties[party]
-    if (!value) { problems.push(`Missing ${party} — this is required by one of the things you chose.`); continue }
+    if (!value) {
+      problems.push(because
+        ? `Missing ${what} — “${because}” needs it. Fill it in, or untick that choice.`
+        : `Missing ${what} — every approval needs it.`)
+      continue
+    }
     const kind = partyKind(value)
-    const wanted = party === 'channel' ? 'channel' : 'key'
+    const wanted = PARTY[party]?.kind || 'key'
     if (kind !== wanted) {
-      problems.push(party === 'channel'
+      problems.push(wanted === 'channel'
         ? 'The channel must be a uuid.'
-        : `The ${party} must be a 64-character public key — paste the hex, or let the page convert an npub1… first. A name is not enough: a grant binds to a key.`)
+        : `${what[0].toUpperCase()}${what.slice(1)} must be a 64-character public key — paste the hex, or let the page convert an npub1… first. A name is not enough: a grant binds to a key.`)
     }
   }
 

--- a/console/connect.html
+++ b/console/connect.html
@@ -84,6 +84,12 @@
   .enforcer.elsewhere{color:var(--warn);border-color:color-mix(in srgb,var(--warn) 45%,transparent)}
   .plane-caution{font-size:12.5px;color:var(--faint);margin:10px 0 0;padding-top:10px;border-top:1px solid var(--line)}
 
+  /* Appears only when a ticked choice needs it. Marked with the accent rail so it reads as a
+     consequence of the choice above rather than as another field you forgot to fill in. */
+  .extra{border:1px solid var(--line);border-left:2px solid var(--accent);border-radius:var(--r-md);
+    background:var(--panel);padding:16px 18px;margin-bottom:16px}
+  .extra[hidden]{display:none}
+
   .choice{display:flex;gap:12px;align-items:flex-start;padding:13px 0;border-top:1px solid var(--line)}
   .plane-head + .choice{border-top:1px solid var(--line);margin-top:14px}
   .choice input{margin:3px 0 0;accent-color:var(--accent);width:16px;height:16px;flex:none}
@@ -183,6 +189,7 @@
     <p class="step-note">Two different things, checked by two different pieces of software. Keep
       them apart in your head; the page keeps them apart on screen.</p>
     <div id="planes"></div>
+    <div id="extras"></div>
   </section>
 
   <section class="step">
@@ -209,7 +216,7 @@
 
 <script type="module">
 import { nip19, verifyEvent } from 'nostr-tools'
-import { planConnection, planSummary, INTENTS, INTENT_KEYS } from './connect-plan.mjs'
+import { planConnection, planSummary, INTENTS, INTENT_KEYS, PARTY, EXTRA_PARTIES } from './connect-plan.mjs'
 import { PLANE_COPY } from './capability-vocabulary.mjs'
 import { scopeHash } from './scope-hash.mjs'
 import { consoleSigner } from './signer-session.mjs'
@@ -271,34 +278,96 @@ function renderPlanes() {
   for (const box of document.querySelectorAll('[data-intent]')) box.addEventListener('change', refresh)
 }
 
+// ── Step 3½: the parties only some choices need ──────────────────────────────────────────────
+// Two intents require a party — `other` and `carrier` — that no fixed field above collects. When
+// this section did not exist, ticking either produced "Missing other", a demand naming a field
+// that was nowhere on the page: a dead end you could not clear except by unticking the choice.
+//
+// The inputs are built once from EXTRA_PARTIES (derived from the intent table, not hand-listed)
+// and then only SHOWN when a ticked choice needs them. Building them lazily would throw away
+// whatever had been typed each time a checkbox moved.
+function renderExtras() {
+  $('extras').innerHTML = EXTRA_PARTIES.map(p => {
+    const meta = PARTY[p]
+    return `<div class="extra" id="extra-${esc(p)}" hidden>
+      <div class="two">
+        <div>
+          <label for="x-name-${esc(p)}">What you call it</label>
+          <input type="text" id="x-name-${esc(p)}" placeholder="a name for the review below" autocomplete="off" data-extra-name="${esc(p)}">
+        </div>
+        <div>
+          <label for="x-key-${esc(p)}">${esc(meta.prompt)}</label>
+          <input type="text" id="x-key-${esc(p)}" placeholder="npub1… or 64-hex" autocomplete="off" spellcheck="false" data-extra-key="${esc(p)}">
+        </div>
+      </div>
+      <div class="field-note">${esc(meta.note)}</div>
+    </div>`
+  }).join('')
+  for (const el of document.querySelectorAll('[data-extra-key],[data-extra-name]')) {
+    el.addEventListener('input', refresh)
+  }
+}
+
+// Which extra slots the current ticks actually require. Read from `needs` so this can never drift
+// from what the planner will ask for.
+function neededExtras() {
+  const checked = [...document.querySelectorAll('[data-intent]:checked')].map(b => b.value)
+  return new Set(checked.flatMap(k => INTENTS[k]?.needs || []))
+}
+
+function syncExtras() {
+  const needed = neededExtras()
+  for (const p of EXTRA_PARTIES) $(`extra-${p}`).hidden = !needed.has(p)
+}
+
 // ── Step 4: direction, drawn ─────────────────────────────────────────────────────────────────
 const ARROW = `<svg width="34" height="10" viewBox="0 0 34 10" aria-hidden="true">
   <path d="M0 5h27" stroke="currentColor" stroke-width="1.5" fill="none"/>
   <path d="M26 1l6 4-6 4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linejoin="round"/>
 </svg>`
 
+// Name a party the way the operator named it. Built by walking every slot rather than the two
+// fixed ones, so `other` and `carrier` read as words in the review instead of as key fragments —
+// the review is the one place where knowing exactly who is the entire point.
 function partyLabel(step, which) {
   const value = step[which]
   const isChannel = UUID.test(String(value))
-  const named = { [readParties().agent]: readNames().agent, [readParties().owner]: readNames().owner }
-  const name = isChannel ? (readNames().channel || String(value)) : (named[value] || `${String(value).slice(0, 8)}…`)
+  const parties = readParties(), names = readNames()
+  const slot = Object.keys(parties).find(k => parties[k] && parties[k] === value)
+  const name = isChannel
+    ? (names.channel || String(value))
+    : ((slot && names[slot]) || `${String(value).slice(0, 8)}…`)
   return `<span class="party${isChannel ? ' chan' : ''}">${esc(name)}</span>`
 }
 
-const readParties = () => ({
-  owner: toHex($('owner-key').value),
-  agent: toHex($('agent-key').value),
-  channel: $('channel-id').value.trim().toLowerCase(),
-})
-const readNames = () => ({
-  owner: 'you',
-  agent: $('agent-name').value.trim() || 'this agent',
-  channel: $('channel-id').value.trim() ? 'the channel' : '',
-})
+// Only slots a ticked choice actually needs are read. A stale value left in a hidden extra field
+// must not reach the planner — it would sit in `parties` unreferenced by any step, which is
+// harmless today and exactly the kind of thing that stops being harmless later.
+const readParties = () => {
+  const needed = neededExtras()
+  const parties = {
+    owner: toHex($('owner-key').value),
+    agent: toHex($('agent-key').value),
+    channel: $('channel-id').value.trim().toLowerCase(),
+  }
+  for (const p of EXTRA_PARTIES) if (needed.has(p)) parties[p] = toHex($(`x-key-${p}`).value)
+  return parties
+}
+const readNames = () => {
+  const needed = neededExtras()
+  const names = {
+    owner: 'you',
+    agent: $('agent-name').value.trim() || 'this agent',
+    channel: $('channel-id').value.trim() ? 'the channel' : '',
+  }
+  for (const p of EXTRA_PARTIES) if (needed.has(p)) names[p] = $(`x-name-${p}`).value.trim()
+  return names
+}
 
 let currentPlan = null
 
 function refresh() {
+  syncExtras()
   validateFields()
   const intents = [...document.querySelectorAll('[data-intent]:checked')].map(b => b.value)
   const plan = planConnection({ intents, parties: readParties(), names: readNames() })
@@ -453,6 +522,7 @@ function renderHandoff() {
 }
 
 renderPlanes()
+renderExtras()
 refresh()
 </script>
 </body>

--- a/tests/connect_plan.mjs
+++ b/tests/connect_plan.mjs
@@ -21,7 +21,8 @@
 //
 //   node tests/connect_plan.mjs
 
-import { planConnection, planSummary, INTENTS, INTENT_KEYS } from '../console/connect-plan.mjs'
+import { readFileSync } from 'node:fs'
+import { planConnection, planSummary, INTENTS, INTENT_KEYS, PARTY, EXTRA_PARTIES } from '../console/connect-plan.mjs'
 
 let pass = true
 const check = (cond, label) => { console.log(`${cond ? 'ok  ' : 'FAIL'} — ${label}`); if (!cond) pass = false }
@@ -261,6 +262,75 @@ for (const key of INTENT_KEYS) {
   const p = planConnection({ intents: ['owner-directs-agent'], parties: { owner: OWNER, agent: AGENT }, names })
   check(p.ok && p.steps.length === 1,
     'NEGATIVE CONTROL — two DIFFERENT keys in the orders plane are still accepted')
+}
+
+// ── EVERY REQUIRED PARTY CAN BE ASKED FOR, AND NAMED ────────────────────────────────────────
+// Shipped defect, found by using the page: `agent-directs-other` and `carrier-relays-to-agent`
+// each require a party — `other`, `carrier` — that no input on connect.html collected. Ticking
+// either produced "Missing other — this is required by one of the things you chose": a demand
+// naming a field that did not exist, a choice it did not identify, and no way forward except
+// untick. The planner was right and the surface could not satisfy it.
+//
+// Both halves are asserted here, because either alone lets it back in: a slot needs a WORD for
+// the message and a FIELD for the operator, and the field is checked against the actual page.
+{
+  const html = readFileSync(new URL('../console/connect.html', import.meta.url), 'utf8')
+  const required = [...new Set(Object.values(INTENTS).flatMap(i => i.needs || []))]
+
+  check(required.length > 0, `some intents require an extra party (${required.join(', ')}) — otherwise this whole section is vacuous`)
+  check(EXTRA_PARTIES.length === required.length && required.every(p => EXTRA_PARTIES.includes(p)),
+    'EXTRA_PARTIES is derived from the intent table, so it cannot drift from what the planner asks for')
+
+  for (const p of ['owner', 'agent', 'channel', ...required]) {
+    const meta = PARTY[p]
+    check(!!meta?.label && !!meta?.prompt && !!meta?.kind,
+      `party "${p}" has a label, a prompt and a kind — a slot with no words gets its variable name printed at the operator`)
+    check(meta?.label !== p, `party "${p}" is named in words, not as the identifier "${p}"`)
+  }
+
+  // The page must actually build an input for each one. Asserting against the real file is the
+  // only version of this check that could have caught the defect — a fixture would have passed.
+  for (const p of required) {
+    check(html.includes(`data-extra-key="${p}"`) || html.includes('data-extra-key="${esc(p)}"'),
+      `connect.html renders a key input for "${p}"`)
+  }
+  check(html.includes('EXTRA_PARTIES'), 'connect.html builds those inputs from EXTRA_PARTIES rather than hand-listing them')
+}
+
+// ── THE MESSAGE NAMES THE FIELD AND THE CHOICE ──────────────────────────────────────────────
+// Asserting the REASON, not only the refusal. `!ok` cannot tell a correct refusal from a correct
+// refusal that sends the operator looking for something that is not there — which is exactly what
+// happened. So: the sentence must contain the human label, must NOT contain the raw slot name,
+// and must say which ticked choice caused it.
+{
+  const partial = planConnection({
+    intents: ['agent-directs-other'],
+    parties: { owner: OWNER, agent: AGENT },  // `other` deliberately absent
+  })
+  check(!partial.ok, 'a plan missing a required extra party is refused')
+  const msg = partial.problems.join(' | ')
+  check(msg.includes(PARTY.other.label), `the message names the field in words: "${PARTY.other.label}"`)
+  check(!/Missing other\b/.test(msg), 'the message does NOT print the raw slot name "other"')
+  check(msg.includes(INTENTS['agent-directs-other'].question),
+    'the message names the CHOICE that requires it, so the fix is visible without guessing')
+  check(/untick/i.test(msg), 'and offers the other way out — untick the choice')
+
+  // Same slot, when nothing requires it, must not be demanded at all.
+  const unrelated = planConnection({
+    intents: ['admit-agent-to-channel'],
+    parties: { owner: OWNER, agent: AGENT, channel: CHANNEL },
+  })
+  check(unrelated.ok, 'NEGATIVE CONTROL — a plan that needs no extra party is accepted, so the demand above is conditional and not blanket')
+
+  // And supplying it clears the refusal — pairing the rejection with an acceptance, so this
+  // cannot pass by refusing everything.
+  const complete = planConnection({
+    intents: ['agent-directs-other'],
+    parties: { owner: OWNER, agent: AGENT, other: OTHER },
+  })
+  check(complete.ok, 'NEGATIVE CONTROL — supplying the extra party clears the refusal')
+  check(complete.steps.length === 1 && complete.steps[0].subject === OTHER,
+    'and the resulting grant has the OTHER agent as subject, which is the direction that matters')
 }
 
 console.log(`\n${pass ? 'ALL PASS' : 'FAILURES ABOVE'}`)


### PR DESCRIPTION
Found by using the page, not by a test. Ticking either of two choices produced:

> Missing other — this is required by one of the things you chose.

That sentence names a field **that did not exist anywhere on `connect.html`**, does not say which
choice caused it, and offers nothing to do about it. There was no way forward except to untick —
so **two of the five capabilities the surface offers were unreachable**, while the flow presented
them as available.

The planner was right and the surface could not satisfy it: `agent-directs-other` declares
`needs: ['other']` and `carrier-relays-to-agent` declares `needs: ['carrier']`, while
`readParties()` collected `owner`, `agent` and `channel` only.

## The fix

**The field exists now.** `connect.html` builds an input per extra party from `EXTRA_PARTIES`,
derived from the intent table rather than hand-listed — the same rule the plane rendering already
follows, and the rule whose absence caused this. Built once, shown/hidden as ticks change so
typing is never discarded; only slots a ticked choice needs are read into the plan.

**The message is in words.** `owner`/`agent`/`other`/`carrier` are variable names — meaningful to
the code, meaningless to the person signing. The vocabulary now lives in `PARTY`, next to the
slots it names:

> Missing **the agent it may instruct** — “Let this agent give instructions to another agent”
> needs it. Fill it in, or untick that choice.

Names the field, names the choice, gives both ways out. Review sentences also resolve `other` and
`carrier` to whatever the operator called them rather than printing a key fragment.

## Verification

**Asserting the reason, not only the refusal.** `!ok` cannot distinguish a correct refusal from a
correct refusal that sends someone hunting for a field that is not there — which is exactly what
shipped. The suite asserts the message contains the human label, does **not** contain the raw slot
name, and names the causing choice.

**The input check reads the real `connect.html`.** A fixture would have passed.

**Paired both directions.** Supplying the party clears the refusal and yields a grant whose
subject is the OTHER agent; a plan needing no extra party is accepted. So this cannot pass by
refusing everything.

**NEGATIVE CONTROL against the pre-fix files from git — all four new checks fire:**

```
CAUGHT — old connect.html has no input for "other"
CAUGHT — old connect.html has no input for "carrier"
CAUGHT — old message leaked the slot name: "Missing other — this is required by one of the things you chose."
CAUGHT — old module exported no PARTY vocabulary
```

**Exercised in the rendered page**, not the source: hidden at load → shown on tick → refusal names
field and choice → sign enabled once filled → hidden again on untick.

68 suites green, `eslint` clean.

## For the reviewer

- `console/` is **not** covered by `npm run lint` (eslint runs `src tools tests`), so the
  connect.html module graph has no static check behind it. Worth a separate issue.
- This touches a signing surface, so it wants eyes that are not mine before it merges.

Drafted with assistance from [Claude Code](https://claude.com/claude-code)