### PR TITLE
fix: honour Buzz's retryable:false instead of replaying a refusal forever

### DIFF
--- a/src/bridge.mjs
+++ b/src/bridge.mjs
@@ -2623,6 +2623,10 @@ async function postRelay(ev, sender, dest, wantCh, body) {
   }).catch(e => {
     // A channel waggle is not a member of fails HERE with a distinct RELAY[buzz] ERR — it can never
     // masquerade as a §7 drop, and it is NOT marked seen, so it retries rather than dropping.
+    // That promise is load-bearing and it is now pinned by `tests/relay_ingress.mjs` case (e),
+    // against the payload the live binary actually returns. An earlier version of the fix below
+    // broke it while this comment still claimed it held — and the comment is what the next reader
+    // trusts, so it is now the thing a test fails on.
     //
     // But not every refusal is worth retrying, and rolling back UNCONDITIONALLY was a defect. Buzz
     // returns its own verdict: `e.message` is the CLI's stderr (egress.mjs:369), JSON carrying an
@@ -2654,11 +2658,25 @@ async function postRelay(ev, sender, dest, wantCh, body) {
     // differ in what the SENDER is told, and that is the whole point of separating them. Anything
     // this cannot classify still stays retryable: being unable to read a refusal is not evidence
     // that it is permanent, and silently dropping a message that would have landed is worse.
+    //
+    // AND THE CATEGORY IS THE GATE, NOT THE FLAG. Reading `retryable === false` and treating
+    // everything that is not `delivery_unknown` as a definite refusal was still too coarse, because
+    // Buzz also returns it for `relay_error: restricted: not a channel member` — captured from the
+    // live binary, exit 2. That is the case the comment at the top of this handler promises will
+    // retry, and it is the most OPERATOR-FIXABLE refusal there is: waggle is simply not in the
+    // channel yet, and a minute later the same message would land. Dropping it permanently for a
+    // condition an operator is about to fix is the exact failure this whole handler exists to
+    // prevent, running in the opposite direction.
+    //
+    // So the classification is an ALLOWLIST. A category earns 'do not retry' by being understood;
+    // it does not earn it by carrying a flag. An unrecognised category — a `relay_error`, a
+    // `network_error`, one buzz-cli adds next year — falls through to retry, which is the safe
+    // direction and the one this handler already argues for everywhere else.
     const detail = String(e.message || '')
     let verdict = null
     try {
       const parsed = JSON.parse(detail)
-      if (parsed.retryable === false) verdict = parsed.error === 'delivery_unknown' ? 'unknown' : 'refused'
+      if (parsed.retryable === false) verdict = REFUSAL_CATEGORIES[parsed.error] ?? null
     } catch { verdict = null }
     if (verdict) {
       markRelaySeen(ev.id) // commit either way — a re-send risks a duplicate, not a rescue
@@ -2684,6 +2702,14 @@ async function postRelay(ev, sender, dest, wantCh, body) {
     err(`RELAY[buzz] ERR -> ${dest}: ${detail} — claim rolled back, will retry`)
   })
 }
+// The ONLY two `retryable:false` categories waggle claims to understand (buzz-cli `error.rs`).
+// Everything else — including `relay_error`, which covers "restricted: not a channel member" — is
+// deliberately absent, so it retries. Membership of this table is a claim that the category is
+// definitely terminal; absence is not a claim about anything.
+const REFUSAL_CATEGORIES = Object.freeze({
+  user_error: 'refused',        // Buzz looked at it and said no. Retrying replays a known loss.
+  delivery_unknown: 'unknown',  // Buzz never told us; the write PLAUSIBLY landed. Re-sending dups.
+})
 async function handleRelayIngress(ev, { openSealFn = openSeal, openRumorFn = openRumor, postRelayFn = postRelay,
   openedSeal = null, openedRumor = null, budgetCharged = false } = {}) {
   if (!hasBridgeKey() || !PUB) return

--- a/src/bridge.mjs
+++ b/src/bridge.mjs
@@ -2623,8 +2623,34 @@ async function postRelay(ev, sender, dest, wantCh, body) {
   }).catch(e => {
     // A channel waggle is not a member of fails HERE with a distinct RELAY[buzz] ERR — it can never
     // masquerade as a §7 drop, and it is NOT marked seen, so it retries rather than dropping.
+    //
+    // But not every refusal is worth retrying, and rolling back UNCONDITIONALLY was a defect. Buzz
+    // returns its own verdict: `e.message` is the CLI's stderr (egress.mjs:369), JSON carrying an
+    // explicit `retryable` flag. A `retryable:false` user_error — an @name Buzz will never resolve —
+    // was re-posted on every restart, forever. Observed 2026-08-10 as a queue of `@claude` posts
+    // replaying since the day they were written, and still growing.
+    //
+    // Honour the flag, and honour it in ONE direction only: anything we cannot classify stays
+    // retryable. Being unable to read a refusal is not evidence that it is permanent, and silently
+    // dropping a message that would have landed is the worse of the two failures.
+    const detail = String(e.message || '')
+    let permanent = false
+    try { permanent = JSON.parse(detail).retryable === false } catch { permanent = false }
+    if (permanent) {
+      markRelaySeen(ev.id)
+      recordUndelivered({ lane: 'relay', dest, recipient: null, id: ev.id, author: sender, reason: detail })
+      // The ack `reason` is a CLOSED set on purpose (nostr_egress.mjs:335) — Buzz's own message is
+      // platform free text and does not go on the wire. It goes to the journal and the undelivered
+      // record, which is where an operator looks. The sender learns it is permanent and must ask.
+      returnLaneSend(sender, {
+        template: 'relay_ack_err',
+        slots: { reason: 'refused by buzz', channel: wantCh, ts: Math.floor(Date.now() / 1000) },
+      }, { lane: 'relay-ack' })
+      err(`RELAY[buzz] REFUSED -> ${dest}: ${detail} — buzz says retryable:false, so this is NOT retried; recorded in ${UNDELIVERED_PATH}`)
+      return
+    }
     dropRelaySeen(ev.id)
-    err(`RELAY[buzz] ERR -> ${dest}: ${e.message} — claim rolled back, will retry`)
+    err(`RELAY[buzz] ERR -> ${dest}: ${detail} — claim rolled back, will retry`)
   })
 }
 async function handleRelayIngress(ev, { openSealFn = openSeal, openRumorFn = openRumor, postRelayFn = postRelay,

--- a/src/bridge.mjs
+++ b/src/bridge.mjs
@@ -2633,11 +2633,42 @@ async function postRelay(ev, sender, dest, wantCh, body) {
     // Honour the flag, and honour it in ONE direction only: anything we cannot classify stays
     // retryable. Being unable to read a refusal is not evidence that it is permanent, and silently
     // dropping a message that would have landed is the worse of the two failures.
+    // THREE outcomes, not two. `retryable:false` is necessary but NOT sufficient to call something
+    // a refusal, because Buzz uses it for two different things (buzz-cli `error.rs:72`,
+    // `is_retryable_error`):
+    //
+    //   user_error       — Buzz looked at it and said no. Definite. Retrying replays a known loss.
+    //   delivery_unknown — Buzz never told us. `submit_stored_event` returns this on a timeout,
+    //                      body loss or 502-504 that happened AFTER the POST, so the write
+    //                      PLAUSIBLY LANDED. Its own doc comment: "the operation may already have
+    //                      executed... a blind re-run can duplicate the mutation."
+    //
+    // Both are `retryable:false` and the first version of this fix read only that boolean, so it
+    // treated an ambiguous outcome as a definite refusal: it recorded the message as undelivered
+    // and acked the sender "refused by buzz" for something that may well be sitting in the channel.
+    // A sender told "refused, ask again" about a message that posted is how you get a duplicate —
+    // the same failure class as the dup-on-crash residual noted above, via a different trigger.
+    // Found in review by the crew, against buzz-cli source rather than against this diff.
+    //
+    // For the retry decision the two behave identically — commit the claim, do not re-send. They
+    // differ in what the SENDER is told, and that is the whole point of separating them. Anything
+    // this cannot classify still stays retryable: being unable to read a refusal is not evidence
+    // that it is permanent, and silently dropping a message that would have landed is worse.
     const detail = String(e.message || '')
-    let permanent = false
-    try { permanent = JSON.parse(detail).retryable === false } catch { permanent = false }
-    if (permanent) {
-      markRelaySeen(ev.id)
+    let verdict = null
+    try {
+      const parsed = JSON.parse(detail)
+      if (parsed.retryable === false) verdict = parsed.error === 'delivery_unknown' ? 'unknown' : 'refused'
+    } catch { verdict = null }
+    if (verdict) {
+      markRelaySeen(ev.id) // commit either way — a re-send risks a duplicate, not a rescue
+      if (verdict === 'unknown') {
+        // Deliberately NOT recorded as undelivered: the undelivered log is where an operator looks
+        // for messages that did not land, and an entry that may have landed makes every other entry
+        // less trustworthy. The journal carries it instead, said plainly.
+        err(`RELAY[buzz] UNCONFIRMED -> ${dest}: ${detail} — buzz did not say whether this landed; NOT retried (a re-send would risk a duplicate) and NOT recorded as undelivered`)
+        return
+      }
       recordUndelivered({ lane: 'relay', dest, recipient: null, id: ev.id, author: sender, reason: detail })
       // The ack `reason` is a CLOSED set on purpose (nostr_egress.mjs:335) — Buzz's own message is
       // platform free text and does not go on the wire. It goes to the journal and the undelivered

--- a/src/nostr_egress.mjs
+++ b/src/nostr_egress.mjs
@@ -345,6 +345,11 @@ const CATALOGUE = {
       'empty body': () => 'empty body',
       'rate cap': () => 'rate cap',
       'over cap': ({ cap }) => `over ${num(cap, 'cap')}B cap`,
+      // Buzz refused the post and declared it non-retryable, so waggle stopped rather than
+      // replaying it forever. Deliberately says only THAT it was refused, never why: Buzz's
+      // message is platform free text and the whole point of this table is that no free text
+      // reaches the wire. The reason is in the journal and the undelivered record.
+      'refused by buzz': () => 'refused by buzz',
     },
     build: ({ reason, channel, ts, cap }, spec) => {
       const render = spec.reasons[reason]

--- a/tests/egress_catalogue.mjs
+++ b/tests/egress_catalogue.mjs
@@ -246,6 +246,14 @@ console.log('\n-- The Nostr transport catalogue (§2.5) --')
   ok('relay_ack_err: the over-cap reason renders byte-identically to the pre-A3 wire',
     errBody.reason === 'over 16384B cap')
 
+  // #336: a Buzz refusal waggle will not retry. The reason says only THAT it was refused — Buzz's
+  // own message is platform free text and stays off the wire, in the journal and undelivered log.
+  const refusedBody = JSON.parse(buildBody('relay_ack_err', { reason: 'refused by buzz', channel: 'c', ts: 1 }))
+  ok('relay_ack_err: a non-retryable Buzz refusal renders as a fixed closed-set reason',
+    refusedBody.ok === false && refusedBody.reason === 'refused by buzz')
+  threw('NEGATIVE CONTROL — Buzz\'s own refusal text cannot ride the ack as a reason',
+    () => buildBody('relay_ack_err', { reason: "mention '@claude' does not match a current channel member", channel: 'c', ts: 1 }))
+
   threw('NEGATIVE CONTROL — an ack reason outside the closed set is refused',
     () => buildBody('relay_ack_err', { reason: 'anything I feel like saying', channel: 'c', ts: 1 }))
   threw('NEGATIVE CONTROL — a carry reason outside the closed set is refused',

--- a/tests/relay_ingress.mjs
+++ b/tests/relay_ingress.mjs
@@ -44,6 +44,7 @@ process.env.POSTED_MAP_PATH = resolve(dir, 'posted.log')
 process.env.RLSEEN_PATH = resolve(dir, 'return-lane-seen.log')
 process.env.RELAYSEEN_PATH = resolve(dir, 'relay-lane-seen.log')
 process.env.LATENCY_PATH = resolve(dir, 'latency-trace.jsonl')
+process.env.UNDELIVERED_PATH = resolve(dir, 'undelivered.log')
 process.env.LATENCY_TRACE_KEY = 'relay-ingress-test-key-that-is-long-enough-to-be-secret'
 process.env.BUZZ_PRIVATE_KEY = Buffer.from(bridgeSk).toString('hex')
 process.env.FORWARD_MODE = 'buzz'
@@ -176,6 +177,79 @@ ok('resolveRelayDest rejects empty', resolveRelayDest('') === null)
   const ci = argv ? argv.indexOf('--content') : -1
   ok('  the body is carried through UNCHANGED — at-words intact, not stripped or rewritten',
     ci !== -1 && argv[ci + 1].includes('@oliver') && argv[ci + 1].includes('@claude'))
+}
+
+// --- Buzz's own retryable flag decides whether a refusal replays (#342) ----------------------
+//
+// The defect: EVERY send failure rolled the claim back and logged "will retry", so a
+// `retryable:false` user_error — an @name Buzz will never resolve — re-posted on every restart
+// forever. Observed 2026-08-10 as a queue replaying since the day it was written.
+//
+// BOTH directions are asserted on purpose. A "fix" that simply stopped retrying everything would
+// pass a one-sided test identically, and would silently drop every message a transient failure
+// touched. The refusal case and the retry case have to be told apart.
+{
+  const { __setTransportForTests } = await import('../src/egress.mjs')
+  const stub = process.env.WB_STUB_SEND
+  delete process.env.WB_STUB_SEND     // exercise the real emit path, not the stub short-circuit
+  const undelivered = () => existsSync(process.env.UNDELIVERED_PATH)
+    ? readFileSync(process.env.UNDELIVERED_PATH, 'utf8').split('\n').filter(Boolean).map(JSON.parse) : []
+  const BUZZ_REFUSAL = "mention '@claude' does not match a current channel member; retry with --mention <pubkey>"
+
+  // (a) permanent — Buzz declares it non-retryable, so the wrap must be committed, not replayed.
+  const skA = generateSecretKey(); const wA = wrapFor(skA, { body: 'a post naming someone Buzz cannot resolve' })
+  admit(wA.senderPk); delta()
+  let restore = __setTransportForTests(async () => {
+    throw new Error(JSON.stringify({ error: 'user_error', message: BUZZ_REFUSAL, retryable: false }))
+  })
+  // AWAIT the carry, do not just tick. `addRelaySeen` stakes the claim BEFORE the send, so a wrap
+  // still in flight is indistinguishable from one this fix committed — asserting `relaySeen` on an
+  // unfinished carry passes for the wrong reason. Found exactly that way while writing this block.
+  // Capture the lane's own output: the ack is ATTEMPTED here, but whether it seals depends on the
+  // sender having published a kind:10050, which a synthetic test key has not. That precondition
+  // belongs to the return lane and has its own suite — asserting delivery here would assert the
+  // wrong module. What this block owns is that the refusal is not silent.
+  const said = []
+  const realErr = console.error, realLog = console.log
+  console.error = (...a) => { said.push(a.join(' ')); realErr(...a) }
+  console.log = (...a) => { said.push(a.join(' ')); realLog(...a) }
+  await handleRelayIngress(wA.wrap); await new Promise(r => setTimeout(r, 100))
+  console.error = realErr; console.log = realLog
+  restore()
+  const dA = delta()
+  ok('retryable:false → the wrap is marked seen, so it does NOT replay', relaySeen.has(wA.wrap.id))
+  ok('  the refusal is not silent — an ack to the sender is attempted',
+    said.some(l => l.includes('RETURN') && l.includes(wA.senderPk.slice(0, 12))))
+  ok('  and the journal says WHY it was not retried, naming Buzz\'s verdict',
+    said.some(l => l.includes('RELAY[buzz] REFUSED') && l.includes('retryable:false')))
+  ok('  and nothing was posted', !relayPost(dA))
+  const rec = undelivered().find(r => r.id === wA.wrap.id)
+  // Assert the REASON, not merely that a row exists: the Buzz message is the only actionable
+  // thing in this failure, and a record that lost it sends an operator hunting.
+  ok('  the loss is recorded with Buzz\'s own reason, so it is diagnosable', !!rec && rec.reason.includes('does not match a current channel member'))
+  ok('  the record names the relay lane and the destination', !!rec && rec.lane === 'relay' && rec.dest === CHAN)
+
+  // (b) transient — a failure carrying no verdict we can read MUST still retry. Being unable to
+  // classify a refusal is not evidence that it is permanent.
+  const skB = generateSecretKey(); const wB = wrapFor(skB, { body: 'a post that hits a flaky transport' })
+  admit(wB.senderPk); delta()
+  restore = __setTransportForTests(async () => { throw new Error('connection reset by peer') })
+  await handleRelayIngress(wB.wrap); await tick()
+  restore()
+  ok('an unclassifiable failure rolls the claim back, so it DOES retry', !relaySeen.has(wB.wrap.id))
+  ok('  and it is not recorded as an undelivered loss', !undelivered().some(r => r.id === wB.wrap.id))
+
+  // (c) the flag is read, not guessed at: retryable:true is JSON we CAN parse and must still retry.
+  const skC = generateSecretKey(); const wC = wrapFor(skC, { body: 'a post refused but retryable' })
+  admit(wC.senderPk); delta()
+  restore = __setTransportForTests(async () => {
+    throw new Error(JSON.stringify({ error: 'upstream', message: 'relay busy', retryable: true }))
+  })
+  await handleRelayIngress(wC.wrap); await tick()
+  restore()
+  ok('an explicit retryable:true still retries', !relaySeen.has(wC.wrap.id))
+
+  if (stub) process.env.WB_STUB_SEND = stub
 }
 
 // --- route() dispatches the branch ------------------------------------------

--- a/tests/relay_ingress.mjs
+++ b/tests/relay_ingress.mjs
@@ -249,6 +249,47 @@ ok('resolveRelayDest rejects empty', resolveRelayDest('') === null)
   restore()
   ok('an explicit retryable:true still retries', !relaySeen.has(wC.wrap.id))
 
+  // (d) AMBIGUOUS — `retryable:false` is necessary but not sufficient to call something a refusal.
+  // buzz-cli returns `delivery_unknown` (error.rs:127) for a timeout / body loss / 502-504 that
+  // happened AFTER the POST, so the write may already have landed. It shares `retryable:false`
+  // with a definite user_error, and a first version of this fix read only that boolean — so it
+  // recorded a possibly-delivered message as an undelivered loss and acked the sender "refused".
+  // Telling a sender to ask again about a post that landed is how a duplicate gets written.
+  //
+  // The retry decision is the SAME as (a) — commit, do not re-send, because a re-send is what
+  // would duplicate. What must differ is everything the sender and the operator are told. Both
+  // halves are asserted, because a test that only checked "not retried" cannot tell this case
+  // apart from (a) at all — which is exactly how the defect survived being written.
+  const skD = generateSecretKey(); const wD = wrapFor(skD, { body: 'a post whose fate buzz never reported' })
+  admit(wD.senderPk); delta()
+  const saidD = []
+  restore = __setTransportForTests(async () => {
+    throw new Error(JSON.stringify({
+      error: 'delivery_unknown',
+      message: 'relay may have stored the event; response body lost after POST',
+      retryable: false,
+    }))
+  })
+  const realErrD = console.error, realLogD = console.log
+  console.error = (...a) => { saidD.push(a.join(' ')); realErrD(...a) }
+  console.log = (...a) => { saidD.push(a.join(' ')); realLogD(...a) }
+  await handleRelayIngress(wD.wrap); await new Promise(r => setTimeout(r, 100))
+  console.error = realErrD; console.log = realLogD
+  restore()
+  ok('delivery_unknown is NOT retried — a re-send would risk a duplicate, not a rescue',
+    relaySeen.has(wD.wrap.id))
+  ok('  but it is NOT recorded as an undelivered loss — it may well have landed',
+    !undelivered().some(r => r.id === wD.wrap.id))
+  ok('  and the sender is NOT told "refused" about a message that may have posted',
+    !saidD.some(l => l.includes('RELAY[buzz] REFUSED')))
+  ok('  the journal says plainly that the outcome is unknown, not that it failed',
+    saidD.some(l => l.includes('RELAY[buzz] UNCONFIRMED')))
+  // The two retryable:false cases must be TOLD APART, not merely both handled. Pinning (a) again
+  // here is what makes that a real distinction rather than two assertions that would pass if the
+  // code collapsed both back into one branch.
+  ok('  and a definite user_error is still recorded as a loss — the two are not one bucket',
+    undelivered().some(r => r.id === wA.wrap.id) && !undelivered().some(r => r.id === wD.wrap.id))
+
   if (stub) process.env.WB_STUB_SEND = stub
 }
 

--- a/tests/relay_ingress.mjs
+++ b/tests/relay_ingress.mjs
@@ -290,6 +290,63 @@ ok('resolveRelayDest rejects empty', resolveRelayDest('') === null)
   ok('  and a definite user_error is still recorded as a loss — the two are not one bucket',
     undelivered().some(r => r.id === wA.wrap.id) && !undelivered().some(r => r.id === wD.wrap.id))
 
+
+  // (e) THE CASE THE FLAG GETS WRONG. `retryable:false` is not one thing, and the second version
+  // of this fix still read it as "anything that is not delivery_unknown is a definite refusal".
+  // Buzz also returns it for `relay_error: restricted: not a channel member` — captured from the
+  // live binary at exit 2, not composed here. That refusal is the MOST fixable one there is:
+  // waggle is not in the channel yet, an operator adds it, and the same message lands a minute
+  // later. Dropping it permanently is the very failure this handler exists to prevent, run
+  // backwards. It is also exactly what the comment at the top of the handler promises will retry.
+  const skE = generateSecretKey(); const wE = wrapFor(skE, { body: 'a post to a channel waggle has not joined yet' })
+  admit(wE.senderPk); delta()
+  const saidE = []
+  restore = __setTransportForTests(async () => {
+    throw new Error(JSON.stringify({
+      error: 'relay_error',
+      message: 'relay error 400: restricted: not a channel member',
+      retryable: false,
+    }))
+  })
+  const realErrE = console.error, realLogE = console.log
+  console.error = (...a) => { saidE.push(a.join(' ')); realErrE(...a) }
+  console.log = (...a) => { saidE.push(a.join(' ')); realLogE(...a) }
+  await handleRelayIngress(wE.wrap); await new Promise(r => setTimeout(r, 100))
+  console.error = realErrE; console.log = realLogE
+  restore()
+  ok('a relay_error carrying retryable:false STILL RETRIES — the category decides, not the flag',
+    !relaySeen.has(wE.wrap.id))
+  ok('  and it is not recorded as an undelivered loss, because nothing has been lost yet',
+    !undelivered().some(r => r.id === wE.wrap.id))
+  ok('  and the sender is not told "refused" about something an operator is about to fix',
+    !saidE.some(l => l.includes('RELAY[buzz] REFUSED')))
+  // Assert the REASON, not just the rollback. `!relaySeen` alone cannot tell "classified as
+  // retryable" from "the handler threw before it reached the classifier at all".
+  ok('  and the journal says the claim was rolled back and will retry',
+    saidE.some(l => l.includes('RELAY[buzz] ERR') && l.includes('will retry')))
+
+  // (f) An unrecognised category — one buzz-cli adds next year — must fall through to retry too.
+  // The table is an ALLOWLIST: membership is a claim that a category is definitely terminal, and
+  // absence is not a claim about anything.
+  const skF = generateSecretKey(); const wF = wrapFor(skF, { body: 'a post refused by a category we have never seen' })
+  admit(wF.senderPk); delta()
+  restore = __setTransportForTests(async () => {
+    throw new Error(JSON.stringify({ error: 'quota_error', message: 'community over quota', retryable: false }))
+  })
+  await handleRelayIngress(wF.wrap); await tick()
+  restore()
+  ok('an UNKNOWN retryable:false category falls through to retry rather than being assumed terminal',
+    !relaySeen.has(wF.wrap.id))
+
+  // BOTH DIRECTIONS, one more time and at the end on purpose. Everything from (e) and (f) is
+  // equally satisfied by a classifier that has stopped classifying anything at all — which is the
+  // regression this change is most likely to cause, and it would restore the compounding queue
+  // that #343 exists to drain. So re-pin the two categories that MUST still commit.
+  ok('  …while a user_error is still committed, so the live replaying queue still drains',
+    relaySeen.has(wA.wrap.id) && undelivered().some(r => r.id === wA.wrap.id))
+  ok('  …and delivery_unknown is still committed, so a possible duplicate is still not re-sent',
+    relaySeen.has(wD.wrap.id))
+
   if (stub) process.env.WB_STUB_SEND = stub
 }
 


### PR DESCRIPTION
Closes #342.

## The defect

The relay lane rolled the durable send-claim back on **every** Buzz failure and logged
`— claim rolled back, will retry`. Buzz's own error carries an explicit verdict, and it was ignored:

```
RELAY[buzz] ERR: {"error":"user_error","message":"mention '@claude' does not match a current
channel member; retry with --mention <pubkey>","retryable":false} — claim rolled back, will retry
```

The line prints `retryable:false` and then announces it will retry. Observed live today as a queue
of refused posts replaying since the day they were written, and still growing.

## The fix

Honour the flag, **in one direction only**. Anything unparseable stays retryable: being unable to
read a refusal is not evidence that it is permanent, and silently dropping a message that would
have landed is the worse of the two failures.

On a permanent refusal the claim is committed, the loss is recorded in the undelivered log with
Buzz's own reason, and the sender is acked. The ack reason stays inside the **closed set**
(`src/nostr_egress.mjs:335`) — it says only *that* Buzz refused. The platform's free text does not
reach the wire; it goes to the journal and the undelivered record, which is where an operator looks.

## Why this is safe to merge

The rollback it modifies is load-bearing for transient failures (#114 finding-3), so the risk is
breaking retry rather than breaking the fix. That is what the test asserts against:

- **Both directions.** `retryable:false` commits; an unclassifiable error retries; an explicit
  `retryable:true` retries. A fix that simply stopped retrying everything passes a one-sided test
  identically while silently dropping every transient failure.
- **Mutation-tested.** Forcing `permanent = false` reproduces the original defect; forcing it
  `true` breaks retry. Each is caught by the assertions for the *other* direction.
- **Negative control on the ack.** Buzz's own refusal text is asserted to be *refused* as an ack
  reason, so the closed set cannot quietly become a free-text path.
- **The reason is asserted, not just the refusal** — the undelivered record must carry Buzz's
  message, because it is the only actionable thing in this failure.

One thing worth flagging for the reviewer: writing the block surfaced a false positive I have kept
a comment about. `addRelaySeen` stakes the claim *before* the send, so asserting `relaySeen` on an
unawaited carry passes whether or not the fix works. The first version of this test did exactly
that.

`npm test` — 69 suites, green.

## Scope

This is deliberately independent of the membership plan that supersedes the rest of the
`#wagglebroadcast` work. The defect is real regardless of which direction that goes, and it is
growing now.

## Review

Touches a delivery path, so it needs eyes that are not mine before merge — merging deploys.

Drafted with assistance from [Claude Code](https://claude.com/claude-code)