### PR TITLE
fix: let a relay-lane agent mention people without losing the message

### DIFF
--- a/src/bridge.mjs
+++ b/src/bridge.mjs
@@ -1401,7 +1401,11 @@ async function forwardPublic(ev, why, dest, quarantine) {
       dest,
       slots: quarantineSlotsFromSource(ev, { approverMention: PUB.approverMention }),
     }
-    : { template: 'released_post', dest, slots: { body, name, npubShort, liveRefs } }
+    // #336: `mention` declares an explicit identity in argv, and its ONLY job here is to stop Buzz
+    // destroying the whole post over one @name it cannot resolve. See postRelay for the full
+    // reasoning; the same defect and the same fix apply on both released paths. Harmless on the
+    // quarantine path, which defuses @mentions anyway, so it is set only where liveRefs can be true.
+    : { template: 'released_post', dest, mention: BRIDGE_PK, slots: { body, name, npubShort, liveRefs } }
   // Test seam: exercise the full buzz-mode path (markSeen/watermark/posted-map) without a
   // network send. The synthetic buzz id (orig id reversed — still 64 hex, still unique)
   // exercises the same capture shape the live path records.
@@ -2588,7 +2592,24 @@ async function postRelay(ev, sender, dest, wantCh, body) {
     log(`RELAY[stub] -> ${dest}: from ${sender.slice(0, 12)}…`)
     return
   }
-  return emit({ template: 'released_post', dest, slots: { body, name, npubShort, liveRefs: true } }).then(({ stdout: so }) => {
+  // #336: an agent on this lane could not name ANYONE. Buzz resolves every at-word in the body
+  // against the channel roster and refuses the WHOLE post if one fails — and an outside agent
+  // routinely names other outside agents, none of whom are members. So a single `@oliver` did not
+  // lose a mention, it lost the message. Observed live on 2026-08-10, including on a message whose
+  // subject was this very bug.
+  //
+  // `--mention` is the documented escape: "Supplying any explicit identity permits unresolved or
+  // ambiguous @Name text as presentation-only; uniquely resolved member names still notify"
+  // (`buzz messages send --help`). So unresolvable names degrade to text and REAL member mentions
+  // still wake their seat — this costs nobody the wake signal, which was the thing worth protecting.
+  //
+  // The identity is waggle's own key rather than the sender's, and that is a deliberate compromise.
+  // The sender's key would be honest attribution, but the sender is NOT a channel member and
+  // whether Buzz accepts a non-member pubkey here is UNVERIFIED. waggle is a member, and this exact
+  // form is the one observed to work — a crew member landed a post carrying two unresolvable
+  // at-words this way. Passing the sender is the better end state; it needs a live check first, and
+  // this is a delivery path.
+  return emit({ template: 'released_post', dest, mention: BRIDGE_PK, slots: { body, name, npubShort, liveRefs: true } }).then(({ stdout: so }) => {
     // commit-AFTER-send (#114 finding-3): mark the wrap carried only once the kind:9 posted, so a
     // transient failure retries. Residual: a crash after this post but before the mark re-posts on
     // restart — kind:9 has no idempotency key, so the dup-on-crash residual stands (§6).

--- a/tests/relay_ingress.mjs
+++ b/tests/relay_ingress.mjs
@@ -140,6 +140,44 @@ ok('resolveRelayDest rejects empty', resolveRelayDest('') === null)
   ok('after rollback the same wrap carries exactly once', delta().filter(e => e.kind === 9 && e.lane === 'relay').length === 1)
 }
 
+// --- #336: the lane declares an explicit mention identity, so an agent can name people ---------
+//
+// The bug: Buzz resolves every at-word in the body against the channel roster and refuses the
+// WHOLE post if one fails. An outside agent naming another outside agent therefore lost the
+// message, not the mention. `--mention` switches Buzz to presentation-only for unresolved names
+// while real member mentions still notify.
+//
+// This asserts ARGV, because that is the only place the fix exists — the body is deliberately
+// unchanged, so a test that only inspected the rendered text would pass either way.
+{
+  const { __setTransportForTests } = await import('../src/egress.mjs')
+  const stub = process.env.WB_STUB_SEND
+  delete process.env.WB_STUB_SEND    // the stub short-circuits before emit; we need the real argv
+  const HEX64 = /^[0-9a-f]{64}$/
+
+  let argv = null
+  const restore = __setTransportForTests(async (a) => { argv = a; return JSON.stringify({ event_id: 'c'.repeat(64) }) })
+  const sk = generateSecretKey()
+  const { wrap, senderPk } = wrapFor(sk, { body: 'ping @oliver and @claude — neither is a Buzz member' })
+  admit(senderPk); delta()
+  await handleRelayIngress(wrap); await tick()
+  restore()
+  if (stub) process.env.WB_STUB_SEND = stub
+
+  const at = argv ? argv.indexOf('--mention') : -1
+  ok('the relay lane passes --mention, so an unresolvable @name cannot destroy the post', at !== -1)
+  ok('  the declared identity is a real pubkey, not a name or a placeholder',
+    at !== -1 && HEX64.test(String(argv[at + 1] || '')))
+  // WHICH key matters: it must be one Buzz will accept, and the sender is not a channel member.
+  ok('  it is the bridge\'s own key — a channel member — not the external sender\'s',
+    at !== -1 && argv[at + 1] === bridgePk && argv[at + 1] !== senderPk)
+  // The fix must not touch the message. If it rewrote or stripped the at-words, the agent's words
+  // would arrive altered — a different bug wearing this fix's clothes.
+  const ci = argv ? argv.indexOf('--content') : -1
+  ok('  the body is carried through UNCHANGED — at-words intact, not stripped or rewritten',
+    ci !== -1 && argv[ci + 1].includes('@oliver') && argv[ci + 1].includes('@claude'))
+}
+
 // --- route() dispatches the branch ------------------------------------------
 {
   // A real read lane has owner approvers as well as relay ingress. Prove the encrypted control


### PR DESCRIPTION
Closes #336.

## The bug

Buzz resolves every at-word in a post against the channel roster and refuses the **whole post** if
one fails. An outside agent routinely names other outside agents — none of whom are channel
members. So a single `@oliver` did not cost a mention, it cost **the message**.

Observed live on 2026-08-10, on waggle's own delivery path:

```
RELAY[buzz] ERR: {"message":"mention '@claude' does not match a current channel member;
retry with --mention <pubkey>","retryable":false}
```

That refusal ate a message whose own subject was this bug. Until now the workaround was a human
hand-checking every outgoing message for names that might not resolve.

## The fix

`--mention` is the documented escape, from `buzz messages send --help`:

> Supplying any explicit identity permits unresolved or ambiguous @Name text as presentation-only;
> **uniquely resolved member names still notify**

So unresolvable names degrade to literal text **and real member mentions still wake their seat**.
That second half is why this is the right fix rather than a trade — mentions are the wake signal for
episodic agents, and nobody loses one.

The plumbing already existed (`src/egress.mjs` `argvFor`, opt-in, only `forward()` used it). Both
released paths now declare an identity. The quarantine path defuses `@mentions` anyway and is
untouched.

## The one judgement call

The declared identity is **waggle's own key, not the sender's**.

The sender would be honest attribution and is the better end state. But the sender is not a channel
member, and whether Buzz accepts a non-member pubkey in this flag is **unverified**. waggle is a
member, and this exact form is the one observed to work — a crew member landed a post carrying two
unresolvable at-words this way.

**The suite pins that choice deliberately:** mutating the fix to the sender's key fails a test. The
better end state cannot be adopted by accident — someone has to check it live first and update the
assertion knowingly.

## Verification

- **Asserted on argv**, because that is the only place the fix exists. The body is deliberately
  unchanged, so a test reading rendered text would pass either way.
- **The body is asserted to arrive with its at-words intact** — a fix that stripped or rewrote them
  would be a different bug wearing this one's clothes.
- **Mutation-tested both ways.** Dropping the fix fails 3 assertions (reproducing the original
  defect); switching to the sender's key fails the one that names the choice.

`npm test` — 69 suites, exit 0.

## Note for the merger

Touches `postRelay` a few lines from #343, which is also open. Whichever lands second will want a
rebase and a read of the result — a stale branch has silently reverted a change in this repo before.

Touches a delivery path, so it needs eyes that are not mine before merge.

Drafted with assistance from [Claude Code](https://claude.com/claude-code)