### PR TITLE
The return lane says who wrote the message (#352)

### DIFF
--- a/src/bridge.mjs
+++ b/src/bridge.mjs
@@ -2714,7 +2714,9 @@ function sourceWireRejectReason(message) {
 
 function carryDescriptor(recipient, message, why, channel) {
   if (recipient.protocol !== 'nvoy-task-carry-v1') {
-    return { template: 'return_carry', slots: { mention: recipient.mention, why, body: String(message.content || '') } }
+    // #352: carry the AUTHOR. The bridge has held `message.pubkey` here all along — it simply was
+    // not passed, so every carried reply arrived attributed to waggle, the carrier.
+    return { template: 'return_carry', slots: { mention: recipient.mention, why, body: String(message.content || ''), author: message.pubkey || null } }
   }
   const ch = String(channel || '').toLowerCase()
   const source = sourceWireEvent(message)
@@ -2859,7 +2861,7 @@ async function scanReturnLane(msgs, opts = {}) {
         dropRlSeen(key)
         // Owed, durably. The overlap re-read may still catch it first; enqueue is idempotent and
         // does not reset the attempt count, so the two paths cannot inflate each other.
-        rlPending.enqueue(key, { to: r.npub_hex, mention: r.mention, why, body, src: m.id,
+        rlPending.enqueue(key, { to: r.npub_hex, mention: r.mention, why, body, src: m.id, author: m.pubkey || null,
           protocol: r.protocol || null, channel: opts.channel || null, source: r.protocol === 'nvoy-task-carry-v1' ? sourceWireEvent(m) : null })
       }
     }
@@ -2897,7 +2899,10 @@ async function retryPendingCarries(opts = {}) {
     try {
       descriptor = item.protocol === 'nvoy-task-carry-v1'
         ? { template: 'return_task_carry', slots: { channel: item.channel, why: item.why, source: item.source } }
-        : { template: 'return_carry', slots: { mention: item.mention, why: item.why, body: item.body } }
+        // `item.author` is absent on anything queued before #352; the template renders that as an
+        // explicit "not recorded" rather than rejecting, so a pending carry does not become a dead
+        // letter over a field that did not exist when it was enqueued.
+        : { template: 'return_carry', slots: { mention: item.mention, why: item.why, body: item.body, author: item.author || null } }
     } catch (e) { err(`RETURN retry invalid: ${String(item.src).slice(0, 12)}…: ${e.message}`); rlPending.remove(key); continue }
     const accepted = await returnLaneSend(item.to, descriptor,
       { src: item.src, why: item.why, protocol: item.protocol || 'return-carry-v1', channel: item.channel || null, retry: n }, opts.publish)

--- a/src/nostr_egress.mjs
+++ b/src/nostr_egress.mjs
@@ -361,9 +361,28 @@ const CATALOGUE = {
   // relay will not serve. The prose is here; the caller supplies who, why, and the body.
   return_carry: {
     whys: ['mention', 'reply'],
-    build: ({ mention, why, body }, spec) => {
+    // `author` is the pubkey of whoever wrote the carried message (#352). Before it existed, this
+    // template named only the RECIPIENT — "you were replied to" — so a carry could not say who
+    // replied, and the reader had to guess from writing style. On the primary read path for an
+    // outside agent, that is the difference between answering "did Neil reply?" and not.
+    //
+    // Rendered as a short pubkey, not a name: waggle does not resolve Buzz display names here, and
+    // inventing one would be a surface asserting something it did not check. A pubkey is stable and
+    // verifiable, which is what identification needs.
+    //
+    // OPTIONAL on purpose. A carry queued before this shipped has no author, and a template that
+    // rejected it would turn a pending message into a dead letter. Absent renders as an explicit
+    // "not recorded" rather than being quietly omitted — a missing attribution line and an
+    // unattributable message must not look identical.
+    build: ({ mention, why, body, author }, spec) => {
       if (!spec.whys.includes(why)) reject(`carry reason not in {${spec.whys.join('|')}}: ${JSON.stringify(why)}`)
-      return `📥 **${handle(mention)}** — you were ${why === 'reply' ? 'replied to' : 'mentioned'} in the community.\n\n> ` +
+      const who = author == null || author === ''
+        ? '_author not recorded — this carry predates #352_'
+        : (/^[0-9a-f]{64}$/i.test(String(author))
+          ? `\`${String(author).toLowerCase().slice(0, 12)}…\``
+          : reject(`carry author is not a 64-char hex pubkey: ${JSON.stringify(String(author).slice(0, 24))}`))
+      return `📥 **${handle(mention)}** — you were ${why === 'reply' ? 'replied to' : 'mentioned'} in the community.\n\n` +
+        `from ${who}\n\n> ` +
         carried(body).replace(/\r/g, '').split('\n').join('\n> ') +
         `\n\n_carried out by waggle's return lane. Replying to this message reaches nobody; ` +
         `post from your own key and the bridge brings it back in._`

--- a/tests/egress_catalogue.mjs
+++ b/tests/egress_catalogue.mjs
@@ -253,20 +253,51 @@ console.log('\n-- The Nostr transport catalogue (§2.5) --')
   threw('NEGATIVE CONTROL — a template outside the Nostr catalogue is refused',
     () => buildBody('freeform', { text: 'anything I feel like saying' }))
 
-  // A3 changes what waggle CAN say, never what crosses. The return lane's carried text moved from
-  // an inline template literal in bridge.mjs into the catalogue, so pin it byte-for-byte against
-  // the pre-#134 string — the existing return-lane suites assert only on WHETHER a carry happened,
-  // never on its bytes, so nothing else would have caught a drifted word here.
+  // A3 changed what waggle CAN say, never what crosses. The return lane's carried text moved from
+  // an inline template literal in bridge.mjs into the catalogue, so it is pinned byte-for-byte —
+  // the existing return-lane suites assert only on WHETHER a carry happened, never on its bytes,
+  // so nothing else would catch a drifted word here.
+  //
+  // #352 changes these bytes DELIBERATELY, and the pin moves with it rather than being relaxed.
+  // The old wire named only the recipient ("you were replied to"), so a carry could not say who
+  // wrote it — on the primary read path for an outside agent, that is the difference between
+  // answering "did Neil reply?" and guessing from writing style. An `from <pubkey>` line is added.
+  const AUTHOR = 'b'.repeat(64)
   for (const [why, verb] of [['mention', 'mentioned'], ['reply', 'replied to']]) {
     const body = 'line one\nline two'
-    const expected =
-      `📥 **claude** — you were ${verb} in the community.\n\n> ` +
-      body.replace(/\r/g, '').split('\n').join('\n> ') +
+    const tail = body.replace(/\r/g, '').split('\n').join('\n> ') +
       `\n\n_carried out by waggle's return lane. Replying to this message reaches nobody; ` +
       `post from your own key and the bridge brings it back in._`
-    ok(`return_carry (${why}): byte-identical to the pre-A3 wire`,
-      buildBody('return_carry', { mention: 'claude', why, body }) === expected)
+    ok(`return_carry (${why}): byte-identical to the #352 wire, author named`,
+      buildBody('return_carry', { mention: 'claude', why, body, author: AUTHOR }) ===
+      `📥 **claude** — you were ${verb} in the community.\n\nfrom \`${'b'.repeat(12)}…\`\n\n> ${tail}`)
+    // A carry queued before #352 has no author. It must still build — rejecting would turn a
+    // pending message into a dead letter over a field that did not exist when it was enqueued —
+    // and must say so EXPLICITLY. "no attribution line" and "unattributable" must not look alike.
+    ok(`return_carry (${why}): a pre-#352 carry still builds, and says the author is unrecorded`,
+      buildBody('return_carry', { mention: 'claude', why, body }) ===
+      `📥 **claude** — you were ${verb} in the community.\n\nfrom _author not recorded — this carry predates #352_\n\n> ${tail}`)
   }
+  // Both directions. A test that only checked "the author appears" cannot tell "renders the author"
+  // from "renders something" — pin that a DIFFERENT author renders differently.
+  ok('return_carry: a different author renders differently — the field is read, not decorative',
+    buildBody('return_carry', { mention: 'claude', why: 'reply', body: 'x', author: 'a'.repeat(64) }) !==
+    buildBody('return_carry', { mention: 'claude', why: 'reply', body: 'x', author: 'b'.repeat(64) }))
+  // The author is a pubkey, and anything else is refused rather than rendered. A display name here
+  // would be attacker-controlled text in an attribution line — a carried name that can mint an
+  // at-word is #336 with extra steps.
+  for (const bad of ['Neil', 'b'.repeat(63), '', 'npub1' + 'q'.repeat(58), 'B'.repeat(64) + 'x']) {
+    if (bad === '') continue                                   // empty is the pre-#352 case above
+    let threw = false
+    try { buildBody('return_carry', { mention: 'claude', why: 'reply', body: 'x', author: bad }) }
+    catch { threw = true }
+    ok(`return_carry: refuses a non-pubkey author ${JSON.stringify(bad.slice(0, 12))}`, threw)
+  }
+  // …and a legitimate value still gets through. Pairing every refusal with an acceptance is the
+  // 2026-08-01 lesson: a validator asserted only to reject also rejected every real recipient.
+  ok('return_carry: an uppercase hex pubkey is accepted and normalised, not refused',
+    buildBody('return_carry', { mention: 'claude', why: 'reply', body: 'x', author: 'A'.repeat(64) })
+      .includes(`\`${'a'.repeat(12)}…\``))
 
   const carry = buildBody('return_carry', { mention: 'claude', why: 'mention', body: HOSTILE })
   ok('return_carry: the community body is quoted, never waggle\'s own voice',

--- a/tests/return_lane.mjs
+++ b/tests/return_lane.mjs
@@ -10,11 +10,25 @@ import { mkdtempSync, writeFileSync, readFileSync, existsSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { resolve } from 'node:path'
 import { getPublicKey, generateSecretKey } from 'nostr-tools/pure'
+import * as nip44 from 'nostr-tools/nip44'
 
 const dir = mkdtempSync(resolve(tmpdir(), 'wb-rl-'))
 const bridgeSk = generateSecretKey()
-const participant = getPublicKey(generateSecretKey())
+const participantSk = generateSecretKey()
+const participant = getPublicKey(participantSk)
 const stranger = getPublicKey(generateSecretKey())
+const participant2 = getPublicKey(generateSecretKey())   // a SECOND author, so attribution can be told apart
+
+// Open a 1059 the way the recipient's own runtime would: unwrap to the seal with the wrap's
+// ephemeral key, then unseal to the rumor with the seal author's. Doing it for real — rather than
+// reaching into a descriptor — is what makes the assertion about what the reader actually sees.
+const openWrapAs = async (sk, wrap) => {
+  try {
+    const seal = JSON.parse(nip44.decrypt(wrap.content, nip44.getConversationKey(sk, wrap.pubkey)))
+    const rumor = JSON.parse(nip44.decrypt(seal.content, nip44.getConversationKey(sk, seal.pubkey)))
+    return String(rumor.content || '')
+  } catch { return null }
+}
 
 writeFileSync(resolve(dir, 'config.json'), JSON.stringify({
   relays: [], recipients: [],
@@ -73,6 +87,38 @@ ok('a mention followed by punctuation still matches', journal().length === 3)
 
 await scanReturnLane([{ id: 'm7', pubkey: stranger, content: '@claude' }])
 ok('a mention alone on the line matches', journal().length === 4)
+
+// --- #352: the carry says WHO wrote it ------------------------------------------------------
+// End-to-end, through the real wrap, not by inspecting a descriptor. The bridge held the author's
+// pubkey all along and simply did not pass it, so every carried reply arrived attributed to
+// waggle — the carrier — and a reader could not answer "who said this?" except by writing style.
+//
+// This is asserted on the DECRYPTED body because the send journal records only {lane, to, kind}.
+// A test that asserted on carryDescriptor's slots would be asserting the mechanism; what matters
+// is that the author reaches the text the recipient actually reads. Written after a mutation —
+// dropping the author in bridge.mjs — passed all 69 suites, which means the wiring had no cover
+// at all and only the template was tested.
+{
+  const wraps = []
+  const capture = async (wrap) => { wraps.push(wrap); return 1 }
+  await scanReturnLane([{ id: 'm8', pubkey: stranger, content: 'over to @claude' }], { publish: capture })
+  ok('the carry was captured for inspection', wraps.length === 1)
+  const body = await openWrapAs(participantSk, wraps[0])
+  ok('the carried text names the author, not only the recipient',
+    !!body && body.includes(stranger.slice(0, 12)))
+  // Both directions, or "names the author" cannot be told from "contains some hex".
+  const other = []
+  await scanReturnLane([{ id: 'm9', pubkey: participant2, content: 'also for @claude' }],
+    { publish: async (w) => { other.push(w); return 1 } })
+  const body2 = await openWrapAs(participantSk, other[0])
+  ok('a different author produces a different attribution — the field is read, not decorative',
+    !!body2 && body2.includes(participant2.slice(0, 12)) && !body2.includes(stranger.slice(0, 12)))
+  // The recipient is still named. The author line must ADD identification, not replace it.
+  ok('the recipient is still named alongside the author', !!body && body.includes('claude'))
+  // And the message itself still crosses intact — an attribution line that ate the body would
+  // pass every assertion above.
+  ok('the carried body is still there, unchanged', !!body && body.includes('over to @claude'))
+}
 
 console.log(fails ? `\nRETURN LANE FAIL — ${fails}` : '\nRETURN LANE PASS — carries mentions out, and nothing else')
 process.exit(fails ? 1 : 0)


### PR DESCRIPTION
Closes #352.

A carried reply arrived attributed to `waggle (bridge)` — the carrier. Asked "has Neil replied?", an agent on this lane could not answer. That is how this was found.

### Cause

Two carry shapes, differing on exactly this:

- `return_task_carry` embeds the kind:9 wire event including `pubkey` and `sig`, and re-verifies it. Authorship preserved.
- `return_carry` carried `{mention, why, body}` — where `mention` is the **recipient's** handle. No author field. `carryDescriptor` picks this one for any recipient not configured as `nvoy-task-carry-v1`, which is the default.

The bridge held `message.pubkey` at carry time all along. It just wasn't passed.

### Choices worth challenging

- **Short pubkey, not a name.** waggle doesn't resolve Buzz display names here, and inventing one would be a surface asserting something it never checked. A non-pubkey author is refused rather than rendered — an attribution line carrying attacker-controlled text is #336 with extra steps.
- **Optional field.** A carry queued before this has no author; rejecting would turn a pending message into a dead letter over a field that didn't exist when it was enqueued. Absent renders an explicit "not recorded" rather than being omitted, so a missing line and an unattributable message don't look alike.

### Why it's not cosmetic

#344 settled that the return lane **is** the read path for an outside agent. Dropping the sender on the primary channel makes routing by remit impossible, and makes any reply an at-word aimed at a guess — which #336 shows destroys the whole message.

### Verification — and a miss worth reporting

The first version of this had the template tested and the **wiring not**. Dropping the author in `bridge.mjs` passed all 69 suites. I only found that by running the mutation, and it is exactly the failure this repo keeps re-learning: a mutation that goes undetected looks identical to a green suite.

The assertion moved from the descriptor to the **decrypted wrap** — what the reader actually sees. That mutation now fails two assertions.

Both directions asserted: a different author must produce a different attribution, or "names the author" can't be told from "contains some hex". Also pinned that the recipient is still named and the body still crosses intact, since an attribution line that ate the body would satisfy everything else.

The egress catalogue's byte-for-byte pin **moves** with the change rather than being relaxed — this is a deliberate wire change, and the comment records why.

69 suites green.

### Review note

Touches a delivery path, so it needs a read by someone who did not write it. Specifically worth challenging: rendering a bare pubkey is honest but not very usable — if there is a name source I should be using, say so.

Drafted with assistance from [Claude Code](https://claude.com/claude-code)