### PR TITLE
Stop naming two files that are not in this tree as though they run

### DIFF
--- a/console/capability-vocabulary.mjs
+++ b/console/capability-vocabulary.mjs
@@ -22,7 +22,8 @@
 //     ["da-scope", <hash>, <salt>]     a salted hash of the SUBJECT the capability is over
 //
 // For the task family the subject is the agent BEING INSTRUCTED and the grantee is the party who
-// MAY INSTRUCT IT. `tools/attention.mjs` is the enforcement site and settles it:
+// MAY INSTRUCT IT. nvoy's `mcp/tools/attention.mjs` — not a file in this repo — is the
+// enforcement site, and settles it:
 //
 //     if (scope[1] !== scopeHash(ME, scope[2] || '')) continue  // authorises tasking some other agent
 //     putGrant(String(grantee).toLowerCase(), { grantId: ev.id, grantor: ev.pubkey, cap })

--- a/console/connect-plan.mjs
+++ b/console/connect-plan.mjs
@@ -16,7 +16,7 @@
 // So this module takes INTENTS — sentences about who does what to whom — and assigns the parties
 // itself. The operator never chooses a grantee. There is exactly one place in the codebase where
 // intent becomes direction, it is this file, and tests/connect_plan.mjs holds it to the direction
-// tools/attention.mjs actually enforces.
+// nvoy's mcp/tools/attention.mjs actually enforces (that file is in nvoy, not in this repo).
 //
 //   node tests/connect_plan.mjs
 

--- a/docs/DESIGN_CONNECT_REMOTE_AGENT.md
+++ b/docs/DESIGN_CONNECT_REMOTE_AGENT.md
@@ -146,7 +146,7 @@ of attention. It is produced by the software.
 
 ### 1. The confirmation sentence is inverted for the whole task family
 
-`tools/attention.mjs` is the enforcement site. It builds the map of who may instruct this agent:
+`mcp/tools/attention.mjs`, **in the nvoy repo and not this one**, is the enforcement site. It builds the map of who may instruct this agent:
 
 ```js
 if (scope[1] !== scopeHash(ME, scope[2] || '')) continue // authorises tasking some other agent

--- a/docs/JOIN_RUNBOOK.md
+++ b/docs/JOIN_RUNBOOK.md
@@ -311,9 +311,11 @@ Then **verify by reading it back**, not by trusting the issuing tool:
 
 Three things, in the order they should be built:
 
-1. **The responder** — `tools/join-approve.mjs`: watch for join requests, DM you the approval
-   card, read your reply through `authorizeJoinReply`, issue the grants. All the decision logic it
-   needs is built and tested; what it adds is I/O and a signer.
+1. **The responder** — `tools/join-approve.mjs`, a **proposed filename, not a file in this tree**:
+   watch for join requests, DM you the approval card, read your reply through `authorizeJoinReply`,
+   issue the grants. All the decision logic it needs is built and tested; what it adds is I/O and a
+   signer. Named here so the design has a handle — do not go looking for it, and nothing else
+   should refer to it as though it runs.
 2. **Minting at approval time** — so step 2 stops being a prerequisite and the identity is created
    into your Bunker when you approve, as `DESIGN_JOIN.md` describes.
 3. **Pairing after approval** — so `tools/join.mjs` finishes the ceremony instead of waiting and

--- a/tests/capability_vocabulary.mjs
+++ b/tests/capability_vocabulary.mjs
@@ -80,7 +80,7 @@ check(capEnforcer(UNKNOWN).trim() !== '',
 
 // ── DIRECTION ───────────────────────────────────────────────────────────────────────────────
 // The defect this section exists for: `task` was labelled "Take tasks from you", which describes
-// the GRANTEE as the task-taker. tools/attention.mjs enforces the opposite — the grantee is the
+// the GRANTEE as the task-taker. nvoy's mcp/tools/attention.mjs (NOT in this repo) enforces the opposite — the grantee is the
 // party permitted to SEND instructions, and the scope subject is the agent receiving them. An
 // operator read the inverted sentence and signed a grant authorising the reverse of their intent.
 // It verified, it was live, and no surface could show it; it was found by recomputing salted

--- a/tests/connect_plan.mjs
+++ b/tests/connect_plan.mjs
@@ -1,7 +1,8 @@
 // connect_plan.mjs — the one place intent becomes direction, held to the direction that is
 // actually enforced.
 //
-// tools/attention.mjs is the enforcement site for the task family:
+// nvoy's mcp/tools/attention.mjs is the enforcement site for the task family. It is NOT in this
+// repo — looking for waggle/tools/attention.mjs finds nothing, which reads as a missing guard.
 //
 //     if (scope[1] !== scopeHash(ME, scope[2] || '')) continue  // authorises tasking some other agent
 //     putGrant(String(grantee).toLowerCase(), …)

--- a/tools/join.mjs
+++ b/tools/join.mjs
@@ -11,8 +11,14 @@
 //
 // WHAT IT DOES NOT DO, and must not be described as doing. It does not mint the persistent agent
 // identity — that is minted into the OWNER's Bunker when they approve, and this session never
-// holds it. It does not pair. It does not post to the channel. Those steps need the responder
-// (tools/join-approve.mjs) and a Bunker; see docs/JOIN_RUNBOOK.md.
+// holds it. It does not pair. It does not post to the channel. Those steps need a Bunker and a
+// responder; see docs/JOIN_RUNBOOK.md.
+//
+// THE RESPONDER IS NOT BUILT. `tools/join-approve.mjs` is a design, not a file — JOIN_RUNBOOK §6
+// lists it first under "what is missing for the unattended loop". Until it exists the owner reads
+// the request and issues the grants by hand from the console (§4 and §5). This comment and the
+// output below both used to name that tool as though it existed, which sent an owner looking for
+// a file that has never been in the tree.
 //
 // The request key is written to a 0600 file in a temp dir for the lifetime of the wait, because a
 // reply sealed to it arrives after this process has been running for a while and a key held only
@@ -130,11 +136,10 @@ console.log()
 console.log('Request id (the owner needs this to approve):')
 console.log(`  ${request.id}`)
 console.log()
-console.log('Now the owner approves. They will receive a DM and reply with exactly:')
-console.log(`  APPROVE ${request.id}`)
-console.log()
-console.log('See docs/JOIN_RUNBOOK.md — the owner runs tools/join-approve.mjs, which reads that')
-console.log('reply and issues the grants. This session holds no key and never will.')
+console.log('Now the owner approves — BY HAND. There is no responder yet: nothing watches for this')
+console.log('request, nothing will DM them, and no reply of theirs will be parsed. They read the')
+console.log('request, decide, and issue the grants from the console (docs/JOIN_RUNBOOK.md §4 and §5).')
+console.log('Send them the request id above. This session holds no key and never will.')
 console.log()
 console.log(`join: waiting up to ${waitSecs}s for the decision, then burning the request key…`)
 


### PR DESCRIPTION
Goal item 6 — *tools/ and docs/ describe only what is shipped. Anything designed-not-built is
labelled as such or deleted.* Two references failed it, and both send a reader looking for a file
that has never existed in this repo.

## `tools/join-approve.mjs` — a design, printed as an instruction

`tools/join.mjs` told the operator, at runtime:

> See docs/JOIN_RUNBOOK.md — the owner runs tools/join-approve.mjs, which reads that reply and
> issues the grants.

There is no such file. `JOIN_RUNBOOK` §6 already lists the responder **first** under *what is
missing for the unattended loop* — so the runbook was honest and the tool's own output was not,
which is the worse way round: the output is the thing somebody acts on.

It now says what is actually true — nothing watches for the request, nothing will DM them, no
reply of theirs will be parsed — and points at §4 and §5, where the owner reads the request and
issues the grants by hand from the console. The runbook marks the filename as a proposed one.

## `tools/attention.mjs` — real, but in the other repo

Named in five places as *the enforcement site* for the task-capability family — which is the
justification for which party a task grant names, and therefore load-bearing on a direction that
has been signed backwards here before. The file is real; it is in **nvoy**, not in waggle. A reader
in this repo looks for `waggle/tools/attention.mjs`, finds nothing, and reads the guard as missing.

Each of the five now says which repo it lives in.

## Verification

Swept the tree for every `tools/…` path referenced in `.md`, `.mjs`, `.html` and `.json` and
checked each resolves. Two do not, and both are now explicitly labelled: `join-approve` as a
design, and `relay-send` as correct relative to the nvoy checkout its code block `cd`s into — that
one was a false positive on the first pass and is left alone.

**69 suites green** and lint clean — this branch is cut from `main`, so 69 is the count of record
here. #356 and #359 take it to 71; a run of this branch reporting 71 would mean it had been rebased
onto them.

Docs and tool copy only; no code path is touched.

Drafted with assistance from [Claude Code](https://claude.com/claude-code)