### PR TITLE
A grantee may hold more than one grant (#364)

### DIFF
--- a/src/bridge.mjs
+++ b/src/bridge.mjs
@@ -798,7 +798,16 @@ const scopeHash = (channelId, saltHex) =>
   createHash('sha256').update(Buffer.concat([
     Buffer.from('waggle/da-scope/v1'), Buffer.from([0]), Buffer.from(String(channelId)), Buffer.from(saltHex, 'hex'),
   ])).digest('hex')
-const grantSet = new Map() // grantee pubkey -> { grantId, grantor }
+// grantee pubkey -> Map(grantId -> grantor). A SET of grants, not one, and that is the whole of
+// #364: a grantee may legitimately hold several — one per channel, per capability, or simply
+// re-issued. This map used to hold the last one written, so revoking THAT id de-admitted a key
+// that still held live grants, and revoking any of the others matched nothing and said nothing.
+//
+// The rule the shape enforces: ADMITTED WHILE ANY HELD GRANT IS UNREVOKED. Membership of the
+// outer map is therefore the admission answer, which is why every consumer below can keep using
+// `.has()`, `.keys()` and `.size` unchanged — an entry exists only while its inner map is
+// non-empty, and it is deleted the moment the last grant goes.
+const grantSet = new Map()
 // An admission grant is also the recipient's return address. Keeping the dynamic
 // portion derived from grantSet (rather than writing it into config) makes a 441
 // remove reachability as well as authority. A configured entry can add the ergonomic
@@ -995,11 +1004,26 @@ function processGrantEvent(ev, { emitFn = emit, queryFn = query } = {}) {
     // — the grant it revokes has not arrived yet. A 441 carries only an `e` tag, never a `p`, so
     // this is the only thing that can be known about it in isolation.
     if (target) revokedGrants.add(String(target).toLowerCase())
-    for (const [pk, g] of grantSet) if (g.grantId === target) {
+    // Remove THIS grant, then ask whether the grantee still holds another. Deleting the grantee
+    // outright was #364: it removed a key that still had a live, unrevoked grant, and did it
+    // silently from the operator's side — the relay lane, live @mention refs, the GRANTED bypass
+    // and activeReturnLane() all simply stopped working for them.
+    let matched = false
+    for (const [pk, grants] of grantSet) {
+      if (!grants.delete(target)) continue
+      matched = true
+      if (grants.size) {
+        log(`NIPDA revoked one of several: grantee ${pk.slice(0, 12)}… keeps ${grants.size} live grant(s), still admitted (441 ${ev.id.slice(0, 12)}…)`)
+        continue                  // the row still has a justification, so it is left alone
+      }
       grantSet.delete(pk)
-      log(`NIPDA revoked: grantee ${pk.slice(0, 12)}… (441 ${ev.id.slice(0, 12)}…)`)
-      unseatGrantee(pk, emitFn)   // the row loses its only justification the moment the grant does
+      log(`NIPDA revoked: grantee ${pk.slice(0, 12)}… held no other grant, no longer admitted (441 ${ev.id.slice(0, 12)}…)`)
+      unseatGrantee(pk, emitFn)   // the row loses its only justification the moment the LAST grant does
     }
+    // Silence here was the other half of #364. A 441 matching nothing is ordinary — the 440 has
+    // usually not arrived yet, and `revokedGrants` above is what makes that safe — but "recorded,
+    // matched nothing" and "revoked someone" must not look the same in the journal.
+    if (!matched) log(`NIPDA revocation recorded: 441 ${ev.id.slice(0, 12)}… targets ${String(target || 'nothing').slice(0, 12)}…, which no admitted grantee is holding — its 440 will be refused if it arrives`)
     return
   }
   if (ev.kind !== NIPDA.grant) return
@@ -1018,9 +1042,15 @@ function processGrantEvent(ev, { emitFn = emit, queryFn = query } = {}) {
     err(`NIPDA drop[revoked]: 440 ${ev.id.slice(0, 12)}… for ${String(grantee).slice(0, 12)}… arrived after its own 441 — not admitted`)
     return
   }
-  grantSet.set(String(grantee).toLowerCase(), { grantId: ev.id, grantor: ev.pubkey })
-  log(`NIPDA granted: ${String(grantee).slice(0, 12)}… admitted (${cap}, 440 ${ev.id.slice(0, 12)}…)`)
-  seatGrantee(String(grantee).toLowerCase(), emitFn, queryFn)
+  const pk = String(grantee).toLowerCase()
+  // ADD, never overwrite. The overwrite is what made revocation depend on which grant happened to
+  // be stored last, i.e. on relay delivery order (#364).
+  const grants = grantSet.get(pk) || new Map()
+  const already = grants.has(ev.id)
+  grants.set(ev.id, ev.pubkey)
+  grantSet.set(pk, grants)
+  if (!already) log(`NIPDA granted: ${pk.slice(0, 12)}… admitted (${cap}, 440 ${ev.id.slice(0, 12)}…${grants.size > 1 ? `, ${grants.size} live grants` : ''})`)
+  seatGrantee(pk, emitFn, queryFn)
 }
 
 // In-door consent (#131/#132, docs/CONSENT.md §8). A SEPARATE lane from grantSet by construction —

--- a/tests/nipda_admission.mjs
+++ b/tests/nipda_admission.mjs
@@ -95,5 +95,83 @@ processGrantEvent(rev)
 check(!grantSet.has(strangerPk), 'valid 441 revokes the grant')
 check(/-> STAGING/.test(routeOf(reply(strangerSk, strangerPk))), 'revoked participant reply -> back to quarantine')
 
-console.info(pass ? '\nNIPDA PASS — admission tier holds' : '\nNIPDA FAIL')
+// ── #364: a grantee may hold SEVERAL grants, and revocation is per-grant ─────────────────────
+//
+// Everything above uses one grant, which is exactly why this went unnoticed: with a single grant
+// the old last-write-wins map behaves identically. The two assertions immediately above are the
+// negative control for this whole block — one grant in, one 441 out, still works — so "removes the
+// right thing" cannot be satisfied here by "removes everything".
+//
+// The measured behaviour before this fix (issue #364, re-measured on this branch):
+//   revoke the grant the map was NOT holding  -> silent, no line at all
+//   revoke the grant it WAS holding           -> de-admitted, while another grant was still live
+{
+  const multiSk = generateSecretKey()
+  const multiPk = getPublicKey(multiSk)
+  const g1 = grant(grantorSk, multiPk, CHAN)
+  const g2 = grant(grantorSk, multiPk, CHAN)
+  const kill = (id) => wire(finalizeEvent({ kind: 441, created_at: now(), tags: [['e', id]], content: '' }, grantorSk))
+  const logOf = (fn) => { const before = buf.length; fn(); return buf.slice(before) }
+
+  logOf(() => { processGrantEvent(g1); processGrantEvent(g2) })
+  check(grantSet.has(multiPk), 'two grants for one grantee: admitted')
+
+  // Revoking either one must leave them admitted. Deliberately revoke g2 — the one the OLD code
+  // stored — because that is the case that used to de-admit a key holding a live grant.
+  const outOne = logOf(() => processGrantEvent(kill(g2.id)))
+  check(grantSet.has(multiPk), 'revoking ONE of two grants leaves the grantee admitted — the other is still live (#364)')
+  check(/keeps 1 live grant/.test(outOne),
+    '…and says so, naming how many remain — the old code was silent here, which is what made it undiagnosable')
+  check(/-> inbox/.test(routeOf(reply(multiSk, multiPk))), '…and the routing agrees: still past quarantine')
+
+  const outAll = logOf(() => processGrantEvent(kill(g1.id)))
+  check(!grantSet.has(multiPk), 'revoking the LAST grant removes the grantee')
+  check(/held no other grant/.test(outAll), '…and the line distinguishes that from revoking one of several')
+  check(/-> STAGING/.test(routeOf(reply(multiSk, multiPk))), '…and the routing agrees: back to quarantine')
+
+  // The relay serves both 440s forever, so every reconnect replays them.
+  const outReplay = logOf(() => { processGrantEvent(g1); processGrantEvent(g2) })
+  check(!grantSet.has(multiPk), 'a reconnect replaying BOTH 440s does not re-admit a fully revoked grantee')
+  check((outReplay.match(/drop\[revoked\]/g) || []).length === 2, '…and both are refused by id, loudly, not merely ignored')
+
+  // A 441 for something nobody holds is ORDINARY — the 440 usually has not arrived yet — but it
+  // must not look the same in the journal as a revocation that removed someone.
+  //
+  // Fired while a DIFFERENT grantee is admitted, deliberately. With an empty grantSet the loop body
+  // never runs, so a version that deleted the target from every grantee rather than only from the
+  // one holding it would pass unnoticed — it did, until this bystander was added.
+  const bystanderSk = generateSecretKey(), bystanderPk = getPublicKey(bystanderSk)
+  const gBystanderReplay = grant(grantorSk, bystanderPk, CHAN)
+  processGrantEvent(gBystanderReplay)
+  check(grantSet.has(bystanderPk), 'a bystander grantee is admitted')
+  const unheld = logOf(() => processGrantEvent(kill('9'.repeat(64))))
+  check(/revocation recorded/.test(unheld) && /no admitted grantee is holding/.test(unheld),
+    'a 441 for a grant nobody holds is RECORDED and logged, not silently dropped')
+  check(!/NIPDA revoked/.test(unheld), '…and is not reported as having revoked anybody')
+  check(grantSet.has(bystanderPk) && !unheld.includes(bystanderPk.slice(0, 12)),
+    '…and it does not touch, or even name, a grantee who was never holding that grant')
+
+  // Replays happen on every reconnect. A 440 we already hold must not re-announce itself, or the
+  // journal fills with admissions that did not happen.
+  const quiet = logOf(() => processGrantEvent(grant(grantorSk, bystanderPk, CHAN)))
+  check(/NIPDA granted/.test(quiet), 'a genuinely NEW grant for an already-admitted grantee is announced')
+  const again = logOf(() => processGrantEvent(gBystanderReplay))
+  check(!/NIPDA granted/.test(again),
+    'but replaying a 440 already held says nothing — every reconnect replays, and re-announcing is journal flood')
+
+  // Order-independence, re-pinned here because it is now the same model doing the work.
+  const lateSk = generateSecretKey(), latePk = getPublicKey(lateSk)
+  const gl = grant(grantorSk, latePk, CHAN)
+  processGrantEvent(kill(gl.id))          // the 441 arrives FIRST, as most relays serve it
+  processGrantEvent(gl)
+  check(!grantSet.has(latePk), 'a 441 delivered before its own 440 still keeps the key out (#361/#368)')
+
+  // …and the control for THAT: a grant with no revocation still admits, so the guard above is not
+  // simply refusing every 440 that arrives late.
+  const okSk = generateSecretKey(), okPk = getPublicKey(okSk)
+  processGrantEvent(grant(grantorSk, okPk, CHAN))
+  check(grantSet.has(okPk), 'an unrevoked grant arriving at the same point still admits')
+}
+
+console.info(pass ? '\nNIPDA PASS — admission tier holds, and a grantee may hold more than one grant' : '\nNIPDA FAIL')
 process.exit(pass ? 0 : 1)


### PR DESCRIPTION
**Stacked on #356**, because the fix depends on its `revokedGrants` set. Merge #356 first.

## Measured before written — and the measurement changed the issue

#364 was reported against `origin/main` at `5817635`. #356 has since added `revokedGrants`, which records a 441's target *before* the match loop. That moves the answer, so I re-ran #364's own three cases by execution against `origin/feat/355-seat-admitted-agent` at `7c7a39c`:

| case | before | on #356's branch |
|---|---|---|
| A — revoke the grant the map is **not** holding | silent, still admitted | still admitted (**correct** — another grant is live), still **silent** |
| B — revoke the grant it **is** holding | de-admitted | de-admitted **while another grant is still live** ← the live defect |
| C — reconnect replays both 440s | **re-admitted** | not re-admitted ✅ **fixed by #356** |

**Case C — the worst of it — is already closed.** "Even revoking every grant does not hold" was what made a 441 meaningfully weaker than the design reads, and it no longer reproduces.

**Case B is the remaining defect, and it points the opposite way from the filed report.** This is **under**-admission: a participant loses the relay lane, live `@mention` refs, the `GRANTED` quarantine bypass and `activeReturnLane()` reachability *while holding a valid, unrevoked grant* — and nothing says so. Safer than over-admission, harder to diagnose, because everything simply stops working for that key.

I've posted the full measurement on #364 so the issue no longer describes a defect that is half-fixed.

## The change

`grantSet` was `grantee -> { grantId, grantor }` — one grant, last write wins. Now `grantee -> Map(grantId -> grantor)`, enforcing: **admitted while any held grant is unrevoked.**

An entry exists only while its inner map is non-empty, so every consumer keeps using `.has()`, `.keys()`, `.size` and `.delete()` untouched. The diff is the two lines that ever read the value — `+116 / -8` across the bridge and its test, and 71 suites pass with no other edit, which is the evidence that the reshape is contained.

The silence is fixed too. A 441 matching nothing is *ordinary* — its 440 usually hasn't arrived, and `revokedGrants` is what makes that safe — but "recorded, matched nothing" and "revoked someone" must not read the same in the journal.

## Verification

**A negative control on the whole change:** restoring last-write-wins makes exactly the four new assertions fail and leaves every pre-existing one passing. The suite can see this defect, and the reshape doesn't disturb anything else.

The single-grant cases already in the file are the paired half — one grant in, one 441 out, still works — so *"removes the right thing"* cannot be satisfied here by *"removes everything"*.

**Six mutations, six detected — two of which were NOT, until the fixtures were fixed:**

- the unheld-441 case fired against an **empty** `grantSet`, so a version that deleted the target from *every* grantee never ran the loop body at all. It now fires with a bystander admitted, and that bystander must be neither touched nor named.
- nothing asserted that a replayed 440 stays quiet. Every reconnect replays every 440, so re-announcing each admission was invisible journal flood.

Both are the same failure shape: an assertion that could not fail because the state it needed was never set up.

## Review

Touches the admission gate, so it needs eyes that aren't mine. The thing to push on: whether **admitted-while-any-grant-lives** is the semantics you want, or whether a partially-revoked grantee should lose capability in some narrower way. The shape makes that decidable; it doesn't decide it.

Closes #364
Refs #356 #361 #368

Drafted with assistance from [Claude Code](https://claude.com/claude-code)