### PR TITLE
Bind checks that no other nvoy MCP server is registered (#380)

### DIFF
--- a/src/agent_install_state.mjs
+++ b/src/agent_install_state.mjs
@@ -61,6 +61,8 @@ export const ARTIFACTS = [
     why: 'The MCP channel transport.' },
   { key: 'mcp-registration', title: 'Registered as an MCP server', blocking: true,
     why: 'How a new session becomes this agent. Needs the instance root set explicitly; the default path does not exist here.' },
+  { key: 'mcp-exclusive', title: 'No other nvoy server registered', blocking: true,
+    why: 'Registered is not sole. A generically-named server alongside carries the tools that sign, bound to somebody else.' },
   { key: 'channel-answers', title: 'Channel server answers', blocking: true,
     why: 'Registered is not running. Proven by initialize + tools/list, not by the registration existing.' },
 ]
@@ -127,6 +129,38 @@ export function installState(observations = {}) {
     unverified: unverified.map(r => r.key),
     unknown: unknown.map(r => r.key),
   }
+}
+
+// Which OTHER nvoy MCP servers is this session carrying? (#380)
+//
+// The failure in #338 was not a missing server. It was a present one: alongside the correctly
+// instance-bound `nvoy-<name>` sat a generically-named `nvoy`, hard-wired to one identity's
+// credential files — and that is the server holding every tool that SIGNS. The instance-bound
+// path cannot act; the acting path is not instance-bound. No server is both, so the
+// default-looking choice is the unsafe one and an agent passes Bind while holding fifteen tools
+// pointed at a teammate.
+//
+// Checking that `nvoy-<name>` exists cannot catch that, because it was there. The question is
+// whether anything ELSE named nvoy is also there.
+//
+// Pure by design, like the rest of this module: it takes the text `claude mcp list` printed and
+// returns names. Passing `null` — the tool could not be run — must reach the UNKNOWN path, never
+// an empty array, because "nothing conflicting" and "I could not look" are the two things this
+// whole module exists to keep apart.
+export function foreignNvoyServers(listOutput, name) {
+  if (typeof listOutput !== 'string') return null
+  const mine = `nvoy-${String(name).toLowerCase()}`
+  const found = []
+  for (const line of listOutput.split('\n')) {
+    // `claude mcp list` prints `<server>: <command…> - <status>`. Take only the name.
+    const m = /^([A-Za-z0-9._-]+):/.exec(line.trim())
+    if (!m) continue
+    const server = m[1].toLowerCase()
+    if (server !== 'nvoy' && !server.startsWith('nvoy-')) continue
+    if (server === mine) continue
+    if (!found.includes(server)) found.push(server)
+  }
+  return found
 }
 
 // Render for a terminal. Kept here rather than in the CLI so the suite can assert that an

--- a/tests/agent_install_state.mjs
+++ b/tests/agent_install_state.mjs
@@ -14,7 +14,7 @@
 //
 //   node tests/agent_install_state.mjs
 
-import { installState, renderState, ARTIFACTS, ARTIFACT_KEYS, PRESENT, UNVERIFIED, MISSING, UNKNOWN }
+import { installState, renderState, foreignNvoyServers, ARTIFACTS, ARTIFACT_KEYS, PRESENT, UNVERIFIED, MISSING, UNKNOWN }
   from '../src/agent_install_state.mjs'
 
 let pass = true
@@ -139,6 +139,64 @@ check(ARTIFACTS.some(a => a.blocking) && ARTIFACTS.some(a => !a.blocking),
   // And prove exit 0 is reachable at all, or "never returns 0" would pass by refusing everything.
   check(installState(complete).exitCode === 0,
     'NEGATIVE CONTROL — a fully observed agent DOES reach exit 0, so the bar is not "always fail"')
+}
+
+// ── #380 — registered is not SOLE ───────────────────────────────────────────────────────────
+// #338's defect left `nvoy-oliver` correctly registered and instance-bound. Asking "is my server
+// there?" answered yes. The tools that SIGN were on a bare `nvoy` sitting beside it, hard-wired
+// to one identity, so the session held fifteen tools pointed at a teammate.
+//
+// Fixtures use the real output shape, real instance names, and a path containing a space — the
+// 2026-08-01 outage was a name with a space against a suite where every name was `A` or `Dennis`.
+{
+  const DIRTY = [
+    'nvoy: node /Users/op/Projects/nvoy/mcp/dist/server.js - ✔ Connected',
+    'nvoy-oliver: /Users/op/My Tools/node /Users/op/connect/claude-channel.mjs --instance oliver - ✘ Failed to connect',
+    'nvoy-lukedog: /Users/op/My Tools/node /Users/op/connect/claude-channel.mjs --instance lukedog - ✘ Failed to connect',
+    'github: docker run ghcr.io/github/github-mcp-server - ✔ Connected',
+  ].join('\n')
+
+  const dirty = foreignNvoyServers(DIRTY, 'oliver')
+  check(dirty.includes('nvoy'),
+    'the bare `nvoy` beside a correct nvoy-oliver is reported — the #338 configuration exactly')
+  check(dirty.includes('nvoy-lukedog'),
+    'another agent’s instance server is foreign too — it signs, just not as oliver')
+  check(!dirty.includes('nvoy-oliver'), 'the agent’s OWN server is not reported against it')
+  check(!dirty.includes('github'), 'a path containing a space does not turn an unrelated server into an nvoy one')
+
+  // BOTH DIRECTIONS. A check that only ever finds a conflict cannot be told from one that calls
+  // everything a conflict, and that version would still pass every assertion above.
+  const CLEAN = [
+    'nvoy-oliver: /Users/op/My Tools/node /Users/op/connect/claude-channel.mjs --instance oliver - ✘ Failed to connect',
+    'github: docker run ghcr.io/github/github-mcp-server - ✔ Connected',
+  ].join('\n')
+  check(Array.isArray(foreignNvoyServers(CLEAN, 'oliver')) && foreignNvoyServers(CLEAN, 'oliver').length === 0,
+    'a correctly provisioned session reports NO conflict — the guard is not "refuse everything"')
+
+  // The distinction this whole module exists to keep: could-not-look is not clean.
+  check(foreignNvoyServers(null, 'oliver') === null,
+    '`claude mcp list` unavailable returns null, NOT an empty array')
+  check(foreignNvoyServers(undefined, 'oliver') === null, 'and so does a missing argument')
+
+  // NEGATIVE CONTROL — a version returning [] on null passes "clean → []" identically. This is
+  // the assertion that tells them apart, so state it as the thing being relied on.
+  const collapsed = (out) => (typeof out === 'string' ? foreignNvoyServers(out, 'oliver') : [])
+  check(collapsed(null).length === 0 && foreignNvoyServers(null, 'oliver') === null,
+    'NEGATIVE CONTROL — a null-collapses-to-empty version WOULD read as clean; the real one returns null')
+}
+{
+  // And the report wiring: unknown must reach UNKNOWN (exit 3), a conflict must reach MISSING and
+  // BLOCK (exit 1). Assert the outcome, not just that something was flagged.
+  const conflicted = installState({ ...complete, 'mcp-exclusive': { found: false, note: 'also registered: nvoy' } })
+  check(conflicted.outcome === 'incomplete' && conflicted.exitCode === 1,
+    'a foreign nvoy server is BLOCKING — exit 1, not a warning the operator can read past')
+  check(conflicted.missing.includes('mcp-exclusive'), 'and it is named in the report')
+
+  const unlooked = installState({ ...complete, 'mcp-exclusive': { found: null } })
+  check(unlooked.outcome === 'inconclusive' && unlooked.exitCode === 3,
+    'and being unable to run `claude mcp list` is INCONCLUSIVE (3), never clean (0)')
+  check(installState(complete).exitCode === 0,
+    'while an exclusive registration still reaches exit 0 — the new artifact is satisfiable')
 }
 
 console.log(`\n${pass ? 'ALL PASS' : 'FAILURES ABOVE'}`)

--- a/tools/connect-agent.mjs
+++ b/tools/connect-agent.mjs
@@ -34,7 +34,7 @@ import { execFileSync } from 'node:child_process'
 import { existsSync, lstatSync, mkdirSync, readFileSync, statSync, writeFileSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
-import { installState, renderState } from '../src/agent_install_state.mjs'
+import { foreignNvoyServers, installState, renderState } from '../src/agent_install_state.mjs'
 
 const flag = n => { const i = process.argv.indexOf(n); return i < 0 ? '' : (process.argv[i + 1] || '') }
 const has = n => process.argv.includes(n)
@@ -160,15 +160,28 @@ see('channel-key', existsSync(keyPath), keyOk, existsSync(keyPath) ? (keyOk ? 'm
 
 // ── MCP registration. Reported, never written: it edits the operator's own config, and this tool
 // prints the exact command rather than reaching into it. ────────────────────────────────────
-let registered = null, regNote = ''
+let registered = null, regNote = '', mcpList = null
 try {
-  const list = execFileSync('claude', ['mcp', 'list'], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'], timeout: 30000 })
-  registered = new RegExp(`^nvoy-${name}:`, 'm').test(list)
+  mcpList = execFileSync('claude', ['mcp', 'list'], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'], timeout: 30000 })
+  registered = new RegExp(`^nvoy-${name}:`, 'm').test(mcpList)
   regNote = registered
     ? 'registered — note that "Failed to connect" here is EXPECTED while the real channel holds the lock'
     : `not registered. Run:\n      claude mcp add nvoy-${name} -s user -e NVOY_INSTANCE_ROOT=${instDir} -- <node> <path>/claude-channel.mjs --instance ${name}`
-} catch { registered = null; regNote = 'could not run `claude mcp list` — INCONCLUSIVE, not absent' }
+} catch { mcpList = null; registered = null; regNote = 'could not run `claude mcp list` — INCONCLUSIVE, not absent' }
 see('mcp-registration', registered, false, regNote)
+
+// Registered is not SOLE. #338: the acting tools live on a generically-named server that is not
+// instance-bound, so a correct `nvoy-<name>` alongside a bare `nvoy` still signs as somebody else.
+// This is the MCP path's EXPECT_PUBKEY — the Bunker path hard-stops on a key mismatch, and until
+// now this one had no guard at all.
+const foreign = foreignNvoyServers(mcpList, name)
+see('mcp-exclusive', foreign === null ? null : foreign.length === 0, foreign !== null && foreign.length === 0,
+  foreign === null
+    ? 'could not run `claude mcp list` — INCONCLUSIVE, not absent'
+    : foreign.length === 0
+      ? `nvoy-${name} is the only nvoy server registered`
+      : `also registered: ${foreign.join(', ')} — these carry the tools that SIGN, and not as ${name}. Remove with \`claude mcp remove <name>\` before acting.`)
+if (foreign?.length) warn.push(`${foreign.join(', ')} would sign as another identity from this session`)
 see('channel-answers', registered === true ? true : null, false, 'registered is not running — prove with an initialize + tools/list handshake')
 
 // ── Report ──────────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #380. waggle's half of #338.

## What was wrong

`connect-agent.mjs` verified that `nvoy-<name>` was registered. #338's defect was not a missing server — Oliver's was registered and correctly instance-bound. It was the **presence of a second, generically-named server** beside it:

| Server | Identity | Tools |
|---|---|---|
| `nvoy-<name>` | instance-bound ✅ | **2** — `nvoy_channel_read`, `nvoy_channel_reply` |
| `nvoy` | hard-wired to one credential path ❌ | **15**, including every tool that signs |

The instance-bound path cannot act; the acting path is not instance-bound. **No server is both.** So the default-looking choice is the unsafe one, and an agent passes Bind while holding fifteen tools pointed at a teammate. Checking "is my server there?" cannot catch that, because it was.

## What this adds

- `foreignNvoyServers(listOutput, name)` in `src/agent_install_state.mjs` — pure, like the rest of that module. Returns **`null`** when `claude mcp list` could not be run, never `[]`; "nothing conflicting" and "I could not look" are the distinction the module exists to keep.
- A **blocking** `mcp-exclusive` artifact. A conflict is exit 1, not a warning an operator reads past.

This is the MCP path's `EXPECT_PUBKEY`. The Bunker path hard-stops on a key mismatch (`tools/publish_relay_list.mjs:38`); this one had no guard at all — #338's own framing.

## Verified

- **Both directions** — a clean registration reports no conflict and still reaches exit 0, so the guard is not "refuse everything".
- **The reason, not only the refusal** — the message names the offending servers.
- **Could-not-look is INCONCLUSIVE (3)**, never clean (0).
- Fixtures use the real `claude mcp list` output shape, real instance names, and a **path containing a space**.
- **Four mutations, each detected, no ANCHOR MISS**: null collapsing to `[]`; own server not skipped; only bare `nvoy` matching; the conflict made non-blocking.
- Full suite (74) green on this base — read before committing.

Run against this machine, it catches the live misconfiguration:

```
[ x ] No other nvoy server registered  MISSING — also registered: nvoy, nvoy-claude-jaf,
      nvoy-lukedog — these carry the tools that SIGN, and not as oliver.
exit 1 (incomplete)
```

## Not in scope

Repointing or removing the shared server — that is nvoy's deployment, tracked in #338. The designed pattern is already written down in `docs/AGENT_PARTICIPANT_ARCHITECTURE.md`: *"each identity receives a separate Docker Compose namespace and watcher/broker/adapter set."* The pattern is right; registration does not follow it, and nothing asserted that it does. This adds the assertion.

**Review note:** touches the agent onboarding path, so it wants eyes that are not mine before merge — merging deploys.

Drafted with assistance from [Claude Code](https://claude.com/claude-code)