### PR TITLE
CLAUDE.md stated #141's rejected design as the design (#371, #382)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,11 +86,28 @@ not in the source you edited.
     remaining gap, and it is an infrastructure ask, not something to engineer around.
   - **The return lane is the design, not a shortfall.** Do not describe it as a workaround for
     missing read, and do not plan work that assumes native read is coming.
-- **You act as your OWN participant key, never as the bridge.** The designed onboarding (#141) is
-  that a session mints an *ephemeral* key, requests a maintainer grant, acts, and burns it — no
-  persistent key held. That reinforces this repo's core rule, it does not bend it: signing as
-  waggle is impersonation; signing as your own admitted key is the mechanism. (Operational
-  procedure lives in the private brief; #141 is partly built — do not describe it as shipped.)
+- **You act as your OWN participant key, never as the bridge.** Signing as waggle is
+  impersonation; signing as your own admitted key is the mechanism.
+
+  **What is disposable is the connection, not the identity (#141, closed 2026-08-04).** The
+  resolution is **two keys doing two different jobs** (`docs/DESIGN_JOIN.md`):
+
+  - **R, the request key** — minted in the session, signs the join request, receives the sealed
+    pairing token, then **burned**. Never granted anything, never in the roster. Its only job is
+    to be an address the owner can reply to, once.
+  - **A, the agent identity** — minted into the owner's **Bunker** at approval time and never held
+    by the session at all. The session holds a NIP-46 *pairing*, not a key.
+
+  Persistence follows from where A lives: a restart, a compaction or a new instance re-pairs to
+  the same A. **The session holding no key is the mechanism, not a limitation worked around.**
+
+  ⚠ **Do not describe "mint an ephemeral key, act, burn it" as the design.** Burning R is correct;
+  burning the *identity* is the shape #141 weighed and set aside — a fresh npub per session is not
+  admitted, is not in `return_lane`, and has no continuity, so it trades the whole
+  first-class-participant model for disposability. This paragraph previously stated exactly that
+  and misled a review (#371). Distinct from the **short-lived burner** in
+  `docs/GETTING_STARTED.md`, which is a deliberately different path for a throwaway agent and is
+  not this. Operational procedure lives in the private brief.
 - **Shipped is never blurred with designed.** If a thing is landed-but-undeployed, say so.
 - **`waggle` is always lowercase.** Including UI wordmarks; the shared Nave titlebar uppercases app
   names, so waggle surfaces override it locally.

--- a/docs/JOIN_RUNBOOK.md
+++ b/docs/JOIN_RUNBOOK.md
@@ -192,6 +192,18 @@ relay-send: DRY_RUN — nothing published
 **A sealed wrap is the proof.** Sealing requires the Bunker to sign, so this cannot succeed with a
 broken pairing — and `DRY_RUN` guarantees nothing reaches a relay.
 
+> **It proves a signature, not *whose*. Set `EXPECT_PUBKEY`.** Those two lines are identical
+> whichever key signed them. `relay-send.mjs` does enforce `EXPECT_PUBKEY` correctly, but it names
+> the key it resolved **only when the check fails** (`relay-send.mjs:62`); no success path prints
+> it. So a clean run is indistinguishable from one where the flag was never set, and today the only
+> way to see your own resolved identity is to make the check fail on purpose.
+>
+> This is not theoretical. A session has been observed bound to a *different* agent's identity at
+> MCP registration time, and every acting tool it held would have signed as that teammate (#338).
+> Pass `EXPECT_PUBKEY=<your npub>` on every run and treat its absence as an unverified step, not a
+> passed one — being unable to check is not the same as being fine. Naming the key on success is
+> tracked in #382; the fix belongs to nvoy, which is where that tool lives.
+
 > **`nip46-signer.mjs` is a library, not a command.** An earlier version of this runbook told you
 > to run it with `--get-public-key`. That flag does not exist, the file has no argument handling at
 > all, so Node loaded the module, defined its exports, printed nothing and **exited 0** — a total


### PR DESCRIPTION
Closes #371. Also lands #382's waggle-side half.

## The auto-loaded doc said the rejected thing

`CLAUDE.md` is loaded into every Claude Code session in this repo, and this sat under **"claims that must never drift"**:

> The designed onboarding (#141) is that a session mints an *ephemeral* key, requests a maintainer grant, acts, and burns it — no persistent key held. … (#141 is partly built)

#141 says the opposite under its own heading, and it **closed 2026-08-04**. Verified by reading the issue rather than the summary: a fresh npub per session is not admitted, is not in `return_lane`, and has no continuity, so it trades the whole first-class-participant model for disposability. That is the alternative #141 weighed and set aside.

It has already cost something — a custody matrix written for #370 reasoned from this paragraph and had to be corrected by someone who read #141 itself.

## What replaces it

`docs/DESIGN_JOIN.md`'s resolution, which is **sharper than #141's own vocabulary** — two keys doing two different jobs:

- **R, the request key** — minted in the session, signs the join request, receives the sealed pairing token, then burned. Never granted anything, never in the roster.
- **A, the agent identity** — minted into the owner's Bunker at approval and never held by the session at all. The session holds a NIP-46 *pairing*, not a key.

Persistence follows from where A lives. **The session holding no key is the mechanism, not a limitation worked around.**

## I checked the rest of the tree rather than sweeping it

`GETTING_STARTED.md` and `DESIGN_OWNER_CONTROL_PLANE.md` also describe minting and burning — but they scope it to a **short-lived burner agent** and explicitly contrast it with the persistent first-class path. That is a different and correct thing. Left alone, and now named as distinct in `CLAUDE.md` so the two don't get conflated in the other direction.

## #382's waggle half

`JOIN_RUNBOOK.md` sends an operator to `relay-send` to prove a Bunker pairing. Its two output lines are **identical whichever key signed them**.

Verified by reading the tool rather than asserting it: it enforces `EXPECT_PUBKEY` correctly, but names the resolved key **only on mismatch** (`relay-send.mjs:62`). No success path prints it. So a clean run is indistinguishable from one where the flag was never set, and the only way to see your own identity is to make the check fail on purpose. Given #338 — a session bound to a different agent's identity, where every acting tool would have signed as that teammate — that is the specific thing that should not be possible.

The fix belongs to nvoy, where the tool lives. This records the caveat where the step is documented and marks an unset `EXPECT_PUBKEY` as an unverified step rather than a passed one.

## Verified

Docs-only; full suite (74) green. No generated file hand-edited — `SPEC_EXTERNAL.md` untouched.

Drafted with assistance from [Claude Code](https://claude.com/claude-code)