### PR TITLE
Resolve the suite-count merge conflict without dropping a suite (#387)

### DIFF
--- a/src/suite_union.mjs
+++ b/src/suite_union.mjs
@@ -1,0 +1,93 @@
+// suite_union.mjs — resolve the suite-count merge conflict without losing a suite (#387).
+//
+// Every PR that adds a test suite edits the same four places: the `test` script in package.json,
+// and the roster + stated count in CLAUDE.md, README.md and docs/GETTING_STARTED.md. So any two
+// such PRs conflict, always, about something they do not actually disagree on.
+//
+// That would be mere friction if the obvious resolution were safe. It is not. Across ten of these
+// merges in one session, NEITHER SIDE WAS EVER A SUPERSET of the other — and twice the two sides
+// declared the SAME COUNT while holding different suites:
+//
+//     ours 71 (has policy_sealed_direct)   theirs 71 (has tripwire_setup)
+//
+// Taking either side, or the side with the larger number, silently drops a working suite. Nothing
+// fails afterwards, because a suite that is not invoked cannot fail. The number looks reconciled
+// and the coverage is gone.
+//
+// So the union is computed, and every property that would make it wrong is asserted rather than
+// assumed. Pure: no filesystem, no git — callers supply the strings and the directory listing.
+
+const SUITE_RE = /node (tests\/[\w-]+\.mjs)/g
+
+/** The suites a `test` script invokes, in invocation order. */
+export function parseSuites(testScript) {
+  return [...String(testScript ?? '').matchAll(SUITE_RE)].map(m => m[1])
+}
+
+/** Render a suite list back into a `test` script. */
+export function renderSuites(suites) {
+  return suites.map(s => `node ${s}`).join(' && ')
+}
+
+/**
+ * Union of two suite lists.
+ *
+ * `theirs` is the spine — it is the side being merged in, so its order is the one the branch will
+ * live with. Each suite only `ours` has is inserted directly after the suite that preceded it in
+ * OURS, which keeps a related pair adjacent instead of dumping additions at the end. Order is not
+ * cosmetic here: suite_count runs first and boot runs early.
+ */
+export function unionSuites(ours, theirs) {
+  const merged = [...theirs]
+  for (const suite of ours) {
+    if (merged.includes(suite)) continue
+    const i = ours.indexOf(suite)
+    const predecessor = i > 0 ? ours[i - 1] : null
+    const at = predecessor && merged.includes(predecessor) ? merged.indexOf(predecessor) + 1 : merged.length
+    merged.splice(at, 0, suite)
+  }
+  return merged
+}
+
+/**
+ * Everything that would make a resolution wrong, checked at resolve time.
+ *
+ * `onDisk` is the tests/ listing (bare filenames). The orphan check is the one that matters most:
+ * it is the property that catches a dropped suite, and checking it here rather than only in
+ * tests/suite_count.mjs means the resolver learns about it before committing rather than after.
+ */
+export function checkSuites(merged, onDisk = []) {
+  const disk = new Set(onDisk.map(f => (f.startsWith('tests/') ? f : `tests/${f}`)))
+  const seen = new Set()
+  const duplicates = []
+  for (const s of merged) {
+    if (seen.has(s)) duplicates.push(s)
+    seen.add(s)
+  }
+  const missing = merged.filter(s => !disk.has(s))
+  const orphans = [...disk].filter(s => !seen.has(s)).sort()
+  const problems = []
+  if (duplicates.length) problems.push(`invoked twice: ${duplicates.join(', ')}`)
+  if (missing.length) problems.push(`invoked but not on disk: ${missing.join(', ')}`)
+  if (orphans.length) problems.push(`on disk but never invoked — a dropped suite: ${orphans.join(', ')}`)
+  return { ok: problems.length === 0, duplicates, missing, orphans, problems }
+}
+
+/**
+ * What each side alone would have lost — the argument for computing a union at all.
+ * Returned so a resolver can PRINT it: a merge that silently did the right thing teaches nobody
+ * that the wrong thing was available.
+ */
+export function unionReport(ours, theirs) {
+  const onlyOurs = ours.filter(s => !theirs.includes(s))
+  const onlyTheirs = theirs.filter(s => !ours.includes(s))
+  const merged = unionSuites(ours, theirs)
+  return {
+    merged,
+    onlyOurs,
+    onlyTheirs,
+    // The trap: equal counts, different contents. Neither number is wrong and a suite is missing.
+    equalCountsDifferentSets: ours.length === theirs.length && (onlyOurs.length > 0 || onlyTheirs.length > 0),
+    supersetExists: onlyOurs.length === 0 || onlyTheirs.length === 0,
+  }
+}

--- a/tests/suite_count.mjs
+++ b/tests/suite_count.mjs
@@ -85,5 +85,81 @@ for (const rel of ['CLAUDE.md', 'README.md']) {
   ok(`${rel}: roster lists ${N} suites`, items.length === N, `roster has ${items.length}`)
 }
 
+// --- resolving the merge conflict this count creates (#387) -----------------------------------
+// The count is load-bearing, and the thing that makes it drift most is the MERGE. Every suite-
+// adding PR touches this same line, so any two of them conflict — and the obvious resolution is
+// wrong in a way nothing downstream catches.
+//
+// Fixtures below are the three real merges from one session. In all three, neither side was a
+// superset; in two, both sides declared the SAME COUNT while holding different suites.
+console.log('\nsuite union (#387)')
+{
+  const { parseSuites, renderSuites, unionSuites, checkSuites, unionReport } =
+    await import('../src/suite_union.mjs')
+
+  const script = (...names) => names.map(n => `node tests/${n}.mjs`).join(' && ')
+
+  // The real #301 ← main case: 71 vs 71, one suite each way.
+  const ours = parseSuites(script('suite_count', 'boot', 'policy_sealed_direct', 'render_states'))
+  const theirs = parseSuites(script('suite_count', 'boot', 'tripwire_setup', 'render_states'))
+  const merged = unionSuites(ours, theirs)
+
+  ok('a suite only OURS has survives the merge', merged.includes('tests/policy_sealed_direct.mjs'))
+  ok('a suite only THEIRS has survives the merge', merged.includes('tests/tripwire_setup.mjs'))
+  ok('the union is larger than either side — equal counts hid a missing suite',
+    merged.length === 5 && ours.length === 4 && theirs.length === 4)
+  ok('the spine keeps THEIRS order, so suite_count still runs first', merged[0] === 'tests/suite_count.mjs')
+  ok('an ours-only suite lands after its own predecessor, not dumped at the end',
+    merged.indexOf('tests/policy_sealed_direct.mjs') === merged.indexOf('tests/boot.mjs') + 1)
+
+  const report = unionReport(ours, theirs)
+  ok('the report names what each side alone would have lost',
+    report.onlyOurs.length === 1 && report.onlyTheirs.length === 1)
+  ok('and flags the trap explicitly: equal counts, different sets',
+    report.equalCountsDifferentSets === true && report.supersetExists === false)
+
+  // NEGATIVE CONTROL. A take-theirs resolver is what a person does by hand, and it passes every
+  // count check afterwards — the number is right and a suite is gone. State it, so the union
+  // assertions above are demonstrably not vacuous.
+  ok('NEGATIVE CONTROL — take-theirs DROPS a suite while leaving a plausible count',
+    !theirs.includes('tests/policy_sealed_direct.mjs') && theirs.length === ours.length)
+
+  // BOTH DIRECTIONS: when one side really is a superset, the union must not invent anything.
+  const sub = parseSuites(script('suite_count', 'boot'))
+  const sup = parseSuites(script('suite_count', 'boot', 'render_states'))
+  ok('a genuine superset merges to exactly itself — no phantom additions',
+    renderSuites(unionSuites(sub, sup)) === renderSuites(sup))
+  ok('and unionReport says a superset existed, so the two cases are told apart',
+    unionReport(sub, sup).supersetExists === true)
+
+  // The checks that make the resolution safe, each reachable and distinct.
+  const disk = ['suite_count.mjs', 'boot.mjs', 'policy_sealed_direct.mjs', 'tripwire_setup.mjs', 'render_states.mjs']
+  ok('a correct union passes every safety check', checkSuites(merged, disk).ok)
+  ok('a DROPPED suite is caught as an orphan — the property that matters',
+    /never invoked/.test(checkSuites(theirs, disk).problems.join(' ')))
+  ok('a suite invoked but absent from disk is caught, and named',
+    checkSuites([...merged, 'tests/ghost.mjs'], disk).missing.join() === 'tests/ghost.mjs')
+  ok('a duplicate invocation is caught', checkSuites([...merged, merged[0]], disk).duplicates.length === 1)
+  // Assert the REASON, not only the refusal: three different faults must be told apart, or the
+  // resolver reports "something is wrong" and the operator guesses which.
+  ok('the three faults produce three DIFFERENT messages',
+    new Set([
+      checkSuites(theirs, disk).problems.join(),
+      checkSuites([...merged, 'tests/ghost.mjs'], disk).problems.join(),
+      checkSuites([...merged, merged[0]], disk).problems.join(),
+    ]).size === 3)
+  // Distinct is not enough — three unhelpful-but-different strings pass that. Each message must
+  // NAME the suite at fault, because the name is the whole actionable content. Caught by mutation:
+  // degrading one message to a bare "problem" left all three distinct and the check still passed.
+  ok('each fault message names the suite at fault',
+    checkSuites(theirs, disk).problems.join().includes('policy_sealed_direct') &&
+    checkSuites([...merged, 'tests/ghost.mjs'], disk).problems.join().includes('ghost') &&
+    checkSuites([...merged, merged[0]], disk).problems.join().includes('suite_count'))
+
+  // And this repo's own list must satisfy the same checks it is asserting about.
+  ok('waggle’s real suite list passes checkSuites', checkSuites(invoked, onDisk).ok,
+    checkSuites(invoked, onDisk).problems.join('; '))
+}
+
 console.log(fails ? `\nsuite_count: ${fails} check(s) failed` : '\nall checks passed')
 process.exit(fails ? 1 : 0)

--- a/tools/merge-suites.mjs
+++ b/tools/merge-suites.mjs
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+// merge-suites.mjs — resolve the suite-count merge conflict, safely (#387).
+//
+// Run it from inside a conflicted merge. It reads BOTH sides out of the index (git stages 2 and 3),
+// computes the union, checks it against tests/ on disk, and writes package.json plus the counts and
+// rosters in CLAUDE.md, README.md and docs/GETTING_STARTED.md.
+//
+//   node tools/merge-suites.mjs            # resolve
+//   node tools/merge-suites.mjs --check     # report only, change nothing
+//
+// Why a tool: the obvious hand resolution — take one side — silently drops a working suite, and
+// nothing downstream fails, because a suite that is not invoked cannot fail. Across ten of these
+// merges in one session neither side was EVER a superset, and twice both sides declared the same
+// count while holding different suites. See src/suite_union.mjs.
+//
+// It refuses rather than guesses: no conflict, no roster, an invoked suite missing from disk, or a
+// suite on disk left uninvoked are all hard stops. Exit 0 resolved · 1 refused · 3 nothing to do.
+
+import { execFileSync } from 'node:child_process'
+import { readFileSync, writeFileSync, readdirSync, existsSync } from 'node:fs'
+import { parseSuites, renderSuites, unionSuites, checkSuites, unionReport } from '../src/suite_union.mjs'
+
+const CHECK = process.argv.includes('--check')
+const DOCS = ['CLAUDE.md', 'README.md', 'docs/GETTING_STARTED.md']
+const say = m => console.log(`merge-suites: ${m}`)
+const die = m => { console.error(`merge-suites: ${m}`); process.exit(1) }
+
+// A file that merged cleanly has no stage 2 or 3, and git says so on stderr. That is an expected
+// answer here, not a failure — so the stderr is swallowed. A tool that prints `fatal:` while
+// succeeding reads as broken, and an operator who learns to ignore its errors will ignore a real one.
+const stage = (n, path) => {
+  try { return execFileSync('git', ['show', `:${n}:${path}`], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }) }
+  catch { return null }
+}
+
+const oursPkg = stage(2, 'package.json')
+const theirsPkg = stage(3, 'package.json')
+if (!oursPkg || !theirsPkg) {
+  say('package.json is not conflicted — nothing to resolve')
+  process.exit(3)
+}
+
+const ours = parseSuites(JSON.parse(oursPkg).scripts.test)
+const theirs = parseSuites(JSON.parse(theirsPkg).scripts.test)
+const report = unionReport(ours, theirs)
+const merged = report.merged
+const N = merged.length
+
+// Say out loud what each side alone would have cost. A resolver that silently does the right thing
+// teaches nobody that the wrong thing was on offer.
+say(`ours ${ours.length} · theirs ${theirs.length} · union ${N}`)
+if (report.onlyOurs.length) say(`  only ours:   ${report.onlyOurs.join(', ')}`)
+if (report.onlyTheirs.length) say(`  only theirs: ${report.onlyTheirs.join(', ')}`)
+if (report.equalCountsDifferentSets) {
+  say('  ⚠ BOTH SIDES DECLARED THE SAME COUNT and hold different suites — taking either would have')
+  say('    dropped a suite while leaving a number that looks reconciled.')
+} else if (!report.supersetExists) {
+  say('  ⚠ neither side is a superset — taking either would have dropped a suite')
+}
+
+const onDisk = readdirSync('tests').filter(f => f.endsWith('.mjs'))
+const safety = checkSuites(merged, onDisk)
+if (!safety.ok) {
+  for (const p of safety.problems) console.error(`merge-suites:   ${p}`)
+  die('the union does not pass its own checks; nothing written')
+}
+say(`union passes: every suite exists on disk, none invoked twice, none left uninvoked`)
+
+// The roster names are not derivable from filenames — but BOTH sides carry a roster, so the delta
+// is. Take the same union across the two rosters that the suite lists just took.
+function rosterOf(text) {
+  const m = text.match(/boot ·[\s\S]*?(?=\n\n)/)
+  return m ? { block: m[0], items: m[0].split('·').map(s => s.trim()).filter(Boolean) } : null
+}
+
+if (CHECK) { say('--check: nothing was changed'); process.exit(0) }
+
+const pkg = JSON.parse(theirsPkg)
+pkg.scripts.test = renderSuites(merged)
+writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n')
+say('wrote package.json')
+
+for (const rel of DOCS) {
+  if (!existsSync(rel)) continue
+  let text = readFileSync(rel, 'utf8')
+
+  // Resolve any conflict in the doc by taking THEIRS, then repair below — the same spine choice the
+  // suite list made, so the two cannot disagree about which side led.
+  text = text.replace(/<<<<<<< HEAD\n(.*?)\n?=======\n(.*?)\n?>>>>>>> [^\n]*\n/gs, (_, __, t) => t + '\n')
+  if (text.includes('<<<<<<<')) die(`${rel}: a conflict remains that this tool did not resolve`)
+
+  const o = rosterOf(stage(2, rel) || ''), t = rosterOf(stage(3, rel) || '')
+  if (o && t) {
+    const onlyOurs = o.items.filter(x => !t.items.includes(x))
+    let block = t.block
+    for (const item of onlyOurs) {
+      const pred = o.items[o.items.indexOf(item) - 1]
+      if (!pred || !block.includes(pred)) die(`${rel}: ANCHOR MISS — no place to insert "${item}"`)
+      block = block.replace(`${pred} · `, `${pred} · ${item} · `)
+    }
+    const cur = rosterOf(text)
+    if (!cur) die(`${rel}: no roster block after resolving`)
+    text = text.replace(cur.block, block)
+    if (onlyOurs.length) say(`${rel}: spliced ${onlyOurs.length} roster entr${onlyOurs.length === 1 ? 'y' : 'ies'}`)
+  }
+
+  text = text.replace(/\b\d+ suites\b/g, `${N} suites`).replace(/fewer than \d+/g, `fewer than ${N}`)
+  writeFileSync(rel, text)
+  say(`wrote ${rel}`)
+}
+
+say(`resolved at ${N} suites — now run: node tests/suite_count.mjs`)


### PR DESCRIPTION
Closes #387.

## The conflict is structural, and the obvious fix is unsafe

Every suite-adding PR edits the same four places — the `test` script in `package.json` and the roster + count in three docs. So **any two of them conflict**, always, about something they don't actually disagree on. With 13 PRs open, that's most of the queue.

That would be friction rather than a defect if taking one side were safe. It isn't. Across **ten** of these merges in one session, **neither side was ever a superset**, and twice both sides declared the *same count* while holding different suites:

| merge | ours | theirs | only ours | only theirs |
|---|---|---|---|---|
| #365 ← base | 77 | 74 | 4 suites | `tripwire_setup` |
| #301 ← main | 71 | 71 | `policy_sealed_direct` | `tripwire_setup` |
| #304 ← base | 72 | 72 | `policy_withdraw_repost` | `tripwire_setup` |

Take either side and you **silently drop a working suite**. Nothing fails afterwards, because a suite that is not invoked cannot fail. The number looks reconciled and the coverage is gone.

## What this adds

**`src/suite_union.mjs`** — pure. Computes the union and asserts what would make it wrong: no duplicates, every invoked suite present on disk, and — the one that matters — **no suite on disk left uninvoked**, checked at resolve time rather than after. `unionReport` names what each side alone would have lost and flags the equal-counts-different-sets case explicitly, because that's the one where the number reassures you.

**`tools/merge-suites.mjs`** — runs inside a conflicted merge, reads both sides from git stages 2 and 3, writes `package.json` plus the counts and rosters. Roster names aren't derivable from filenames, but both sides carry a roster, so the delta is.

**No new suite file, on purpose** — one would add a `package.json` line and conflict with all 13 open PRs. `tests/suite_count.mjs` already owns this subject, so the tests go there. This PR is conflict-free with the entire queue.

## Verified

Unit tests are not the interesting part. **I replayed the real #301 merge from its two parents and ran the tool against the actual conflict:**

```
merge-suites: ours 71 · theirs 71 · union 72
  only ours:   tests/policy_sealed_direct.mjs
  only theirs: tests/tripwire_setup.mjs
  ⚠ BOTH SIDES DECLARED THE SAME COUNT and hold different suites — taking either would have
    dropped a suite while leaving a number that looks reconciled.
```

Its output **matches the resolution I had reached by hand** — same 72 suites, same set, **same order** — with `suite_count.mjs` green.

- **Both directions** — a genuine superset merges to exactly itself, no phantom additions, and `unionReport` tells the two cases apart.
- **Negative control** — asserts that take-theirs *does* drop a suite while leaving a plausible count, so the union checks are demonstrably not vacuous.
- **Five mutations, all detected.** One was **not** caught first time: degrading a fault message to a bare `"problem"` left the three messages distinct, so my "three different messages" check still passed. Distinct isn't enough — each message must *name* the suite at fault, which is the whole actionable content. Test strengthened, mutation re-run, now caught.
- Also fixed the tool printing `fatal:` on stderr for cleanly-merged files while succeeding. An operator who learns to ignore a tool's errors will ignore a real one.
- Full suite green, read before committing.

## Note on the deeper fix

`suite_count.mjs` already asserts `package.json` invokes every file in `tests/` and nothing else — so the list is *derivable*, and a globbing runner would delete this conflict entirely. Two things stop that being trivial and want their own issue: suite **order** is load-bearing, and the prose rosters use human-readable names whose mapping has to live somewhere. Recorded in #387 rather than smuggled in here.

Drafted with assistance from [Claude Code](https://claude.com/claude-code)