### PR TITLE
Unblock main: two unused bindings were stopping every suite from running (#397)

### DIFF
--- a/tests/control_state.mjs
+++ b/tests/control_state.mjs
@@ -719,7 +719,7 @@ const { askBudget } = await import('../src/bridge.mjs')
 
   // BOTH DIRECTIONS on the optionality: an older bridge omits the field entirely and its record must
   // still sign, or this change bricks every deployment that has not restarted yet.
-  const { consent_asks, ...withoutAsks } = buildControlState().operations
+  const { consent_asks: _omitted, ...withoutAsks } = buildControlState().operations
   let legacySigned = null
   try { legacySigned = JSON.parse((await signControlState({ ...buildControlState(), operations: withoutAsks })).content) } catch { /* null */ }
   t('#331 a record signed WITHOUT the budget is still valid — the field is additive',

--- a/tools/merge-suites.mjs
+++ b/tools/merge-suites.mjs
@@ -18,7 +18,7 @@
 
 import { execFileSync } from 'node:child_process'
 import { readFileSync, writeFileSync, readdirSync, existsSync } from 'node:fs'
-import { parseSuites, renderSuites, unionSuites, checkSuites, unionReport } from '../src/suite_union.mjs'
+import { parseSuites, renderSuites, checkSuites, unionReport } from '../src/suite_union.mjs'
 
 const CHECK = process.argv.includes('--check')
 const DOCS = ['CLAUDE.md', 'README.md', 'docs/GETTING_STARTED.md']


### PR DESCRIPTION
Closes #397. **Merge this first — nothing else can land until it does.**

`main` @ `899cb8e` is red, so the deploy runner has no CI-green commit to ship, and every open PR inherits the failure (#376 is otherwise `MERGEABLE` and shows `npm test fail` for exactly this reason).

## What was actually wrong

Two `no-unused-vars` errors. Lint runs ahead of the suites in the same `&&` chain, so **no test ran at all** — CI just says `npm test fail`, which reads like a test failure.

| where | binding | verdict |
|---|---|---|
| `tests/control_state.mjs:722` | `consent_asks` | destructuring-omit idiom — named only so the rest-spread excludes it |
| `tools/merge-suites.mjs:21` | `unionSuites` | dead import; `unionReport()` calls it internally and the tool takes `report.merged` |

I checked the second one rather than deleting it on sight — an unused import in the tool that resolves suite-count merge conflicts could just as easily have been a step someone forgot to wire up. It isn't.

For the first, I matched the convention the repo already has (`_drop` in `tests/agent_challenge.mjs`, `_omitted` in `tests/buzz_policy_runner.mjs`) rather than setting `ignoreRestSiblings`, which would relax the rule repo-wide to fix one line.

## The thing this was hiding

`docs/GETTING_STARTED.md` had drifted to a stale suite count. `tests/suite_count.mjs` already covers that file and **does** catch it — negative control, with the stale number put back deliberately:

```
FAIL docs/GETTING_STARTED.md: every stated suite count is 73 — found 72 — package.json says 73
```

So the arbiter is sound; it was simply never reached. That doc fix is **not in this PR** — on `main` the count is a self-consistent 72 across `package.json`, `CLAUDE.md`, `README.md` and `GETTING_STARTED.md`. The drift is on #376's branch, where the union takes it to 73, and it is fixed there.

**Worth a follow-up:** lint short-circuiting the suites means a one-character lint error makes the entire test suite silently not-run while CI still says `npm test fail`. A separate lint job would make "lint broke" and "a test broke" distinguishable at a glance.

## Verification

`npm run lint` exit 0. `npm test` exit 0 across all 72 suites (`&&` joiners, so exit 0 proves every suite ran).

Not substantive under the CLAUDE.md rule — a test variable, a dev tool's dead import. No delivery path, gate, key or deploy runner touched.

Drafted with assistance from [Claude Code](https://claude.com/claude-code)