### PR TITLE
The agent runtime slug is mc-claude, and a slug is not a name

### DIFF
--- a/docs/JOIN_RUNBOOK.md
+++ b/docs/JOIN_RUNBOOK.md
@@ -97,8 +97,14 @@ npm ci
 
 Join admits an identity; it does not invent one. Pick the key that will *be* the agent.
 
-If you already have one seated — `claude-jaf` is, at `~/.nvoy/desktop/claude-jaf` — use it and
+If you already have one seated — MC Claude is, at `~/.nvoy/desktop/mc-claude` — use it and
 skip to **step 3**. Its credentials are already paired, so steps 2a–2d are for a *new* agent only.
+
+The runtime slug and the agent's name are two different things. `mc-claude` is the slug: it keys the
+directory, the instance manifest and the `--instance` flag, and `runtime_manifest.mjs` holds it to
+`/^[a-z0-9][a-z0-9._-]{1,63}$/i` — so it can carry no spaces and no capitals. The name a person
+reads is the `kind:0` `display_name` (MC Claude), which is what Buzz resolves an at-word against.
+Do not set one from the other.
 
 ---
 
@@ -149,7 +155,7 @@ bunker://<pubkey>?relay=wss://…&secret=<one-time>
 
 **Do not paste that into chat, an issue, a commit, or a log.** Write it to a file the agent's
 runtime can read and nothing else can. `$AGENT_RUNTIME` below is that agent's identity root — for
-`claude-jaf` it is `~/.nvoy/desktop/claude-jaf`; a new agent gets its own directory beside it:
+`mc-claude` it is `~/.nvoy/desktop/mc-claude`; a new agent gets its own directory beside it:
 
 ```bash
 export AGENT_RUNTIME=~/.nvoy/desktop/my-agent

--- a/tests/join_request.mjs
+++ b/tests/join_request.mjs
@@ -25,7 +25,7 @@ const read = (ev, over = {}) => readJoinRequest(ev, { hivePubkey: HIVE, verify: 
 
 // ── Build: the happy path, and what it refuses to build ─────────────────────────────────────
 {
-  const ev = buildJoinRequest({ hivePubkey: HIVE, caps: ['task', 'task-relay'], purpose: 'ship the runbook', label: 'claude-jaf', createdAt: NOW })
+  const ev = buildJoinRequest({ hivePubkey: HIVE, caps: ['task', 'task-relay'], purpose: 'ship the runbook', label: 'mc-claude', createdAt: NOW })
   check(ev.kind === JOIN_REQUEST_KIND, 'a built request carries the join-request kind')
   check(ev.tags.filter(t => t[0] === 'p').length === 1, 'and names exactly one hive')
   check(ev.tags.filter(t => t[0] === 'da-cap').length === 2, 'and one tag per requested capability')


### PR DESCRIPTION
`~/.nvoy/desktop/claude-jaf` is now `~/.nvoy/desktop/mc-claude`. `JOIN_RUNBOOK.md` named the old path twice and `tests/join_request.mjs` used the old label.

The doc now also states the distinction, because getting it wrong fails silently. `runtime_manifest.mjs` holds the slug to `/^[a-z0-9][a-z0-9._-]{1,63}$/i`, so the display name "MC Claude" cannot be the slug — it has a space and a capital, and `instanceId()` calls `die('instance id must be a short stable identifier')` on it. The name a person reads is the `kind:0` `display_name`, which is what Buzz resolves an at-word against. Two registries, set independently.

## Why the rename needed care

The instance id is load-bearing:

- `claude-channel.mjs:109` rejects any record where `record.instance !== manifest.id`
- `claude-channel.mjs:68` throws `channel lock does not bind this instance`
- `instance-worker.mjs:122` filters admitted tasks through `validateAdmittedTask` inside `catch { return false }`

Renaming the manifest without the queues would have dropped 29 admitted tasks, 5 reply requests and 7 read records with **no error** — a `catch` that returns false. The local rename moved them in lockstep: 29/5/7 rewritten, 0 stale, anchor-asserted.

## Evidence

- Full suite green, **75/75**, `EXIT=0`.
- Bunker re-proved through the new paths both directions: `DRY_RUN` with the correct `EXPECT_PUBKEY` exits 0 and builds a sealed wrap; a wrong key exits 1 with `signer identity mismatch`. Same key `ad05b00e…` before and after.
- Watcher, broker and adapter restarted against the new slug and observed live: broker `draining mc-claude`, adapter `listening for mc-claude`, watcher `watching 2 relay(s) for ad05b00ee492…`.

Not proven here: the staged host config `~/.nvoy/staged/mc-claude.json` was rewritten to host paths `/var/lib/nvoy/mc-claude` and `/etc/nvoy/credentials/mc-claude.*`. If that config was ever deployed, the box-side files still carry the old names. I cannot reach the box to check, so that is an operator step, not a verified one.

Docs and tests only — exempt from the outside-review bar, but @My Dude may want the queue-continuity reasoning checked since it is the part that would have failed quietly.

Refs the runtime rename; no issue filed as this followed directly from an operator instruction.

Drafted with assistance from [Claude Code](https://claude.com/claude-code)