### PR TITLE
Scope a short RETURN ratio's explanation to this send (#402)

### DIFF
--- a/src/bridge.mjs
+++ b/src/bridge.mjs
@@ -63,7 +63,7 @@ import { PolicyRequestQueue } from './policy_request_queue.mjs'
 import { defuseRefs, defuseMarkup, quoted, renderQuarantined, renderReleased } from './render.mjs'
 import { hex as concordHex, publicChannel, openChannelWrap } from './concord_lib.mjs'
 import { thinRelaySet } from './relays.mjs'
-import { refusalLedger } from './relay_refusals.mjs'
+import { refusalLedger, explainSendRefusals } from './relay_refusals.mjs'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const ROOT = resolve(__dirname, '..')
@@ -2428,7 +2428,7 @@ function rlDropOnce(id) {
 // wherever the operator is already looking for faults. One line the first time, then counted.
 const relayRefusals = refusalLedger({ log: err })
 
-function publishWrapToRelayList(wrap, relays, mkSocket) {
+function publishWrapToRelayList(wrap, relays, mkSocket, onRefusal) {
   if (process.env.WB_STUB_SEND) return Promise.resolve(relays.length || 1)
   // All-settled-with-a-count: per-relay OK-true is the ONLY landing signal. A relay that opens but
   // never OKs is bounded by the budget, and an explicit ["OK", id, false] rejection must not read
@@ -2439,6 +2439,11 @@ function publishWrapToRelayList(wrap, relays, mkSocket) {
   // the ledger, which logs a relay's first refusal, counts the identical repeats, and speaks up
   // again if the reason changes. Nothing here reacts to a refusal; that is #346, and it cannot be
   // built on a message nobody reads.
+  //
+  // `onRefusal` is additive (#402): the ledger's view is a lifetime one, right for a periodic
+  // summary and wrong for explaining THIS call's own short ratio — a refusal from an unrelated
+  // relay on an unrelated send is not this send's story. A caller that needs to explain its own
+  // ratio collects only what this call actually saw.
   let accepted = 0
   return fanout(relays || [], {
     timeoutMs: 10000,
@@ -2454,6 +2459,7 @@ function publishWrapToRelayList(wrap, relays, mkSocket) {
             // event"]` is the healthiest answer a relay gives, and reading it as one would report
             // the working relays as the broken ones. The boolean decides; the message explains.
             relayRefusals.record({ relay: url, accepted: !!m[2], reason: m[3] })
+            if (!m[2] && typeof onRefusal === 'function') onRefusal({ relay: url, reason: m[3] })
             done()
           }
         } catch { /* non-OK frame */ }
@@ -2464,8 +2470,8 @@ function publishWrapToRelayList(wrap, relays, mkSocket) {
   })
 }
 
-function publishWrapToRelays(wrap, mkSocket) {
-  return publishWrapToRelayList(wrap, PUB.relays || [], mkSocket)
+function publishWrapToRelays(wrap, mkSocket, onRefusal) {
+  return publishWrapToRelayList(wrap, PUB.relays || [], mkSocket, onRefusal)
 }
 
 // --- signed owner-control state (#67 / #206) -------------------------------------------------
@@ -2983,7 +2989,13 @@ async function returnLaneSend(toHex, descriptor, meta, publish = publishWrapToRe
       return 0
     }
     const relays = recipientRelays ? recipientRelays.length : (PUB.relays || []).length
-    const publisher = recipientRelays ? (wrap) => publishWrapToRelayList(wrap, recipientRelays) : publish
+    // Collected fresh per call (#402): this send's own refusals, not the ledger's lifetime view —
+    // see publishWrapToRelayList. Extra args on an injected test `publish` are simply ignored.
+    const sendRefusals = []
+    const collectRefusal = (r) => sendRefusals.push(r)
+    const publisher = recipientRelays
+      ? (wrap) => publishWrapToRelayList(wrap, recipientRelays, undefined, collectRefusal)
+      : (wrap) => publish(wrap, undefined, collectRefusal)
     // A3 §2.5: the seal/wrap construction and the key both live in nostr_egress.mjs. `descriptor`
     // is {template, slots} — there is no parameter here that could carry a composed sentence.
     const { wrap, accepted, bytes } = await sealAndWrap({ template: descriptor.template, to: toHex, slots: descriptor.slots }, publisher)
@@ -2998,12 +3010,21 @@ async function returnLaneSend(toHex, descriptor, meta, publish = publishWrapToRe
     if (traceSource && accepted >= 1) markLatency(traceSource, 'return.published')
     if (accepted < 1)
       err(`RETURN 0/${relays} -> ${toHex.slice(0, 12)}…: seal reached NO relay — NOT marked sent, will re-carry (wrap ${wrap.id.slice(0, 12)}…)`)
-    else
+    else {
       // A short ratio is the moment somebody asks which relay and why, so the answer goes on the
       // same line rather than in a separate one they would have to correlate by timestamp. Only
       // when it IS short: appending "all relays fine" to every send is noise, and noise is what
       // stops the short ones being noticed.
-      log(`RETURN ${accepted}/${relays} -> ${toHex.slice(0, 12)}…: sealed ${bytes}B (wrap ${wrap.id.slice(0, 12)}…)` + (accepted < relays && relayRefusals.summary() ? ` — ${relayRefusals.summary()}` : ''))
+      //
+      // The explanation is THIS call's own refusals (#402), never relayRefusals.summary() — that
+      // ledger is a lifetime view across every relay this process has ever dialed, on every send,
+      // and a return-lane send normally dials a *different* relay set per recipient (their own
+      // kind:10050 list). Printing the ledger's global summary here blamed relays that were never
+      // part of this send; a short ratio with no recorded refusal (a timeout) now correctly prints
+      // no explanation rather than an unrelated one.
+      const explanation = accepted < relays ? explainSendRefusals(sendRefusals) : null
+      log(`RETURN ${accepted}/${relays} -> ${toHex.slice(0, 12)}…: sealed ${bytes}B (wrap ${wrap.id.slice(0, 12)}…)` + (explanation ? ` — ${explanation}` : ''))
+    }
     return accepted
   } catch (e) { err(`return lane: seal/send failed: ${e.message}`); return 0 }
 }

--- a/src/relay_refusals.mjs
+++ b/src/relay_refusals.mjs
@@ -108,3 +108,25 @@ export function refusalLedger({ cap = 64, log = () => {} } = {}) {
     reset() { rows.clear() },
   }
 }
+
+/// Explain ONE fanout call's refusals — never the ledger's lifetime view (#402). `summary()` above
+/// answers "what has this relay ever done", which is the right question for a periodic operator
+/// report and the wrong one for "why was THIS send short": a relay that refused hours ago, on a
+/// different send, to a different relay set, is unrelated history, and printing it next to an
+/// unrelated short ratio is the #374 misattribution moved one level up — the reader blames a relay
+/// that was never dialed.
+///
+/// Takes exactly what the caller collected from its own fanout call, so it is scoped by
+/// construction: no relay it never talked to, no refusal from a different send. First reason per
+/// relay only — a caller that wants the ledger's fuller history has `summary()`.
+export function explainSendRefusals(refusals) {
+  if (!refusals || !refusals.length) return null
+  const byRelay = new Map()
+  for (const r of refusals) {
+    const relay = String(r?.relay || '')
+    if (!relay || byRelay.has(relay)) continue
+    byRelay.set(relay, String(r?.reason ?? '') || '(no reason given)')
+  }
+  if (!byRelay.size) return null
+  return [...byRelay].map(([relay, reason]) => `${relay}: ${reason}`).join(' · ')
+}

--- a/tests/relay_refusal.mjs
+++ b/tests/relay_refusal.mjs
@@ -33,10 +33,12 @@ process.env.WB_NO_BOOT = '1'
 process.env.FORWARD_MODE = 'dryrun'
 process.env.SEEN_PATH = join(dir, 'seen.log')
 process.env.PUB_WATERMARK_PATH = join(dir, 'watermark')
+process.env.SEND_JOURNAL_PATH = join(dir, 'send-journal.log')
+process.env.BUZZ_PRIVATE_KEY = 'c'.repeat(64)   // returnLaneSend refuses to seal with no bridge key
 delete process.env.WB_STUB_SEND          // the stub short-circuits the publisher entirely
 
 const { refusalKey, refusalLedger, explainSendRefusals } = await import('../src/relay_refusals.mjs')
-const { publishWrapToRelayList, relayRefusals } = await import('../src/bridge.mjs')
+const { publishWrapToRelayList, relayRefusals, returnLaneSend, PUB } = await import('../src/bridge.mjs')
 
 let fails = 0
 const ok = (n, c) => { console.info(`${c ? 'ok  ' : 'FAIL'} — ${n}`); if (!c) fails++ }
@@ -263,6 +265,57 @@ const ok = (n, c) => { console.info(`${c ? 'ok  ' : 'FAIL'} — ${n}`); if (!c) 
   ok('a relay that never answers contributes no accept', accepted === 0)
   ok('  …onRefusal was never called — a timeout is not a refusal, in this send or any other',
     collected.length === 0 && explainSendRefusals(collected) === null)
+}
+
+// ── #402 gap: `returnLaneSend` itself, not the two functions it calls in isolation ────────────
+// Every assertion above drives `explainSendRefusals` or `publishWrapToRelayList` directly. The
+// line that actually shipped the bug lives one level up — the RETURN log statement INSIDE
+// `returnLaneSend` — and nothing above calls that function at all, so reverting only that one
+// line back to `relayRefusals.summary()` would leave every prior assertion green. This drives the
+// real function with an injected publish, reads the real console line it wrote, and checks it the
+// same both-directions way: named when it should be, silent about unrelated history when it
+// should be.
+{
+  const savedRelays = PUB.relays
+  PUB.relays = ['wss://this-send-a.invalid', 'wss://this-send-b.invalid']
+
+  relayRefusals.reset()
+  // Stands in for "a different relay refused a different send, hours ago" — still live in the
+  // shared ledger at the moment THIS send runs.
+  relayRefusals.record({ relay: 'wss://stale-history.invalid', accepted: false, reason: 'pow: 28 bits needed. (12)' })
+
+  const testPublish = async (_wrap, _mkSocket, onRefusal) => {
+    if (typeof onRefusal === 'function') onRefusal({ relay: 'wss://this-send-a.invalid', reason: 'blocked: not on the allow list' })
+    return 1   // 1 of the 2 configured relays — a short ratio, so the RETURN line explains itself
+  }
+
+  const said = []
+  const realLog = console.log, realErr = console.error
+  console.log = (...a) => { said.push(a.join(' ')) }
+  console.error = (...a) => { said.push(a.join(' ')) }
+  let accepted
+  try {
+    accepted = await returnLaneSend(
+      'a'.repeat(64),
+      { template: 'return_carry', slots: { mention: 'someone', why: 'mention', body: 'hello there', author: null } },
+      {},
+      testPublish,
+    )
+  } finally {
+    console.log = realLog; console.error = realErr
+    PUB.relays = savedRelays
+  }
+
+  ok('returnLaneSend reports the short accept count unchanged', accepted === 1)
+  const line = said.find(l => l.includes('RETURN'))
+  ok('returnLaneSend logged a RETURN line at all — a test that captured nothing has proven nothing',
+    !!line)
+  ok('POSITIVE — the RETURN line names THIS send\'s own refusing relay, with its own reason',
+    !!line && /this-send-a\.invalid: blocked: not on the allow list/.test(line))
+  ok('NEGATIVE (load-bearing) — it does NOT fall back to the shared ledger\'s unrelated history, ' +
+    'live in that ledger at the moment this send ran; reverting the RETURN line inside ' +
+    'returnLaneSend back to relayRefusals.summary() makes this assertion fail',
+    !!line && !/stale-history\.invalid/.test(line))
 }
 
 console.info(`\n${fails ? `RELAY REFUSAL FAIL — ${fails}` : 'RELAY REFUSAL PASS — the reason survives, the repeat is quiet, and a change speaks'}`)

--- a/tests/relay_refusal.mjs
+++ b/tests/relay_refusal.mjs
@@ -35,7 +35,7 @@ process.env.SEEN_PATH = join(dir, 'seen.log')
 process.env.PUB_WATERMARK_PATH = join(dir, 'watermark')
 delete process.env.WB_STUB_SEND          // the stub short-circuits the publisher entirely
 
-const { refusalKey, refusalLedger } = await import('../src/relay_refusals.mjs')
+const { refusalKey, refusalLedger, explainSendRefusals } = await import('../src/relay_refusals.mjs')
 const { publishWrapToRelayList, relayRefusals } = await import('../src/bridge.mjs')
 
 let fails = 0
@@ -187,6 +187,82 @@ const ok = (n, c) => { console.info(`${c ? 'ok  ' : 'FAIL'} — ${n}`); if (!c) 
   // Both directions: without this, "resets on accept" is indistinguishable from never suppressing.
   ok('  …and suppression still holds WITHIN the new episode — this is not "log everything"',
     L.record({ relay: R, accepted: false, reason: 'pow: 28 bits needed. (11)' }) === 'suppressed' && lines.length === 2)
+}
+
+// ── #402: a short ratio is explained by THIS send, never by the ledger's lifetime view ────────
+// The ledger view (`summary()`) is right for a periodic report and wrong for "why was this send
+// short": a relay that refused on a different send, to a different relay set, is unrelated history.
+// The negative control matters more than the positive one — a fix that explains nothing passes the
+// positive half too, so both must hold: this send's own reason is named, and history's is not.
+{
+  ok('a relay with no refusals in this send explains to null — nothing to blame, so nothing is said',
+    explainSendRefusals([]) === null && explainSendRefusals(null) === null)
+  ok('one refusal is named with its reason',
+    explainSendRefusals([{ relay: 'wss://a.invalid', reason: 'pow: 28 bits needed. (12)' }]) ===
+    'wss://a.invalid: pow: 28 bits needed. (12)')
+  ok('  …a second relay from the SAME send is named alongside it, first reason kept if repeated',
+    explainSendRefusals([
+      { relay: 'wss://a.invalid', reason: 'pow: 28 bits needed. (12)' },
+      { relay: 'wss://b.invalid', reason: 'blocked: not on the allow list' },
+      { relay: 'wss://a.invalid', reason: 'pow: 28 bits needed. (9)' },
+    ]) === 'wss://a.invalid: pow: 28 bits needed. (12) · wss://b.invalid: blocked: not on the allow list')
+}
+{
+  // THE PAIRED HALF, end to end through the real publisher. `relayRefusals` (the shared ledger) is
+  // seeded with an UNRELATED relay's refusal from a prior send, standing in for "nos.lol refused
+  // hours ago". A fresh send then goes to two DIFFERENT relays, neither of them the seeded one.
+  const made = []
+  const mkSocket = (url) => {
+    const h = {}
+    const s = {
+      url, on(ev, fn) { (h[ev] ||= []).push(fn); return this }, send() {}, close() {},
+      emit(ev, ...a) { for (const fn of h[ev] || []) fn(...a) },
+      frame(o) { this.emit('message', { toString: () => JSON.stringify(o) }) },
+    }
+    made.push(s)
+    return s
+  }
+
+  relayRefusals.reset()
+  relayRefusals.record({ relay: 'wss://stale-history.invalid', accepted: false, reason: 'pow: 28 bits needed. (12)' })
+
+  const wrap = { id: 'e'.repeat(64), kind: 1059, content: 'x', tags: [], pubkey: 'b'.repeat(64), created_at: 1, sig: 'c'.repeat(128) }
+  const RELAYS = ['wss://this-send-a.invalid', 'wss://this-send-b.invalid']
+  const collected = []
+  const p = publishWrapToRelayList(wrap, RELAYS, mkSocket, (r) => collected.push(r))
+  made[0].emit('open'); made[1].emit('open')
+  made[0].frame(['OK', wrap.id, false, 'blocked: not on the allow list'])
+  made[1].frame(['OK', wrap.id, true, ''])
+  const accepted = await p
+  ok('the send is short (1 of 2), same as before onRefusal existed', accepted === 1)
+
+  const explanation = explainSendRefusals(collected)
+  ok('POSITIVE — the relay that refused THIS send is named, with its own reason',
+    /this-send-a\.invalid: blocked: not on the allow list/.test(explanation))
+  ok('NEGATIVE (load-bearing) — the relay that never saw this send is NOT named, even though the ' +
+    'shared ledger still remembers it refusing earlier — a fix that explains nothing would pass the ' +
+    'POSITIVE assertion above by accident, so this is the one that catches it',
+    !/stale-history\.invalid/.test(String(explanation)))
+  ok('  …and the accepting relay from this send is not named as a refusal either',
+    !/this-send-b\.invalid/.test(String(explanation)))
+}
+{
+  // A timeout in this send has no reason (matches the ledger's own rule above) — onRefusal must not
+  // invent one, so a short ratio caused purely by silence explains to null, not to stale history.
+  const made = []
+  const mkSocket = (url) => {
+    const h = {}
+    const s = { url, on(ev, fn) { (h[ev] ||= []).push(fn); return this }, send() {}, close() {}, emit(ev, ...a) { for (const fn of h[ev] || []) fn(...a) } }
+    made.push(s); return s
+  }
+  relayRefusals.reset()
+  relayRefusals.record({ relay: 'wss://stale-history.invalid', accepted: false, reason: 'pow: 28 bits needed. (12)' })
+  const wrap = { id: 'f'.repeat(64), kind: 1059, content: 'x', tags: [], pubkey: 'b'.repeat(64), created_at: 1, sig: 'c'.repeat(128) }
+  const collected = []
+  const accepted = await publishWrapToRelayList(wrap, ['wss://silent-this-send.invalid'], mkSocket, (r) => collected.push(r))
+  ok('a relay that never answers contributes no accept', accepted === 0)
+  ok('  …onRefusal was never called — a timeout is not a refusal, in this send or any other',
+    collected.length === 0 && explainSendRefusals(collected) === null)
 }
 
 console.info(`\n${fails ? `RELAY REFUSAL FAIL — ${fails}` : 'RELAY REFUSAL PASS — the reason survives, the repeat is quiet, and a change speaks'}`)


### PR DESCRIPTION
- **fix: scope a short RETURN ratio's explanation to this send (#402)**
- **test: cover returnLaneSend's own RETURN log line (#402)**

<!--
Delete any section that does not apply. The Verification section is the one that matters
most here — see CONTRIBUTING.md.
-->

## What this changes

<!-- One or two sentences. What is different afterwards? -->

Closes #

## Why

<!-- What went wrong, or would go wrong, without this? If a guard is being added, name the
     failure it is guarding against. -->

## Verification

<!-- How would we know if this were wrong? Be specific; "tests pass" on its own is not an
     answer, because every real bug in this project has been invisible to a test that ran. -->

- [ ] `npm test` — exit 0
- [ ] `npm run lint` — exit 0
- [ ] **Negative control run:** I broke the new check on purpose and watched it fail
      <!-- If this PR adds a guard or an alarm, say what you did and what it printed.
           If it adds none, say "n/a — no new guard". -->
- [ ] Anything I could **not** verify is stated below

<!-- What you could not check, and why. This is not a confession, it is part of the result. -->

## Risk

<!-- Behaviour changes? Config schema? Wire format? Anything a deployed box would notice?
     If the answer is "none", say so explicitly — a reviewer should not have to infer it. -->

- [ ] No secrets, keys, tokens, or host addresses in the diff (hosts referred to by role)
- [ ] Shipped vs designed is stated accurately, and not blurred
