### PR TITLE
A refusing deploy tick fails a named check instead of killing the suite (#378)

### DIFF
--- a/tests/deploy_runner.mjs
+++ b/tests/deploy_runner.mjs
@@ -85,6 +85,35 @@ catch {
   process.exit(3)
 }
 
+// #378: DEPLOYED_SHA is the watermark a tick writes only when it is satisfied, so every read of
+// it below is a read of a file a REFUSING tick deliberately did not write. A bare readFileSync
+// turns that refusal into an uncaught ENOENT: the suite dies on the spot, printing a stack trace
+// with no check name, no `N check(s) failed` summary, and none of the runner's own output — so
+// the one thing a red run must say, WHY the tick refused, is the one thing it does not say. The
+// remaining cases never run either, including the NEGATIVE CONTROL that is the only check able to
+// tell a working no-op gate from a runner that skips everything.
+//
+// Report the absence instead, carrying the tick's output, and return a value no sha and no
+// content regex can match. The assertion is unchanged and absence is still a failure — it is now
+// a legible one, and the checks after it still run.
+const readOrReport = (path, tick) => {
+  if (existsSync(path)) return readFileSync(path, 'utf8')
+  console.error(`  ↳ ${path} does not exist. The runner tick that should have written it said:`)
+  console.error(((tick && tick.out) || '(no output captured)').replace(/^/gm, '      '))
+  return ''
+}
+
+// That reporter only ever fires on a red run, so prove both of its directions on every run: it
+// must hand back real content when the file is there, and must not merely swallow the absence.
+const probe = mkdtempSync(join(tmpdir(), 'wb-runner-probe-'))
+writeFileSync(join(probe, 'present'), 'a-sha\n')
+check(readOrReport(join(probe, 'present'), { out: '' }).trim() === 'a-sha',
+  'watermark reader returns file content when the file is there')
+console.log('  (the next two lines are this suite exercising its own absence reporter — not a failure)')
+check(readOrReport(join(probe, 'absent'), { out: 'stub tick output' }) === '',
+  'watermark reader reports an absent file instead of throwing ENOENT and killing the suite')
+rmSync(probe, { recursive: true, force: true })
+
 const work = mkdtempSync(join(tmpdir(), 'wb-runner-'))
 // One hub clone shared across cases (the runner only reads + detaches within it).
 const hub = join(work, 'hub')
@@ -290,7 +319,7 @@ try {
   check(docsTick.code === 0, 'docs-only commit -> exit 0')
   check(!existsSync(nm), 'docs-only commit -> lane NOT restarted')
   check(/no shipped files changed/.test(docsTick.out), 'docs-only -> says why it skipped, never silently')
-  check(readFileSync(join(nt, 'DEPLOYED_SHA'), 'utf8').trim() === DOCS_SHA,
+  check(readOrReport(join(nt, 'DEPLOYED_SHA'), docsTick).trim() === DOCS_SHA,
     'docs-only -> SHA still recorded, so the next tick is not re-evaluated')
   check(/verified/.test(docsTick.out), 'docs-only -> tree still VERIFIED, not merely assumed')
 
@@ -304,7 +333,7 @@ try {
   const policyDocs = tick(policyTree, DOCS_SHA, policyMarker, { WB_CONFIG_VERIFY_CMD: 'false' })
   check(policyDocs.code === 1, 'docs-only with incomplete policy -> exit 1')
   check(/policy is incomplete/.test(policyDocs.out), 'docs-only incomplete policy -> loud alarm')
-  check(readFileSync(join(policyTree, 'DEPLOYED_SHA'), 'utf8').trim() === TARGET,
+  check(readOrReport(join(policyTree, 'DEPLOYED_SHA'), policyDocs).trim() === TARGET,
     'docs-only incomplete policy -> old DEPLOYED_SHA retained for retry')
 
   // NEGATIVE CONTROL. The checks above pass just as happily if the gate skipped everything
@@ -315,7 +344,7 @@ try {
   check(codeTick.code === 0, 'NEGATIVE CONTROL — shipped-file change -> exit 0')
   check(existsSync(nm), 'NEGATIVE CONTROL — shipped-file change DOES restart the lane')
   check(!/no shipped files changed/.test(codeTick.out), 'NEGATIVE CONTROL — did not take the no-op path')
-  check(/\/\/ shipped change/.test(readFileSync(join(nt, 'src', 'log.mjs'), 'utf8')),
+  check(/\/\/ shipped change/.test(readOrReport(join(nt, 'src', 'log.mjs'), codeTick)),
     'NEGATIVE CONTROL — the new code actually reached the tree')
 
   // #104: "already current" is also a live health check. A box-side routing-policy
@@ -327,7 +356,7 @@ try {
   check(currentBadPolicy.code === 1, 'already-current with incomplete policy -> exit 1')
   check(/policy is incomplete/.test(currentBadPolicy.out), 'already-current incomplete policy -> loud alarm')
   check(!existsSync(nm), 'already-current incomplete policy -> lane NOT restarted')
-  check(readFileSync(join(nt, 'DEPLOYED_SHA'), 'utf8').trim() === CODE_SHA,
+  check(readOrReport(join(nt, 'DEPLOYED_SHA'), currentBadPolicy).trim() === CODE_SHA,
     'already-current incomplete policy -> last verified SHA is retained')
   const currentBadPolicyAgain = tick(nt, CODE_SHA, nm, { WB_CONFIG_VERIFY_CMD: 'false' })
   check(currentBadPolicyAgain.code === 1 && /will re-alarm next tick/.test(currentBadPolicyAgain.out),


### PR DESCRIPTION
Refs #378. **Does not close it** — I could not reproduce the nondeterminism, and this changes nothing that would make it stop.

## Reproduction: INCONCLUSIVE, 85 runs

| how | runs | failures |
|---|---|---|
| full `npm test`, sequential | 16 | 0 |
| `deploy_runner.mjs`, 4 concurrent | 48 | 0 |
| `deploy_runner.mjs`, 6 concurrent + saturating CPU load | 6 | 0 |
| `deploy_runner.mjs` under constant `git commit` in the source repo | 15 | 0 |

The last row tests the "found while rebasing #359" angle: the suite clones the repo once and then works only inside that clone, so moving HEAD underneath it does nothing. Disproven.

One `npm test` did go red during that work, in `tests/deploy_verify.mjs` (`✗ clean tree passes`, `✗ clean tree reports OK summary`) — my own `git commit` landing mid-run under a suite that reads REPO's `HEAD` live. My interference, not the flake, and a different file.

So: the flake is unresolved. Not a clock, not an ordering I can name, not a shared temp path — every suite's `mkdtemp` prefix is distinct and nothing collides with `wb-runner-*`.

## What is reproducible

`DEPLOYED_SHA` is the watermark a tick writes **only when it is satisfied**. Every read of it in this suite is therefore a read of a file a *refusing* tick deliberately did not write, and four of them were bare `readFileSync`. Delete the file on purpose before line 293 and you get the reported error verbatim:

```
  ✓ docs-only -> says why it skipped, never silently
node:fs:442
Error: ENOENT: no such file or directory, open '/var/folders/.../T/wb-runner-HFdF4H/tree-noop/DEPLOYED_SHA'
    at file:///.../tests/deploy_runner.mjs:294:9
```

62 lines, dead at check 62 of 79. No check name. No `N check(s) failed` summary. **None of the runner's output**, so the one question a red run has to answer — why did the tick refuse — is the one it cannot. And the cases after it never execute, including the NEGATIVE CONTROL block, which is the only check that can tell a working no-op gate from a runner that skips everything. That is why #378 has a symptom and no cause.

## The change

`readOrReport()` reports the absence, prints the tick's own transcript, and returns a value no sha and no content regex can match. Applied to the four reads that can hit an absent file.

Nothing is loosened: the assertions are unchanged, an absent watermark is still a failed check, the exit code is still 1. What changes is that the run says which check failed, what the runner said, and keeps going.

Same injection after the change:

```
  ↳ /var/folders/.../T/wb-runner-wonT9o/tree-noop/DEPLOYED_SHA does not exist. The runner tick that should have written it said:
      deploy-runner[read] target 039411d (…); deployed 8971567…
      deploy-runner[read] no shipped files changed between 8971567 and 039411d — recording without restarting
      == OK: all 164/164 shipped files match 039411d ==
      deploy-runner[read] no-op deploy OK — … already matches 039411d, verified, lane untouched
  ✗ docs-only -> SHA still recorded, so the next tick is not re-evaluated
  …
deploy_runner: 1 check(s) failed
```

exit 1, and 16 further checks still ran — the whole NEGATIVE CONTROL block among them. On the next occurrence of #378 that transcript is the diagnosis: here it says the runner *did* record the watermark, so something removed it afterwards, which is a different bug from the runner refusing to write it.

The reporter only ever fires on a red run, so both its directions are asserted on every run: content returned when the file is there, absence reported when it is not.

## Evidence

- `npm test`: 83 suites green on this base (main advanced from 82 to 83 while this was in flight; rebased onto b043454 and re-run).
- Post-change: 10 consecutive full `npm test` runs, 1 red — `deploy_verify.mjs`, caused by my concurrent commit as described above; 9 green, and `deploy_runner.mjs` green in all 10.
- Negative control: run on the final commit, output above. `eslint` clean.

## Review

Worth a second pair of eyes on whether converting a thrown ENOENT into a failed check reads as loosening. My argument that it is not: the condition still fails, still exits 1, and strictly *more* checks execute on a bad run than before. If that argument is wrong, the change should not land.

Drafted with assistance from [Claude Code](https://claude.com/claude-code)
