### PR TITLE
fix: derive the mention word boundary from the mention alphabet (#408)

### DIFF
--- a/console/task-route-mention.mjs
+++ b/console/task-route-mention.mjs
@@ -11,12 +11,25 @@ export const TASK_ROUTE_MENTION_MAX = 32
 // which is a fan-out, not a route. Compared case-folded.
 const RESERVED = new Set(['everyone', 'here', 'channel', 'all'])
 
+// THE ALPHABET, written once (#408). Everything below derives from this string, and so does the
+// matcher's word boundary in scanReturnLane. That is the whole point of hoisting it: the boundary
+// `(?![\w-])` used to be correct only because the grammar was the slug alphabet `[a-z0-9_-]`, so
+// every admissible character was already in `\w` or was `-` — the boundary class and the grammar
+// were THE SAME SET. #404 widened the grammar and left the boundary alone, and the invariant broke
+// silently: a route named `Dr` was carried `@Dr. Watson`, because `.` ends `\w` and so looked like
+// the end of the name. Two classes that must agree must not be two literals.
+//
+// The separator is deliberately NOT in here — it is added for the allowlist and withheld from the
+// boundary, which is the one real difference between the two. A space may appear INSIDE a mention
+// and must not terminate it; every other admissible character must.
+const MENTION_ALPHABET = "\\p{L}\\p{N}_.'\\-"
+
 // Allowlist, one character at a time — the whole point is that nothing has to be enumerated as
 // dangerous. A control character, a newline, a NBSP, a zero-width space and a second `@` are all
 // refused because none of them is a letter, a number, or one of `_ - . '`. Written as four small
 // checks rather than one shape regex on purpose: each fault gets its own sentence, and a class
 // nobody can read is a class nobody can check.
-const ALLOWED_CHAR = /[\p{L}\p{N}_.'\- ]/u
+const ALLOWED_CHAR = new RegExp(`[${MENTION_ALPHABET} ]`, 'u')
 const STARTS_WELL = /^[\p{L}\p{N}]/u
 
 const codepoint = ch => `U+${ch.codePointAt(0).toString(16).toUpperCase().padStart(4, '0')}`
@@ -50,3 +63,29 @@ export function taskRouteMention(value) {
 // The COMPARISON key. Folded the same way the matcher's `i` flag folds, so `@MC Claude` and
 // `@mc claude` are one route rather than two rows that both fire.
 export const taskRouteMentionKey = value => String(value == null ? '' : value).toLowerCase()
+
+// THE MATCHER (#408). Lives here, next to the alphabet it depends on, rather than as a regex
+// literal in scanReturnLane — the defect this replaces was precisely those two drifting apart.
+//
+// The trailing lookahead says "the name has not ended here". It is the alphabet MINUS the
+// separator: any character that may appear inside a mention would mean the at-word in the body is
+// a longer name than this route, and only a space is exempt because a space may be interior.
+// Keeping `\p{L}`/`\p{N}` in the class also keeps every ASCII letter and digit that `\w` used to
+// contribute, which is what still stops a route named `every` matching `@everyone` and `chan`
+// matching `@channel` — the one direction the old boundary got right.
+//
+// There is deliberately no LEADING boundary. Buzz writes the at-word at a word start, and adding
+// one would be a behaviour change beyond this fix; `mail@Dennis` matching is pre-existing and
+// belongs to whoever revisits it.
+const RE_ESCAPE = /[.*+?^${}()|[\]\\]/g
+export function taskRouteMentionMatcher(mention) {
+  const m = String(mention == null ? '' : mention).replace(/^@/, '')
+  if (!m) return null
+  return new RegExp(`@${m.replace(RE_ESCAPE, '\\$&')}(?![${MENTION_ALPHABET}])`, 'iu')
+}
+
+// Does this body name this mention? The one question scanReturnLane actually asks.
+export function taskRouteMentioned(body, mention) {
+  const re = taskRouteMentionMatcher(mention)
+  return !!re && re.test(String(body == null ? '' : body))
+}

--- a/src/bridge.mjs
+++ b/src/bridge.mjs
@@ -48,7 +48,7 @@ import { fileURLToPath } from 'node:url'
 // Extracted leaf modules (#154). Each is dependency-free of config and ambient state, which is why
 // these four came out first — the split is staged, not big-bang.
 import { LANE_IDS, LANES, RELEASED } from './lanes.mjs'   // the trust gradient's one source (#282)
-import { taskRouteMention, taskRouteMentionProblem, taskRouteMentionKey } from './task_route_mention.mjs'   // #404
+import { taskRouteMention, taskRouteMentionProblem, taskRouteMentionKey, taskRouteMentioned } from './task_route_mention.mjs'   // #404, #408
 import { log, err } from './log.mjs'
 import { markLatency } from './latency.mjs'
 import { durableSet, durableQueue } from './stores.mjs'
@@ -3436,7 +3436,9 @@ async function scanReturnLane(msgs, opts = {}) {
       const boundUnique = r.authors.some(a => a === from && !PUB.sharedAuthorKeys.has(a))
       if (from === r.npub_hex || boundUnique || agentAuthoredBy(m.id) === r.npub_hex) continue
       const mentioned = ptags.includes(r.npub_hex) ||
-        (!r.dynamic && !!r.mention && new RegExp('@' + r.mention.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '(?![\\w-])', 'i').test(body))
+        // #408: the boundary is derived from the mention alphabet in task_route_mention.mjs, not
+        // restated here. `(?![\w-])` was correct only while the grammar was the slug alphabet.
+        (!r.dynamic && !!r.mention && taskRouteMentioned(body, r.mention))
       if (!mentioned && !repliedTo) continue
       const why = repliedTo && !mentioned ? 'reply' : 'mention'
       let descriptor

--- a/src/task_route_mention.mjs
+++ b/src/task_route_mention.mjs
@@ -6,11 +6,13 @@
 // src/lanes.mjs ↔ console/routing-model.mjs.
 //
 // What it replaces, and why. Both halves used to require /^[a-z0-9][a-z0-9_-]{0,31}$/ and
-// lowercase the value before storing it. The matcher (bridge.mjs, scanReturnLane) builds
-// `new RegExp('@' + mention + '(?![\\w-])', 'i')` and runs it against the raw channel body, and
-// Buzz writes the at-word from the member's `display_name` — so the body holds `@MC Claude` or
-// `@My Dude`, with a space and a capital. Every value that grammar accepted failed to match, and
-// every value that would have matched was refused. There was no working input.
+// lowercase the value before storing it. The matcher (bridge.mjs, scanReturnLane) runs against the
+// raw channel body, and Buzz writes the at-word from the member's `display_name` — so the body
+// holds `@MC Claude` or `@My Dude`, with a space and a capital. A SPACED name was therefore
+// unreachable: the grammar refused it at the form, and no value the grammar accepted could contain
+// the space needed to match. (A single-token name such as `codex` or `Dennis` did work under the
+// old grammar — the original framing in #404 overstated this as "no working input existed", which
+// is corrected here because `docs/` inherits this header.)
 //
 // `return_lane` never had the restriction and has always held spaced names, so the widening here
 // is the two halves agreeing with the mechanism, not a new capability.
@@ -26,12 +28,25 @@ export const TASK_ROUTE_MENTION_MAX = 32
 // which is a fan-out, not a route. Compared case-folded.
 const RESERVED = new Set(['everyone', 'here', 'channel', 'all'])
 
+// THE ALPHABET, written once (#408). Everything below derives from this string, and so does the
+// matcher's word boundary in scanReturnLane. That is the whole point of hoisting it: the boundary
+// `(?![\w-])` used to be correct only because the grammar was the slug alphabet `[a-z0-9_-]`, so
+// every admissible character was already in `\w` or was `-` — the boundary class and the grammar
+// were THE SAME SET. #404 widened the grammar and left the boundary alone, and the invariant broke
+// silently: a route named `Dr` was carried `@Dr. Watson`, because `.` ends `\w` and so looked like
+// the end of the name. Two classes that must agree must not be two literals.
+//
+// The separator is deliberately NOT in here — it is added for the allowlist and withheld from the
+// boundary, which is the one real difference between the two. A space may appear INSIDE a mention
+// and must not terminate it; every other admissible character must.
+const MENTION_ALPHABET = "\\p{L}\\p{N}_.'\\-"
+
 // Allowlist, one character at a time — the whole point is that nothing has to be enumerated as
 // dangerous. A control character, a newline, a NBSP, a zero-width space and a second `@` are all
 // refused because none of them is a letter, a number, or one of `_ - . '`. Written as four small
 // checks rather than one shape regex on purpose: each fault gets its own sentence, and a class
 // nobody can read is a class nobody can check.
-const ALLOWED_CHAR = /[\p{L}\p{N}_.'\- ]/u
+const ALLOWED_CHAR = new RegExp(`[${MENTION_ALPHABET} ]`, 'u')
 const STARTS_WELL = /^[\p{L}\p{N}]/u
 
 const codepoint = ch => `U+${ch.codePointAt(0).toString(16).toUpperCase().padStart(4, '0')}`
@@ -65,3 +80,29 @@ export function taskRouteMention(value) {
 // The COMPARISON key. Folded the same way the matcher's `i` flag folds, so `@MC Claude` and
 // `@mc claude` are one route rather than two rows that both fire.
 export const taskRouteMentionKey = value => String(value == null ? '' : value).toLowerCase()
+
+// THE MATCHER (#408). Lives here, next to the alphabet it depends on, rather than as a regex
+// literal in scanReturnLane — the defect this replaces was precisely those two drifting apart.
+//
+// The trailing lookahead says "the name has not ended here". It is the alphabet MINUS the
+// separator: any character that may appear inside a mention would mean the at-word in the body is
+// a longer name than this route, and only a space is exempt because a space may be interior.
+// Keeping `\p{L}`/`\p{N}` in the class also keeps every ASCII letter and digit that `\w` used to
+// contribute, which is what still stops a route named `every` matching `@everyone` and `chan`
+// matching `@channel` — the one direction the old boundary got right.
+//
+// There is deliberately no LEADING boundary. Buzz writes the at-word at a word start, and adding
+// one would be a behaviour change beyond this fix; `mail@Dennis` matching is pre-existing and
+// belongs to whoever revisits it.
+const RE_ESCAPE = /[.*+?^${}()|[\]\\]/g
+export function taskRouteMentionMatcher(mention) {
+  const m = String(mention == null ? '' : mention).replace(/^@/, '')
+  if (!m) return null
+  return new RegExp(`@${m.replace(RE_ESCAPE, '\\$&')}(?![${MENTION_ALPHABET}])`, 'iu')
+}
+
+// Does this body name this mention? The one question scanReturnLane actually asks.
+export function taskRouteMentioned(body, mention) {
+  const re = taskRouteMentionMatcher(mention)
+  return !!re && re.test(String(body == null ? '' : body))
+}

--- a/tests/task_route_mention.mjs
+++ b/tests/task_route_mention.mjs
@@ -25,7 +25,8 @@ import { tmpdir } from 'node:os'
 import { resolve } from 'node:path'
 import { getPublicKey, generateSecretKey, finalizeEvent } from 'nostr-tools/pure'
 
-import { taskRouteMentionProblem, taskRouteMention, taskRouteMentionKey, TASK_ROUTE_MENTION_MAX }
+import { taskRouteMentionProblem, taskRouteMention, taskRouteMentionKey, TASK_ROUTE_MENTION_MAX,
+  taskRouteMentioned, taskRouteMentionMatcher }
   from '../src/task_route_mention.mjs'
 
 let fails = 0
@@ -241,5 +242,93 @@ to = await carriedBy('@mydude what do you think')
 ok('the old slug form of the name does not route — the display name is the handle',
   to.length === 0, to.join('|'))
 
-console.log(fails ? `\nTASK ROUTE MENTION FAIL — ${fails}` : '\nTASK ROUTE MENTION PASS — grammar, reasons, console join, end-to-end carry')
+// ---------------------------------------------------------------------------------------------
+// 5. The word boundary, which must be the mention alphabet minus the separator (#408).
+// ---------------------------------------------------------------------------------------------
+// `(?![\w-])` was correct only while the grammar WAS the slug alphabet: every admissible character
+// was in `\w` or was `-`, so the boundary class and the grammar were the same set. #404 widened the
+// grammar and left the boundary alone, and a route named `Dr` began receiving `@Dr. Watson` while
+// the real `Dr. Watson` received nothing. Two classes that must agree cannot be two literals, so
+// the matcher now derives from MENTION_ALPHABET — and this table is what says so.
+//
+// Both directions in ONE table, deliberately: a boundary that only ever suppresses cannot be told
+// from one that suppresses everything, and that is the exact failure mode this repo keeps paying
+// for. `carry: false` rows are the fix; `carry: true` rows are the proof it did not overreach.
+console.log('\nboundary — the alphabet minus the separator, both directions')
+
+const BOUNDARY = [
+  // [mention, body, must it carry?, why this row exists]
+  ['Dr',        '@Dr. Watson — please look',   false, 'the #408 defect itself: `.` is not in \\w, so the old boundary ended the name'],
+  ['Dan',       "@Dan'ielle can you check",    false, "`'` is not in \\w either"],
+  ['Jos',       '@José replied',               false, 'a non-ASCII letter is not in \\w — \\w is ASCII-only'],
+  ['My Dude',   '@My Dudeé said no',           false, 'the same hole one word later'],
+  ['My Dude',   "@My Dude's Assistant will",   false, "a possessive is a different name, not this one"],
+  ['every',     '@everyone gather round',      false, 'the direction the OLD boundary got right — must stay right'],
+  ['chan',      '@channel wide notice',        false, 'ditto: the class must keep \\w\'s ASCII letters'],
+  ['Dr. Watson', '@Dr. Watson — please look',  true,  'the real recipient, who received nothing before'],
+  ['My Dude',   '@My Dude — please look',      true,  'the ordinary case must survive the fix'],
+  ['My Dude',   '@my dude — please look',      true,  'still case-insensitive'],
+  ['My Dude',   '@My Dude! urgent',            true,  'ordinary punctuation still ends the name'],
+  ['My Dude',   '@My Dude, and also',          true,  'a comma is not part of a name'],
+  ["O'Brien",   "@O'Brien please review",      true,  'an apostrophe INSIDE the name still matches'],
+  ['codex',     '@Codex please look',          true,  'a single-token name — this always worked, and must keep working'],
+  ['MC Claude', '@MC Claude — please look',    true,  'a space is interior and must not terminate'],
+  ['MC',        '@MC Claude — please look',    true,  'NOT fixed here and deliberately so — see #409, the ambiguity is a design call'],
+]
+for (const [mention, body, want, why] of BOUNDARY) {
+  ok(`${want ? 'carries' : 'suppresses'} ${JSON.stringify(mention)} in ${JSON.stringify(body)} — ${why}`,
+    taskRouteMentioned(body, mention) === want)
+}
+
+// A table of literals proves the table. This proves the RULE the table is drawn from, so a future
+// widening of the grammar cannot pass by leaving the boundary behind — which is the whole defect.
+{
+  const interior = [...'\u00e9A9_.\'-']            // one character from each part of the alphabet
+  const missed = interior.filter(ch => taskRouteMentioned(`@Ann${ch}x`, 'Ann'))
+  ok('every non-separator character in the alphabet terminates a shorter route',
+    missed.length === 0, `leaked: ${JSON.stringify(missed)}`)
+  ok('  …and the separator does NOT, because a space may be interior to a name',
+    taskRouteMentioned('@Ann Boleyn', 'Ann'))
+}
+
+// Size floor and a live matcher, so an empty or broken input cannot report clean.
+ok('the matcher is a real RegExp with the unicode flag', taskRouteMentionMatcher('My Dude') instanceof RegExp &&
+  taskRouteMentionMatcher('My Dude').flags.includes('u'))
+ok('an empty mention yields no matcher rather than one that matches everything',
+  taskRouteMentionMatcher('') === null && taskRouteMentioned('@anything', '') === false)
+ok('the boundary table is not empty', BOUNDARY.length >= 16, `${BOUNDARY.length} rows`)
+ok('and holds both verdicts', BOUNDARY.some(r => r[2]) && BOUNDARY.some(r => !r[2]))
+
+// Every admitted codepoint, in an interior position: the matcher must build and must find its own
+// at-word. Adding the `u` flag changes escape semantics, so this is checked rather than assumed.
+{
+  let built = 0, threw = 0, missedSelf = 0
+  for (let cp = 0x20; cp <= 0x2FFF; cp++) {
+    const ch = String.fromCodePoint(cp)
+    if (taskRouteMentionProblem(`A${ch}B`) !== null) continue
+    built++
+    try { if (!taskRouteMentioned(`@A${ch}B stop`, `A${ch}B`)) missedSelf++ } catch { threw++ }
+  }
+  ok(`every admitted codepoint builds a matcher that finds its own at-word (${built} admitted)`,
+    built > 1000 && threw === 0 && missedSelf === 0, `threw=${threw} missedSelf=${missedSelf}`)
+}
+
+// ---------------------------------------------------------------------------------------------
+// 6. The boundary defect, end to end through the real scanReturnLane (#408).
+// ---------------------------------------------------------------------------------------------
+// The table above drives the matcher directly. bridge.mjs imports that exact function, but "the
+// module is right" and "the lane uses it" are different claims, and only the second one is the
+// thing that broke. These two bodies both carried to My Dude before this fix.
+to = await carriedBy("@My Dude's Assistant will handle it")
+ok('a possessive does NOT carry to the agent whose name it starts with', to.length === 0, to.join('|'))
+
+to = await carriedBy('@MC Claudeé is someone else entirely')
+ok('a non-ASCII letter continuing the name does NOT carry — \\w could not see it',
+  to.length === 0, to.join('|'))
+
+to = await carriedBy('@My Dude — still here after all that')
+ok('  …and the legitimate carry still lands, so the fix suppresses rather than blocks',
+  to.length === 1 && to[0] === short(myDude), to.join('|'))
+
+console.log(fails ? `\nTASK ROUTE MENTION FAIL — ${fails}` : '\nTASK ROUTE MENTION PASS — grammar, reasons, console join, boundary, end-to-end carry')
 process.exit(fails ? 1 : 0)


### PR DESCRIPTION
Closes #408.

`scanReturnLane` matched a route with `@name(?![\w-])`. That boundary was correct only because the grammar was the slug alphabet `[a-z0-9_-]` — every admissible character was already in `\w` or was `-`, so the boundary class and the grammar were **the same set**. #404 widened the grammar to letters, numbers, spaces and `_ - . '` and left the boundary alone.

The invariant broke silently. Live consequences:

| route | body | before | after |
|---|---|---|---|
| `Dr` | `@Dr. Watson — please look` | carried to Dr | not carried |
| `Dan` | `@Dan'ielle can you check` | carried to Dan | not carried |
| `My Dude` | `@My Dudeé said no` | carried to My Dude | not carried |
| `My Dude` | `@My Dude's Assistant will` | carried to My Dude | not carried |

Each wakes the wrong agent on a message addressed to someone else.

## The fix

The two classes are no longer two literals. `MENTION_ALPHABET` is written once in `src/task_route_mention.mjs`; the allowlist adds the separator to it, the matcher withholds the separator from it. A space may appear inside a mention and must not terminate it; every other admissible character must. The matcher moves into that module, next to the alphabet it depends on, and `bridge.mjs` calls `taskRouteMentioned`.

`every` still does not match `@everyone` and `chan` still does not match `@channel` — `\p{L}`/`\p{N}` keep every ASCII letter and digit `\w` used to contribute. That is the one direction the old boundary got right, and it is asserted alongside the new rows.

No leading boundary is added. `mail@Dennis` matching is pre-existing and out of scope here.

## Evidence

- 16-row boundary table, `carry: true` and `carry: false` rows both.
- Rule-level check: every non-separator character in the alphabet terminates a shorter route.
- Codepoint sweep 0x20–0x2FFF: each of the 6418 admitted characters builds a matcher that finds its own at-word (`threw === 0 && missedSelf === 0`).
- Three end-to-end `scanReturnLane` cases through the journal, not the regex.
- **Negative control**: reverting the boundary to `(?![\w-])` in both copies fails 8 assertions, including the rule-level check, which names the leaked characters `é . '`. Restored before commit.
- 77 of 77 suites that run on macOS pass. Six suites fail on this machine — `install_state`, `relay_fanout`, `relay_refusal`, `durable_store`, `render_states`, `undelivered` — and all six fail **identically on unmodified `origin/main` (b043454f)**, so they are pre-existing local-environment failures, not this change. CI is the arbiter for those.

Also corrects this module's header: #404 claimed no working input existed under the old grammar. A single-token name such as `codex` or `Dennis` did work; only spaced names were unreachable. `docs/` inherits this header, so the overstatement would have propagated into a shipped artifact. Caught by My Dude reviewing #406.

## Review

@My Dude — you wrote the fix and caught the #404 overstatement. Worth your eyes on two things: whether withholding only the space from the boundary is the right cut (an apostrophe inside a name is admissible but terminates a shorter route — that is deliberate, but it is the judgement call in here), and whether moving the matcher out of `scanReturnLane` changes anything you were relying on at the call site.

Drafted with assistance from [Claude Code](https://claude.com/claude-code)
