### PR TITLE
fix: the longest mention wins each at-word (#409, #407)

### DIFF
--- a/console/task-route-mention.mjs
+++ b/console/task-route-mention.mjs
@@ -104,8 +104,21 @@ export function taskRouteMentioned(body, mention) {
 // one position are all prefixes of one span and are totally ordered by length. That dissolves the
 // awkward case raised in #409 — `MC Claude` against `Claude Ops` in `@MC Claude Ops` — because
 // `Claude Ops` has no `@` in front of it there and is not a candidate at that position at all.
-// Ties are impossible: two mentions matching the same span with the same length are the same
-// mention case-folded, and those are collapsed to one row before the scan.
+// TIES ARE NOT IMPOSSIBLE, AND ARE NOT BROKEN. This first claimed that two mentions matching the
+// same span with the same length must be the same mention case-folded, so the dedup above would
+// already have collapsed them. That is false, found in review of #414. `taskRouteMentionKey` is
+// `toLowerCase()` — Unicode case MAPPING — and the matcher is a regex with `iu` — Unicode simple
+// case FOLDING. Those are different equivalence relations, and where they disagree a same-length
+// pair survives dedup. `Me\u017Fnil` (LATIN SMALL LETTER LONG S) and `Mesnil` are two dedup keys of
+// equal length, each matching the other's at-word; the sweep that found it turned up exactly one
+// such character in U+0020–U+FFFF. Picking a winner with `>` then picked by ARRAY ORDER — the
+// message reached whichever route the operator happened to configure first, and the skip line told
+// the other's owner that a longer name had taken it, which was not true.
+//
+// So every mention of the longest length carries. A tie cannot be broken wrongly if it is not
+// broken, which makes the ordering claim true by construction rather than by an argument about
+// Unicode. This is a strict generalisation of longest-wins, not a different rule: where lengths
+// differ it is unchanged.
 //
 // A mention that loses at one at-word and wins at another IS CARRIED. Suppression is a statement
 // about a single at-word, never about a route, which is why `carried` is resolved before
@@ -132,17 +145,17 @@ export function taskRouteMentionArbitrate(body, mentions) {
   const contested = []
   for (let i = 0; i < text.length; i++) {
     if (text[i] !== '@') continue
-    let winner = null
     const hits = []
     for (const row of rows) {
       row.re.lastIndex = i
-      if (!row.re.test(text)) continue
-      hits.push(row)
-      if (!winner || row.mention.length > winner.mention.length) winner = row
+      if (row.re.test(text)) hits.push(row)
     }
-    if (!winner) continue
-    carried.set(winner.key, winner.mention)
-    for (const row of hits) if (row.key !== winner.key) contested.push({ row, by: winner.mention, at: i })
+    if (!hits.length) continue
+    // EVERY mention of the longest length carries — the tie is not broken. See above.
+    const longest = Math.max(...hits.map(r => r.mention.length))
+    const winners = hits.filter(r => r.mention.length === longest)
+    for (const w of winners) carried.set(w.key, w.mention)
+    for (const row of hits) if (row.mention.length !== longest) contested.push({ row, by: winners[0].mention, at: i })
   }
   const suppressed = new Map()
   for (const { row, by, at } of contested) {

--- a/console/task-route-mention.mjs
+++ b/console/task-route-mention.mjs
@@ -84,8 +84,70 @@ export function taskRouteMentionMatcher(mention) {
   return new RegExp(`@${m.replace(RE_ESCAPE, '\\$&')}(?![${MENTION_ALPHABET}])`, 'iu')
 }
 
-// Does this body name this mention? The one question scanReturnLane actually asks.
+// Does this body name this mention? True in isolation — see the arbitration below for what happens
+// when a second route's mention also matches the same at-word.
 export function taskRouteMentioned(body, mention) {
   const re = taskRouteMentionMatcher(mention)
   return !!re && re.test(String(body == null ? '' : body))
+}
+
+// ARBITRATION (#407, #409). A boundary cannot settle `@MC Claude` when both `mc` and `MC Claude`
+// are routed in one channel, because the separator has to be two things at once. A space must
+// TERMINATE a mention, or a route named `My Dude` would never match `@My Dude and …`. A space must
+// also be INTERIOR to a mention, or `MC Claude` could not be a name at all. Both readings of
+// `@MC Claude` are correct — one mention, or `mc` followed by the word "Claude" — so what is
+// missing is arbitration, not a better character class. #411 withheld the space from the boundary
+// deliberately and could not have fixed this; including the space would have broken every spaced
+// mention instead.
+//
+// LONGEST WINS, PER `@` POSITION. Every candidate must begin at the SAME `@`, so the candidates at
+// one position are all prefixes of one span and are totally ordered by length. That dissolves the
+// awkward case raised in #409 — `MC Claude` against `Claude Ops` in `@MC Claude Ops` — because
+// `Claude Ops` has no `@` in front of it there and is not a candidate at that position at all.
+// Ties are impossible: two mentions matching the same span with the same length are the same
+// mention case-folded, and those are collapsed to one row before the scan.
+//
+// A mention that loses at one at-word and wins at another IS CARRIED. Suppression is a statement
+// about a single at-word, never about a route, which is why `carried` is resolved before
+// `suppressed` is answered.
+//
+// Returns { carried, suppressed }: `carried` maps mention key -> mention as written; `suppressed`
+// maps mention key -> { mention, by, at }, naming the longer mention that took the at-word and
+// where. The caller logs from `suppressed` — a route that silently stops receiving a carry it used
+// to receive presents as the return lane being flaky, which is the failure this repo keeps paying
+// for.
+export function taskRouteMentionArbitrate(body, mentions) {
+  const text = String(body == null ? '' : body)
+  const rows = []
+  for (const value of (Array.isArray(mentions) ? mentions : [])) {
+    const m = String(value == null ? '' : value).replace(/^@/, '')
+    if (!m) continue
+    const key = taskRouteMentionKey(m)
+    if (rows.some(row => row.key === key)) continue
+    // Sticky, so a candidate is tested AT the at-word rather than anywhere after it. A non-sticky
+    // test would let a mention later in the body win an at-word it does not start.
+    rows.push({ mention: m, key, re: new RegExp(`@${m.replace(RE_ESCAPE, '\\$&')}(?![${MENTION_ALPHABET}])`, 'iuy') })
+  }
+  const carried = new Map()
+  const contested = []
+  for (let i = 0; i < text.length; i++) {
+    if (text[i] !== '@') continue
+    let winner = null
+    const hits = []
+    for (const row of rows) {
+      row.re.lastIndex = i
+      if (!row.re.test(text)) continue
+      hits.push(row)
+      if (!winner || row.mention.length > winner.mention.length) winner = row
+    }
+    if (!winner) continue
+    carried.set(winner.key, winner.mention)
+    for (const row of hits) if (row.key !== winner.key) contested.push({ row, by: winner.mention, at: i })
+  }
+  const suppressed = new Map()
+  for (const { row, by, at } of contested) {
+    if (carried.has(row.key) || suppressed.has(row.key)) continue   // won elsewhere, or already recorded
+    suppressed.set(row.key, { mention: row.mention, by, at })
+  }
+  return { carried, suppressed }
 }

--- a/src/bridge.mjs
+++ b/src/bridge.mjs
@@ -48,7 +48,7 @@ import { fileURLToPath } from 'node:url'
 // Extracted leaf modules (#154). Each is dependency-free of config and ambient state, which is why
 // these four came out first — the split is staged, not big-bang.
 import { LANE_IDS, LANES, RELEASED } from './lanes.mjs'   // the trust gradient's one source (#282)
-import { taskRouteMention, taskRouteMentionProblem, taskRouteMentionKey, taskRouteMentioned } from './task_route_mention.mjs'   // #404, #408
+import { taskRouteMention, taskRouteMentionProblem, taskRouteMentionKey, taskRouteMentionArbitrate } from './task_route_mention.mjs'   // #404, #408, #409
 import { log, err } from './log.mjs'
 import { markLatency } from './latency.mjs'
 import { durableSet, durableQueue } from './stores.mjs'
@@ -3414,6 +3414,21 @@ async function scanReturnLane(msgs, opts = {}) {
     }
     const body = String(m.content || '')
     const ptags = tags.filter(t => t[0] === 'p' && t[1]).map(t => String(t[1]).toLowerCase())
+    // #407/#409: WHO IS NAMED is a property of the text and the route set together, so it is
+    // settled once per message, before any per-recipient delivery test. Asking each route on its
+    // own is what let `mc` and `MC Claude` both carry `@MC Claude`. Longest wins at each at-word.
+    // Scoped to routes bound to THIS channel: a route in another channel is not in play here and
+    // must not take an at-word from one that is.
+    const contestants = recipients.filter(r => !r.dynamic && !!r.mention &&
+      (!r.managedTaskRoute || r.scan_channel === String(opts.channel || '').toLowerCase()))
+    const { carried: namedHere, suppressed: shadowed } =
+      taskRouteMentionArbitrate(body, contestants.map(r => r.mention))
+    // Named, not dropped silently. This says only who took the at-word — a route can also fail to
+    // carry for reasons that have nothing to do with naming, and this line does not claim otherwise.
+    if (shadowed.size && rlDropOnce(m.id)) {
+      for (const { mention, by, at } of shadowed.values())
+        log(`RETURN skip[longer-name]: ${String(m.id).slice(0, 12)}… @${mention} does not take the at-word at ${at} — @${by} is longer`)
+    }
     let carried = false
     // No break: one message fans out to EVERY matching recipient, each deduped on its own
     // (source × recipient) key. "@a @b" reaching only one of them was finding #4.
@@ -3437,8 +3452,10 @@ async function scanReturnLane(msgs, opts = {}) {
       if (from === r.npub_hex || boundUnique || agentAuthoredBy(m.id) === r.npub_hex) continue
       const mentioned = ptags.includes(r.npub_hex) ||
         // #408: the boundary is derived from the mention alphabet in task_route_mention.mjs, not
-        // restated here. `(?![\w-])` was correct only while the grammar was the slug alphabet.
-        (!r.dynamic && !!r.mention && taskRouteMentioned(body, r.mention))
+        // restated here. #409: and the winner among overlapping mentions is settled above, once
+        // for the whole message, because it is a cross-route question this per-route loop cannot
+        // answer on its own.
+        (!r.dynamic && !!r.mention && namedHere.has(taskRouteMentionKey(r.mention)))
       if (!mentioned && !repliedTo) continue
       const why = repliedTo && !mentioned ? 'reply' : 'mention'
       let descriptor

--- a/src/task_route_mention.mjs
+++ b/src/task_route_mention.mjs
@@ -121,8 +121,21 @@ export function taskRouteMentioned(body, mention) {
 // one position are all prefixes of one span and are totally ordered by length. That dissolves the
 // awkward case raised in #409 — `MC Claude` against `Claude Ops` in `@MC Claude Ops` — because
 // `Claude Ops` has no `@` in front of it there and is not a candidate at that position at all.
-// Ties are impossible: two mentions matching the same span with the same length are the same
-// mention case-folded, and those are collapsed to one row before the scan.
+// TIES ARE NOT IMPOSSIBLE, AND ARE NOT BROKEN. This first claimed that two mentions matching the
+// same span with the same length must be the same mention case-folded, so the dedup above would
+// already have collapsed them. That is false, found in review of #414. `taskRouteMentionKey` is
+// `toLowerCase()` — Unicode case MAPPING — and the matcher is a regex with `iu` — Unicode simple
+// case FOLDING. Those are different equivalence relations, and where they disagree a same-length
+// pair survives dedup. `Me\u017Fnil` (LATIN SMALL LETTER LONG S) and `Mesnil` are two dedup keys of
+// equal length, each matching the other's at-word; the sweep that found it turned up exactly one
+// such character in U+0020–U+FFFF. Picking a winner with `>` then picked by ARRAY ORDER — the
+// message reached whichever route the operator happened to configure first, and the skip line told
+// the other's owner that a longer name had taken it, which was not true.
+//
+// So every mention of the longest length carries. A tie cannot be broken wrongly if it is not
+// broken, which makes the ordering claim true by construction rather than by an argument about
+// Unicode. This is a strict generalisation of longest-wins, not a different rule: where lengths
+// differ it is unchanged.
 //
 // A mention that loses at one at-word and wins at another IS CARRIED. Suppression is a statement
 // about a single at-word, never about a route, which is why `carried` is resolved before
@@ -149,17 +162,17 @@ export function taskRouteMentionArbitrate(body, mentions) {
   const contested = []
   for (let i = 0; i < text.length; i++) {
     if (text[i] !== '@') continue
-    let winner = null
     const hits = []
     for (const row of rows) {
       row.re.lastIndex = i
-      if (!row.re.test(text)) continue
-      hits.push(row)
-      if (!winner || row.mention.length > winner.mention.length) winner = row
+      if (row.re.test(text)) hits.push(row)
     }
-    if (!winner) continue
-    carried.set(winner.key, winner.mention)
-    for (const row of hits) if (row.key !== winner.key) contested.push({ row, by: winner.mention, at: i })
+    if (!hits.length) continue
+    // EVERY mention of the longest length carries — the tie is not broken. See above.
+    const longest = Math.max(...hits.map(r => r.mention.length))
+    const winners = hits.filter(r => r.mention.length === longest)
+    for (const w of winners) carried.set(w.key, w.mention)
+    for (const row of hits) if (row.mention.length !== longest) contested.push({ row, by: winners[0].mention, at: i })
   }
   const suppressed = new Map()
   for (const { row, by, at } of contested) {

--- a/src/task_route_mention.mjs
+++ b/src/task_route_mention.mjs
@@ -101,8 +101,70 @@ export function taskRouteMentionMatcher(mention) {
   return new RegExp(`@${m.replace(RE_ESCAPE, '\\$&')}(?![${MENTION_ALPHABET}])`, 'iu')
 }
 
-// Does this body name this mention? The one question scanReturnLane actually asks.
+// Does this body name this mention? True in isolation — see the arbitration below for what happens
+// when a second route's mention also matches the same at-word.
 export function taskRouteMentioned(body, mention) {
   const re = taskRouteMentionMatcher(mention)
   return !!re && re.test(String(body == null ? '' : body))
+}
+
+// ARBITRATION (#407, #409). A boundary cannot settle `@MC Claude` when both `mc` and `MC Claude`
+// are routed in one channel, because the separator has to be two things at once. A space must
+// TERMINATE a mention, or a route named `My Dude` would never match `@My Dude and …`. A space must
+// also be INTERIOR to a mention, or `MC Claude` could not be a name at all. Both readings of
+// `@MC Claude` are correct — one mention, or `mc` followed by the word "Claude" — so what is
+// missing is arbitration, not a better character class. #411 withheld the space from the boundary
+// deliberately and could not have fixed this; including the space would have broken every spaced
+// mention instead.
+//
+// LONGEST WINS, PER `@` POSITION. Every candidate must begin at the SAME `@`, so the candidates at
+// one position are all prefixes of one span and are totally ordered by length. That dissolves the
+// awkward case raised in #409 — `MC Claude` against `Claude Ops` in `@MC Claude Ops` — because
+// `Claude Ops` has no `@` in front of it there and is not a candidate at that position at all.
+// Ties are impossible: two mentions matching the same span with the same length are the same
+// mention case-folded, and those are collapsed to one row before the scan.
+//
+// A mention that loses at one at-word and wins at another IS CARRIED. Suppression is a statement
+// about a single at-word, never about a route, which is why `carried` is resolved before
+// `suppressed` is answered.
+//
+// Returns { carried, suppressed }: `carried` maps mention key -> mention as written; `suppressed`
+// maps mention key -> { mention, by, at }, naming the longer mention that took the at-word and
+// where. The caller logs from `suppressed` — a route that silently stops receiving a carry it used
+// to receive presents as the return lane being flaky, which is the failure this repo keeps paying
+// for.
+export function taskRouteMentionArbitrate(body, mentions) {
+  const text = String(body == null ? '' : body)
+  const rows = []
+  for (const value of (Array.isArray(mentions) ? mentions : [])) {
+    const m = String(value == null ? '' : value).replace(/^@/, '')
+    if (!m) continue
+    const key = taskRouteMentionKey(m)
+    if (rows.some(row => row.key === key)) continue
+    // Sticky, so a candidate is tested AT the at-word rather than anywhere after it. A non-sticky
+    // test would let a mention later in the body win an at-word it does not start.
+    rows.push({ mention: m, key, re: new RegExp(`@${m.replace(RE_ESCAPE, '\\$&')}(?![${MENTION_ALPHABET}])`, 'iuy') })
+  }
+  const carried = new Map()
+  const contested = []
+  for (let i = 0; i < text.length; i++) {
+    if (text[i] !== '@') continue
+    let winner = null
+    const hits = []
+    for (const row of rows) {
+      row.re.lastIndex = i
+      if (!row.re.test(text)) continue
+      hits.push(row)
+      if (!winner || row.mention.length > winner.mention.length) winner = row
+    }
+    if (!winner) continue
+    carried.set(winner.key, winner.mention)
+    for (const row of hits) if (row.key !== winner.key) contested.push({ row, by: winner.mention, at: i })
+  }
+  const suppressed = new Map()
+  for (const { row, by, at } of contested) {
+    if (carried.has(row.key) || suppressed.has(row.key)) continue   // won elsewhere, or already recorded
+    suppressed.set(row.key, { mention: row.mention, by, at })
+  }
+  return { carried, suppressed }
 }

--- a/tests/task_route_mention.mjs
+++ b/tests/task_route_mention.mjs
@@ -414,7 +414,12 @@ ok('no routes means nothing carries', arb('@MC Claude', []).won.length === 0)
 // pair CAN survive dedup and reach the comparison. Breaking that tie by `>` broke it by array
 // order: the message went to whichever route was configured first, and the other's owner was told
 // a longer name had taken it — a false reason for a delivery to the wrong participant.
-ok('a same-length pair survives dedup, so the tie is real and not a hypothetical',
+// This guard is DIAGNOSIS, not non-vacuity. The tie assertions below cannot pass vacuously —
+// `won.length === 2` is unsatisfiable unless two rows survive dedup and both match at that at-word.
+// What it buys is that a future fixture edit or fold change fails as "the fixture stopped being a
+// tie" rather than as a bare "a tie carries to BOTH", which is otherwise a puzzle. Proven by
+// degrading the precondition four ways: it fires in all four, and never alone.
+ok('the fixture is still a genuine tie — same length, distinct keys, each matching the other',
   taskRouteMentionKey(MESNIL_LONG) !== taskRouteMentionKey('Mesnil') &&
   MESNIL_LONG.length === 'Mesnil'.length &&
   taskRouteMentioned('@Mesnil please look', MESNIL_LONG) &&
@@ -450,7 +455,11 @@ ok('two at-words in one message reach two different agents',
   to.length === 2 && to.join('|') === [short(mcOnly), short(mcClaude)].sort().join('|'), to.join('|'))
 
 to = await carriedBy('@Mesnil please look at this.')
-ok('end to end: a tie reaches BOTH agents, so neither is intercepted',
+// Carrying to both fixes the MUTE and the ORDER DEPENDENCE. It does not fix interception, and the
+// name of this assertion used to say it did (#414 re-read). `@Mesnil` still reaches `Me\u017Fnil`, an
+// agent nobody named; what changed is that it no longer reaches it EXCLUSIVELY. Arbitration cannot
+// tell an impostor from a legitimate namesake — that closes at admission, not here (#416).
+ok('end to end: a tie reaches BOTH agents, so the real agent is not displaced',
   to.length === 2 && to.join('|') === [short(mesnilLong), short(mesnilPlain)].sort().join('|'), to.join('|'))
 
 

--- a/tests/task_route_mention.mjs
+++ b/tests/task_route_mention.mjs
@@ -177,6 +177,14 @@ const bridgeSk = generateSecretKey()
 const myDude = getPublicKey(generateSecretKey())
 const mcClaude = getPublicKey(generateSecretKey())
 const mcOnly = getPublicKey(generateSecretKey())
+// The tie pair. `Me\u017Fnil` is LATIN SMALL LETTER LONG S — written escaped because it is a
+// letter nobody can tell from `f` or `s` at a glance, and a fixture nobody can read is a fixture
+// nobody can check. It is the ONE character in U+0020–U+FFFF that regex `iu` folds onto an ASCII
+// letter but `String.prototype.toLowerCase()` does not, so these two survive dedup as separate
+// routes of equal length that each match the other's at-word.
+const mesnilLong = getPublicKey(generateSecretKey())
+const mesnilPlain = getPublicKey(generateSecretKey())
+const MESNIL_LONG = 'Me\u017Fnil'
 const crewSk = generateSecretKey(), crew = getPublicKey(crewSk)
 const channel = 'a8186b53-537d-46ad-a7e7-b6486c58970e'
 
@@ -192,6 +200,8 @@ writeFileSync(resolve(dir, 'config.json'), JSON.stringify({ relays: [], recipien
     // with the ambiguity present — a suppression rule is only trustworthy if the cases it must
     // NOT change are checked against it too.
     { participant: mcOnly, sender: crew, channel, mention: 'MC', protocol: 'nvoy-task-carry-v1' },
+    { participant: mesnilLong, sender: crew, channel, mention: MESNIL_LONG, protocol: 'nvoy-task-carry-v1' },
+    { participant: mesnilPlain, sender: crew, channel, mention: 'Mesnil', protocol: 'nvoy-task-carry-v1' },
   ],
 } }))
 process.env.CONFIG_PATH = resolve(dir, 'config.json')
@@ -208,11 +218,13 @@ const { scanReturnLane, PUB, grantSet } = await import('../src/bridge.mjs')
 grantSet.set(myDude, { grantId: '1'.repeat(64), grantor: crew })
 grantSet.set(mcClaude, { grantId: '2'.repeat(64), grantor: crew })
 grantSet.set(mcOnly, { grantId: '3'.repeat(64), grantor: crew })
+grantSet.set(mesnilLong, { grantId: '4'.repeat(64), grantor: crew })
+grantSet.set(mesnilPlain, { grantId: '5'.repeat(64), grantor: crew })
 
-ok('all three routes survive config parsing, spaces and all', PUB.taskRoutes.length === 3,
+ok('all five routes survive config parsing, spaces and all', PUB.taskRoutes.length === 5,
   String(PUB.taskRoutes.length))
 ok("and keep the operator's casing on the way in",
-  PUB.taskRoutes.map(r => r.mention).sort().join('|') === 'MC|MC Claude|My Dude',
+  PUB.taskRoutes.map(r => r.mention).sort().join('|') === `MC|MC Claude|Mesnil|${MESNIL_LONG}|My Dude`,
   PUB.taskRoutes.map(r => r.mention).join('|'))
 
 const journal = () => existsSync(process.env.SEND_JOURNAL_PATH)
@@ -363,6 +375,7 @@ const arb = (body, mentions) => {
   return { won: [...carried.values()].sort(), lost: [...suppressed.values()].map(s => s.mention).sort() }
 }
 const ROUTES = ['MC', 'MC Claude', 'My Dude']
+const ALL_ROUTES = [...ROUTES, MESNIL_LONG, 'Mesnil']
 
 const ARBITRATE = [
   // body                                       won                        suppressed
@@ -395,6 +408,34 @@ ok('the winner does not depend on route order',
 // Size floor — an arbitration over no routes must report nothing rather than everything.
 ok('no routes means nothing carries', arb('@MC Claude', []).won.length === 0)
 
+// TIES ARE NOT BROKEN — the claim this fix originally rested on was false (#414 review).
+// `taskRouteMentionKey` folds with `toLowerCase()` (Unicode case MAPPING); the matcher folds with
+// regex `iu` (Unicode simple case FOLDING). Two different equivalence relations, so a same-length
+// pair CAN survive dedup and reach the comparison. Breaking that tie by `>` broke it by array
+// order: the message went to whichever route was configured first, and the other's owner was told
+// a longer name had taken it — a false reason for a delivery to the wrong participant.
+ok('a same-length pair survives dedup, so the tie is real and not a hypothetical',
+  taskRouteMentionKey(MESNIL_LONG) !== taskRouteMentionKey('Mesnil') &&
+  MESNIL_LONG.length === 'Mesnil'.length &&
+  taskRouteMentioned('@Mesnil please look', MESNIL_LONG) &&
+  taskRouteMentioned(`@${MESNIL_LONG} please look`, 'Mesnil'))
+
+{
+  const forward = arb('@Mesnil please look at this.', [MESNIL_LONG, 'Mesnil'])
+  const reverse = arb('@Mesnil please look at this.', ['Mesnil', MESNIL_LONG])
+  ok('a tie carries to BOTH rather than to one of them',
+    forward.won.length === 2 && forward.lost.length === 0, JSON.stringify(forward))
+  ok('  …and the outcome does not depend on the order they were configured in',
+    forward.won.join('|') === reverse.won.join('|'), `${forward.won.join('|')} vs ${reverse.won.join('|')}`)
+}
+
+// The generalisation must not have loosened the rule it generalises: a genuinely longer name
+// still takes the at-word, with the collision pair present in the route set.
+ok('longest still wins when the lengths actually differ',
+  arb('@MC Claude — please look at this.', ALL_ROUTES).won.join('|') === 'MC Claude' &&
+  arb('@MC Claude — please look at this.', ALL_ROUTES).lost.join('|') === 'MC',
+  JSON.stringify(arb('@MC Claude — please look at this.', ALL_ROUTES)))
+
 // --- end to end, through the real scanReturnLane -----------------------------------------------
 to = await carriedBy('@MC Claude — please look at this.')
 ok('#407 live repro: the at-word reaches ONLY the longer route',
@@ -407,6 +448,11 @@ ok('and the shorter route still reaches its own agent',
 to = await carriedBy('@MC and @MC Claude are two different agents')
 ok('two at-words in one message reach two different agents',
   to.length === 2 && to.join('|') === [short(mcOnly), short(mcClaude)].sort().join('|'), to.join('|'))
+
+to = await carriedBy('@Mesnil please look at this.')
+ok('end to end: a tie reaches BOTH agents, so neither is intercepted',
+  to.length === 2 && to.join('|') === [short(mesnilLong), short(mesnilPlain)].sort().join('|'), to.join('|'))
+
 
 // The suppression must be READABLE. A short route that quietly stops receiving presents as the
 // return lane being flaky, which is the failure this repo keeps paying for — so assert the reason,

--- a/tests/task_route_mention.mjs
+++ b/tests/task_route_mention.mjs
@@ -26,7 +26,7 @@ import { resolve } from 'node:path'
 import { getPublicKey, generateSecretKey, finalizeEvent } from 'nostr-tools/pure'
 
 import { taskRouteMentionProblem, taskRouteMention, taskRouteMentionKey, TASK_ROUTE_MENTION_MAX,
-  taskRouteMentioned, taskRouteMentionMatcher }
+  taskRouteMentioned, taskRouteMentionMatcher, taskRouteMentionArbitrate }
   from '../src/task_route_mention.mjs'
 
 let fails = 0
@@ -176,6 +176,7 @@ const dir = mkdtempSync(resolve(tmpdir(), 'wb-mention-'))
 const bridgeSk = generateSecretKey()
 const myDude = getPublicKey(generateSecretKey())
 const mcClaude = getPublicKey(generateSecretKey())
+const mcOnly = getPublicKey(generateSecretKey())
 const crewSk = generateSecretKey(), crew = getPublicKey(crewSk)
 const channel = 'a8186b53-537d-46ad-a7e7-b6486c58970e'
 
@@ -186,6 +187,11 @@ writeFileSync(resolve(dir, 'config.json'), JSON.stringify({ relays: [], recipien
   task_routes: [
     { participant: myDude, sender: crew, channel, mention: 'My Dude', protocol: 'nvoy-task-carry-v1' },
     { participant: mcClaude, sender: crew, channel, mention: 'MC Claude', protocol: 'nvoy-task-carry-v1' },
+    // `MC` is a whole-word prefix of `MC Claude`, which is the #407/#409 collision. It is in the
+    // harness from the start rather than in a section of its own, so every assertion above runs
+    // with the ambiguity present — a suppression rule is only trustworthy if the cases it must
+    // NOT change are checked against it too.
+    { participant: mcOnly, sender: crew, channel, mention: 'MC', protocol: 'nvoy-task-carry-v1' },
   ],
 } }))
 process.env.CONFIG_PATH = resolve(dir, 'config.json')
@@ -201,10 +207,12 @@ process.env.WB_NO_BOOT = '1'
 const { scanReturnLane, PUB, grantSet } = await import('../src/bridge.mjs')
 grantSet.set(myDude, { grantId: '1'.repeat(64), grantor: crew })
 grantSet.set(mcClaude, { grantId: '2'.repeat(64), grantor: crew })
+grantSet.set(mcOnly, { grantId: '3'.repeat(64), grantor: crew })
 
-ok('both spaced routes survive config parsing', PUB.taskRoutes.length === 2)
+ok('all three routes survive config parsing, spaces and all', PUB.taskRoutes.length === 3,
+  String(PUB.taskRoutes.length))
 ok("and keep the operator's casing on the way in",
-  PUB.taskRoutes.map(r => r.mention).sort().join('|') === 'MC Claude|My Dude',
+  PUB.taskRoutes.map(r => r.mention).sort().join('|') === 'MC|MC Claude|My Dude',
   PUB.taskRoutes.map(r => r.mention).join('|'))
 
 const journal = () => existsSync(process.env.SEND_JOURNAL_PATH)
@@ -324,11 +332,98 @@ ok('a possessive does NOT carry to the agent whose name it starts with', to.leng
 
 to = await carriedBy('@MC Claudeé is someone else entirely')
 ok('a non-ASCII letter continuing the name does NOT carry — \\w could not see it',
-  to.length === 0, to.join('|'))
+  !to.includes(short(mcClaude)), to.join('|'))
+// It carries to `MC` instead, and that is correct rather than a leak. `@MC Claudeé is …` and
+// `@MC has this one …` are the same shape — `@MC`, a space, a word — so any rule that withheld the
+// first would withhold the second, and `MC` would be unreachable in prose. The space terminates a
+// mention; that is the price of spaced names being possible at all, and it is paid deliberately.
+ok('  …it reaches the SHORT route instead, which the separator makes unavoidable',
+  to.length === 1 && to[0] === short(mcOnly), to.join('|'))
 
 to = await carriedBy('@My Dude — still here after all that')
 ok('  …and the legitimate carry still lands, so the fix suppresses rather than blocks',
   to.length === 1 && to[0] === short(myDude), to.join('|'))
 
-console.log(fails ? `\nTASK ROUTE MENTION FAIL — ${fails}` : '\nTASK ROUTE MENTION PASS — grammar, reasons, console join, boundary, end-to-end carry')
+// ---------------------------------------------------------------------------------------------
+// 6. Arbitration: longest wins per at-word (#407, #409).
+// ---------------------------------------------------------------------------------------------
+// #411 derived the boundary from the alphabet and fixed `@Dr. Watson`. It could not fix
+// `@MC Claude`, and no boundary can: the separator has to TERMINATE a mention (or `My Dude` would
+// never match `@My Dude and …`) and be INTERIOR to one (or `MC Claude` could not be a name), so
+// both readings of `@MC Claude` are correct. What was missing is arbitration — longest wins, per
+// at-word — and the shorter route's loss is logged rather than dropped quietly.
+//
+// Both directions, and the second one carries the weight: a suppression rule cannot be told from a
+// rule that suppresses everything unless the shorter route is shown STILL CARRYING the at-words
+// that really are its own. `MC` is in the harness config from the top of this file for that reason.
+console.log('\narbitration — longest wins per at-word, both directions')
+
+const arb = (body, mentions) => {
+  const { carried, suppressed } = taskRouteMentionArbitrate(body, mentions)
+  return { won: [...carried.values()].sort(), lost: [...suppressed.values()].map(s => s.mention).sort() }
+}
+const ROUTES = ['MC', 'MC Claude', 'My Dude']
+
+const ARBITRATE = [
+  // body                                       won                        suppressed
+  ['@MC Claude — please look at this.',         ['MC Claude'],             ['MC']],
+  ['@MC please look at this.',                  ['MC'],                    []],
+  ['@MC and @MC Claude both',                   ['MC', 'MC Claude'],       []],
+  ['@My Dude and @MC Claude',                   ['MC Claude', 'My Dude'],  ['MC']],
+  ['@MC CLAUDE shouting',                       ['MC Claude'],             ['MC']],
+  ['@My Dude on their own',                     ['My Dude'],               []],
+  ['@MCClaude is nobody',                       [],                        []],
+  ['no at-words here',                          [],                        []],
+]
+for (const [body, won, lost] of ARBITRATE) {
+  const got = arb(body, ROUTES)
+  ok(`${JSON.stringify(body)} -> carries ${JSON.stringify(won)}`,
+    got.won.join('|') === won.join('|'), got.won.join('|'))
+  ok(`  …suppressing ${JSON.stringify(lost)}`, got.lost.join('|') === lost.join('|'), got.lost.join('|'))
+}
+
+// A route that LOSES one at-word and WINS another is carried. Suppression is a statement about one
+// at-word, never about a route — get this wrong and a busy channel silently mutes a short name.
+ok('losing one at-word does not mute a route that won another',
+  arb('@MC Claude first, then @MC alone', ROUTES).lost.length === 0,
+  JSON.stringify(arb('@MC Claude first, then @MC alone', ROUTES)))
+
+// Order independence: the winner is the longest, not the first configured.
+ok('the winner does not depend on route order',
+  arb('@MC Claude', ['MC', 'MC Claude']).won.join('|') === arb('@MC Claude', ['MC Claude', 'MC']).won.join('|'))
+
+// Size floor — an arbitration over no routes must report nothing rather than everything.
+ok('no routes means nothing carries', arb('@MC Claude', []).won.length === 0)
+
+// --- end to end, through the real scanReturnLane -----------------------------------------------
+to = await carriedBy('@MC Claude — please look at this.')
+ok('#407 live repro: the at-word reaches ONLY the longer route',
+  to.length === 1 && to[0] === short(mcClaude), to.join('|'))
+
+to = await carriedBy('@MC has this one on its own')
+ok('and the shorter route still reaches its own agent',
+  to.length === 1 && to[0] === short(mcOnly), to.join('|'))
+
+to = await carriedBy('@MC and @MC Claude are two different agents')
+ok('two at-words in one message reach two different agents',
+  to.length === 2 && to.join('|') === [short(mcOnly), short(mcClaude)].sort().join('|'), to.join('|'))
+
+// The suppression must be READABLE. A short route that quietly stops receiving presents as the
+// return lane being flaky, which is the failure this repo keeps paying for — so assert the reason,
+// not merely that the carry did not happen.
+{
+  const captured = []
+  const realLog = console.log
+  console.log = (...a) => { captured.push(a.join(' ')) }
+  await carriedBy('@MC Claude — the suppression must be legible')
+  console.log = realLog
+  ok('the bridge logged something at all', captured.length > 0, `${captured.length} lines`)
+  const line = captured.find(l => l.includes('skip[longer-name]'))
+  ok('the suppressed route is NAMED, not dropped silently', !!line,
+    captured.join(' / ').slice(0, 200))
+  ok('  …and the line says which longer name took the at-word, and where',
+    !!line && /@MC does not take the at-word at \d+ — @MC Claude is longer/.test(line), String(line))
+}
+
+console.log(fails ? `\nTASK ROUTE MENTION FAIL — ${fails}` : '\nTASK ROUTE MENTION PASS — grammar, reasons, console join, boundary, arbitration, end-to-end carry')
 process.exit(fails ? 1 : 0)


### PR DESCRIPTION
Both `mc` and `MC Claude` carried `@MC Claude`. #411 derived the word boundary from the mention alphabet and fixed `@Dr. Watson`; it could not fix this one, and no boundary rule can.

The separator has to be two things at once. A space must **terminate** a mention, or a route named `My Dude` would never match `@My Dude and …`. A space must also be **interior** to a mention, or `MC Claude` could not be a name. So `@MC Claude` genuinely satisfies both routes, and the boundary has no information with which to prefer one. What was missing is arbitration, not classification.

## The rule

`taskRouteMentionArbitrate` settles who is named once per message, before any per-recipient delivery test. At each `@` position, the longest matching mention wins.

Asking each route on its own is what let both carry — it is a cross-route question, and the per-route loop cannot answer it.

~~Ties are impossible~~ — **that claim was false, and the review found a working counterexample.** Corrected in `9aea284e`: `taskRouteMentionKey` folds with `toLowerCase()` (Unicode case *mapping*) while the matcher folds with regex `iu` (Unicode simple case *folding*). Different equivalence relations, so a same-length pair survives dedup — `Meſnil` (U+017F) against `Mesnil`, the one such character in U+0020–U+FFFF. Breaking that tie with `>` broke it by array order. **Every mention of the longest length now carries**, so the tie is not broken at all, and the ordering claim is true by construction rather than by an argument about Unicode.

The ordering that does hold: every

A route that loses one at-word and wins another **is carried**. Suppression is a statement about a single at-word, never about a route; get that wrong and a busy channel silently mutes a short name. The loss is logged with the name that took it and the offset, because a short route that quietly stops receiving presents as the return lane being flaky.

```
RETURN skip[longer-name]: 5c963196c30b… @MC does not take the at-word at 0 — @MC Claude is longer
```

## Scope

Arbitration runs over routes bound to **this** channel. A route in another channel is not in play and must not take an at-word from one that is.

## Evidence

`MC` is in the test harness config from the top of the file, not in a section of its own, so every pre-existing assertion runs with the ambiguity present — a suppression rule is only trustworthy if the cases it must *not* change are checked against it too.

Both directions, unit and end to end:

| body | carries | suppressed |
|---|---|---|
| `@MC Claude — please look at this.` | `MC Claude` | `MC` |
| `@MC please look at this.` | `MC` | — |
| `@MC and @MC Claude both` | `MC`, `MC Claude` | — |
| `@My Dude and @MC Claude` | `MC Claude`, `My Dude` | `MC` |
| `@MC CLAUDE shouting` | `MC Claude` | `MC` |
| `@MCClaude is nobody` | — | — |

Plus order-independence, an empty route set carrying nothing, and an assertion on the suppression line's **reason** rather than only on the absence of a carry.

**Negative control**: reverting `taskRouteMentionArbitrate` to pre-fix semantics (every route that matches anywhere carries, none loses) fails 11 assertions, including the `console/` byte-identity join.

**Suites**: `task_route_mention`, `return_lane`, `return_lane_scan`, `return_lane_task_carry`, `return_lane_nomiss`, `return_lane_pending`, `admission_return_lane`, `console_vocabulary`, `console_access_list`, `console_importmap` — all rc=0. `install_state` fails in this worktree and passes in the main checkout with the change stashed, so it is worktree residue, not this change. CI is the arbiter.

## One expectation changed rather than preserved

With `MC` routed, `@MC Claudeé is someone else entirely` now reaches `MC`. That is correct and unavoidable, not a leak: `@MC Claudeé is …` and `@MC has this one …` are textually the same shape — `@MC`, a space, a word — so any rule that withheld the first would withhold the second, and `MC` would be unreachable in prose. The assertion was rewritten to say what is true (it does not reach `MC Claude`, and it does reach `MC`) rather than relaxed.

## Reviewer note

@My Dude — the thing worth attacking is the claim that longest-wins is well-defined at a position. If candidates at one `@` are *not* totally ordered by length, the rule has a tie it cannot break and the fix is wrong.

Not currently exploitable on the production bridge: the two live routes in the scanned channel are `codex` and `MC Claude`, and neither is a whole-word prefix of the other. It becomes exploitable the moment a short route is added, and the failure is silent — the wrong agent is woken and nothing is logged, because carrying to a matched route is not an error.

Closes #409, closes #407.

Drafted with assistance from [Claude Code](https://claude.com/claude-code)

