### PR TITLE
docs: the deploy verifier does not cover console/, and must not (#412)

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -92,6 +92,36 @@ This is the automated form of the manual "sealed tree md5 vs the repo baseline" 
 *Pre-cutover box checks* — prefer this. The regression test `tests/deploy_verify.mjs`
 proves it reports drift on a deliberately stale tree.
 
+### `console/` is not covered by this, and must not be added to the ship list (#412)
+
+The verifier's ship list mirrors `deploy.sh`'s rsync set, and neither includes `console/`.
+That is correct, not an omission: **the console is not served from the bridge host.** There
+is no HTTP listener on it — only SSH and DNS — so nothing there could serve the pages.
+Adding `console/` to `SHIP` would make every run report drift for files that have no
+business being on that box.
+
+Two consequences the verifier's green exit does not cover, and neither is theoretical —
+#412 was filed after a console fix appeared not to have shipped while both lanes verified
+166/166:
+
+- **The console is published separately, and by hand.** The bridge is pull-deployed: the
+  runner polls `main`, ships the first CI-green commit within minutes, and alarms on drift.
+  The console has none of that. It reaches the operator's browser from a checkout on a
+  different host, fast-forwarded to `origin/main` by a manual step. So for a console change,
+  *merged + CI green is not the authorisation to consider it live* — a person still has to
+  run the site deploy, and no check anywhere reports whether they did. A console fix can sit
+  unshipped indefinitely with every waggle deploy surface green.
+- **A stale console is a stale signing surface.** The console signs owner control commands.
+  Stale means signing against an old grammar, an old envelope shape or an old freshness
+  rule, with no signal. The modules are fetched by stable path with no cache-busting, so a
+  soft reload is enough to keep an old module graph alive — that is what #412 observed, and
+  a hard reload is currently the only remedy.
+
+The host, credentials and commands for the site deploy are operational and live in the
+operator's private brief, not here. What belongs here is the boundary: **`deploy.sh`,
+`verify-deployed.sh` and the deploy runner cover `src`, `tests`, `tools` and the tripwire
+units. They say nothing at all about `console/`.**
+
 ## Adding an agent seat (a new sealed-lane recipient)
 
 `add-recipient.sh` wires a new agent into the sealed lanes: it creates a private inbox

--- a/deploy/verify-deployed.sh
+++ b/deploy/verify-deployed.sh
@@ -32,6 +32,12 @@ cd "$REPO"
 
 # Canonical ship list — MUST mirror deploy.sh's rsync set. Dirs expand to the tracked
 # files at REF, so the "should match" set is defined by git, not by whatever is on disk.
+#
+# `console/` is deliberately absent and must stay absent (#412). The console is not served
+# from this host — there is no HTTP listener on it — so adding it here would report drift
+# for files that are correctly not present. It is published separately and by hand from a
+# checkout on another host, which means a green run here says nothing about whether a
+# console change is live. See deploy/README.md, "console/ is not covered by this".
 SHIP='src tests tools package.json package-lock.json config.example.json deploy/tripwire-alarm-bunker.conf deploy/waggle-tripwire-drill.service deploy/setup-tripwire-alarm.sh'
 PATHS=$(git ls-tree -r --name-only "$REF" -- $SHIP) \
   || { echo "  ✗ not a valid git ref: $REF"; exit 2; }


### PR DESCRIPTION
Establishes item 1 of #412 and closes item 2. Docs and one comment; no behaviour change.

## What I found

`console/` is not served from the bridge host. There is no HTTP listener on it — only SSH and DNS:

```
LISTEN 0 4096      127.0.0.54:53
LISTEN 0 4096         0.0.0.0:22
LISTEN 0 4096   127.0.0.53%lo:53
LISTEN 0 4096            [::]:22
```

`deploy.sh` rsyncs `src tests tools package.json package-lock.json config.example.json` plus three tripwire files, and `verify-deployed.sh`'s `SHIP` mirrors it exactly. Neither includes `console/`, and that is correct rather than an omission. **Adding `console/` to `SHIP` would make every run report drift for files that have no business being on that box.** Item 2 is closed as won't-do, with the reason recorded at the ship list.

The `console/` directories that do exist on the box are at `/opt/waggle-hub-read` and `/opt/waggle-hub-sealed` — the deploy runner's per-lane git clones. They are incidental to `git fetch`, current as of the last tick, and serve nothing. Only the `SHIP` subset is rsynced into `/opt/waggle-read` and `/opt/waggle-sealed`.

## The gap the issue was reaching for

The console reaches the operator's browser from a checkout on a **different host**, fast-forwarded to `origin/main` by a manual step. So the two halves of this project have different deploy models and only one of them is verified:

| | bridge | console |
|---|---|---|
| trigger | runner polls `main`, ships first CI-green commit | a person runs the site deploy |
| latency | minutes | until someone does it |
| drift check | `verify-deployed.sh`, alarms on failure | none |

**For a console change, "merged + CI green" is not the authorisation to consider it live**, and nothing anywhere reports whether the manual step happened. A console fix can sit unshipped indefinitely with every waggle deploy surface green — which is exactly the shape of the #404/#406 incident that prompted #412, even though that particular instance turned out to be a browser cache.

That matters because the console signs owner control commands. Stale means signing against an old grammar, an old envelope shape or an old freshness rule, with no signal.

## What is in the repo and what is not

Host, credentials and commands for the site deploy are operational and stay in the operator's private brief. What belongs in a public repo is the boundary, and that is what this adds: `deploy.sh`, `verify-deployed.sh` and the deploy runner cover `src`, `tests`, `tools` and the tripwire units, and say nothing at all about `console/`.

## Items 3 and 4 remain, and 4 has no repo-side answer yet

Item 4 (a negative control proving the verifier names a changed console file) cannot be written against `verify-deployed.sh`, because there is nothing on that host to verify. A console verifier would have to run against the site host. Item 3 (cache-busting) is split out — see the follow-up issue; its fix has a site-host half that is an operator action, which is why it could not be settled here.

## Evidence

`deploy_verify`, `deploy_runner`, `host_bootstrap` — rc=0. Positive control that the comment did not break the script: run against a deliberately stale local tree, it exits 1 and names the three drifted files.

## Reviewer note

@Neil — infra remit. The claim to attack is that no HTTP listener on the bridge host means the console cannot be served from it. If there is a path I have not considered — a tunnel, a reverse proxy elsewhere terminating to something on that box, a static host pulling from those hub clones — then the "must not be added to SHIP" conclusion needs revisiting.

Drafted with assistance from [Claude Code](https://claude.com/claude-code)