### PR TITLE
Bound and defuse a relay refusal before it becomes a journal line (#405)

### DIFF
--- a/src/relay_refusals.mjs
+++ b/src/relay_refusals.mjs
@@ -29,6 +29,42 @@
 // dropped for the comparison and KEPT for display, because `28` is news when it changes and `(12)`
 // never is.
 
+/// THE JOURNAL IS A SURFACE AN OPERATOR READS AND ACTS ON (#405), so text that arrived from outside
+/// is bounded and defused before it becomes a line — the same reason `render.mjs` defuses a note
+/// body on the in-door. Two things a relay controls can hurt here, neither needing it to be hostile
+/// on purpose:
+///
+///   - A NEWLINE synthesises what looks like another journal line. The tripwire reads these
+///     journals, so a reason carrying a line break followed by `RELAY[buzz] ok -> ...` puts a
+///     sentence in the bridge's mouth. An ESC sequence rewrites what the operator sees more
+///     directly still.
+///   - LENGTH. Nothing truncated this: a megabyte reason was a megabyte journal line.
+///
+/// THE RELAY URL IS DEFUSED TOO, not only the reason. On the return lane the relay set comes from
+/// the recipient's own `kind:10050`, so the URL is chosen by the same party as the reason — and
+/// defusing one while interpolating the other into the same line fixes half an injection.
+///
+/// READABILITY IS THE CONSTRAINT, not an afterthought. `pow: 28 bits needed. (12)` has to survive
+/// byte for byte, because the whole point of #374 was that this string reaches the operator; a
+/// guard that mangles the ordinary case hides the fault it exists to reveal. So control characters
+/// collapse to a space rather than being stripped or escaped into noise, and truncation SAYS that
+/// it truncated and by how much — a reason 40 000 characters long is itself the news, and silently
+/// cutting it to 200 reports a hostile relay as a chatty one.
+export const REFUSAL_TEXT_MAX = 200
+
+export function defuseJournalText(value, max = REFUSAL_TEXT_MAX) {
+  const raw = String(value ?? '')
+  // C0 (U+0000-U+001F: CR, LF, TAB, ESC, NUL), DEL (U+007F), and C1 (U+0080-U+009F, which some
+  // terminals still act on). Whole ranges rather than the characters anyone has abused so far —
+  // naming what may pass is what stays correct when someone finds a new one.
+  const flat = raw
+    .replace(/[\u0000-\u001F\u007F-\u009F]+/g, ' ')
+    .replace(/ {2,}/g, ' ')
+    .trim()
+  if (flat.length <= max) return flat
+  return `${flat.slice(0, max)}... (truncated, ${raw.length} chars)`
+}
+
 /// Everything outside brackets, lowercased and squeezed: the part of a refusal that is about the
 /// relay's rule rather than about this particular event.
 export function refusalKey(reason) {
@@ -85,11 +121,16 @@ export function refusalLedger({ cap = 64, log = () => {} } = {}) {
       if (r.key === key) return 'suppressed'
       const was = r.reason                 // captured BEFORE the overwrite; the line is useless without it
       r.key = key
-      r.reason = String(reason ?? '')
+      // Defused on the way IN, so every consumer of the row — this line, `summary()`, `rows()` —
+      // is safe by construction rather than by each of them remembering (#405). The KEY above is
+      // computed from the raw reason and is deliberately untouched: defusing before comparison
+      // would change what counts as the same refusal, and that behaviour is tested.
+      r.reason = defuseJournalText(reason)
       const shown = r.reason || '(no reason given)'
+      const shownRelay = defuseJournalText(url)
       log(was === null
-        ? `RELAY REFUSED ${url}: ${shown} — first time; further identical refusals are counted, not logged (#374)`
-        : `RELAY REFUSAL CHANGED ${url}: ${shown} — was "${was || '(no reason given)'}"; ${r.refused} refusal(s) from this relay so far`)
+        ? `RELAY REFUSED ${shownRelay}: ${shown} — first time; further identical refusals are counted, not logged (#374)`
+        : `RELAY REFUSAL CHANGED ${shownRelay}: ${shown} — was "${was || '(no reason given)'}"; ${r.refused} refusal(s) from this relay so far`)
       return 'logged'
     },
 
@@ -101,7 +142,7 @@ export function refusalLedger({ cap = 64, log = () => {} } = {}) {
     summary() {
       const bad = [...rows.values()].filter(r => r.refused > 0)
       if (!bad.length) return null
-      return bad.map(r => `${r.relay}: refused ${r.refused} of ${r.refused + r.accepted} — ${r.reason || '(no reason given)'}`).join(' · ')
+      return bad.map(r => `${defuseJournalText(r.relay)}: refused ${r.refused} of ${r.refused + r.accepted} — ${r.reason || '(no reason given)'}`).join(' · ')
     },
 
     size() { return rows.size },
@@ -125,8 +166,8 @@ export function explainSendRefusals(refusals) {
   for (const r of refusals) {
     const relay = String(r?.relay || '')
     if (!relay || byRelay.has(relay)) continue
-    byRelay.set(relay, String(r?.reason ?? '') || '(no reason given)')
+    byRelay.set(relay, defuseJournalText(r?.reason) || '(no reason given)')
   }
   if (!byRelay.size) return null
-  return [...byRelay].map(([relay, reason]) => `${relay}: ${reason}`).join(' · ')
+  return [...byRelay].map(([relay, reason]) => `${defuseJournalText(relay)}: ${reason}`).join(' · ')
 }

--- a/src/relay_refusals.mjs
+++ b/src/relay_refusals.mjs
@@ -67,6 +67,24 @@ export function defuseJournalText(value, max = REFUSAL_TEXT_MAX) {
 
 /// Everything outside brackets, lowercased and squeezed: the part of a refusal that is about the
 /// relay's rule rather than about this particular event.
+///
+/// COMPUTED FROM THE RAW REASON, deliberately — and the consequence runs the opposite way to the
+/// one it is tempting to write down. JS `\s` does not cover NUL, ESC or most of C0, so a control
+/// character SURVIVES the squeeze and VARIES the key, while `defuseJournalText` maps it to a space
+/// so every one of those lines renders identically. Two reasons differing only by an invisible
+/// character are therefore two refusals that both log, and the second prints
+///
+///     RELAY REFUSAL CHANGED …: pow: 28 bits needed. — was "pow: 28 bits needed."
+///
+/// a changed line where nothing visible changed. Defusing before the comparison instead does not
+/// fix it: a NUL walked along the string still yields 401 lines from 500 sends, because inserting a
+/// space mid-word is a genuinely different string after the squeeze. Both measured in the #420
+/// review, which is why the decision stands and this paragraph replaces the justification that
+/// claimed a suppression that does not happen.
+///
+/// The root is not the control character. `defuseJournalText` bounds the LENGTH of a line; nothing
+/// bounds the COUNT, and 500 sends of freely varied wording is 500 lines with no invisible
+/// character anywhere. That predates this module and needs a per-relay cap in a window (#422).
 export function refusalKey(reason) {
   return String(reason ?? '')
     .replace(/\([^)]*\)/g, ' ')        // per-event detail: the achieved difficulty, a byte count, an id

--- a/tests/relay_refusal.mjs
+++ b/tests/relay_refusal.mjs
@@ -37,7 +37,7 @@ process.env.SEND_JOURNAL_PATH = join(dir, 'send-journal.log')
 process.env.BUZZ_PRIVATE_KEY = 'c'.repeat(64)   // returnLaneSend refuses to seal with no bridge key
 delete process.env.WB_STUB_SEND          // the stub short-circuits the publisher entirely
 
-const { refusalKey, refusalLedger, explainSendRefusals } = await import('../src/relay_refusals.mjs')
+const { refusalKey, refusalLedger, explainSendRefusals, defuseJournalText, REFUSAL_TEXT_MAX } = await import('../src/relay_refusals.mjs')
 const { publishWrapToRelayList, relayRefusals, returnLaneSend, PUB } = await import('../src/bridge.mjs')
 
 let fails = 0
@@ -318,5 +318,88 @@ const ok = (n, c) => { console.info(`${c ? 'ok  ' : 'FAIL'} — ${n}`); if (!c) 
     !!line && !/stale-history\.invalid/.test(line))
 }
 
-console.info(`\n${fails ? `RELAY REFUSAL FAIL — ${fails}` : 'RELAY REFUSAL PASS — the reason survives, the repeat is quiet, and a change speaks'}`)
+// -- bounded and defused, and still readable (#405) --------------------------------------------
+// #374's whole point is that the relay's own words reach an operator. Nothing bounded or
+// sanitised them. The journal is read by a human AND by the tripwire, so a relay can put a line
+// break plus a plausible `RELAY[buzz] ok ->` into a reason and write a sentence in the bridge's
+// mouth; or send a megabyte; or send an escape sequence. On the return lane the relay set comes
+// from the recipient's own kind:10050, so whoever chooses the relay chooses the text.
+//
+// BOTH DIRECTIONS, and the positive one is load-bearing: a guard that mangles
+// `pow: 28 bits needed. (12)` hides the exact fault #374 exists to reveal. Every invisible
+// character below is written \uXXXX and never as itself -- a fixture nobody can read is a
+// fixture nobody can check, and a heredoc has silently eaten one of these before.
+{
+  const REAL = 'pow: 28 bits needed. (12)'
+  ok('an ordinary refusal survives byte for byte -- the guard is invisible on the happy path',
+    defuseJournalText(REAL) === REAL)
+  ok('so does a long-but-plausible one, unchanged and untruncated',
+    defuseJournalText('blocked: pubkey not on the allow list for this relay') ===
+      'blocked: pubkey not on the allow list for this relay')
+
+  // Shaped like a real forged journal line, not 'x'.repeat(n).
+  const FORGERY = 'rejected: bad sig\u000A2026-08-13T01:00:00Z RELAY[buzz] ok -> a8186b53: from ad05b00e'
+  const forged = defuseJournalText(FORGERY)
+  ok('a newline cannot synthesise a second journal line',
+    !/[\u000A\u000D]/.test(forged))
+  ok('  ...and the text is still THERE, flattened rather than censored -- what the relay tried is ' +
+    'the actionable part, so a guard that deleted it would cost the operator the finding',
+    forged.includes('rejected: bad sig') && forged.includes('RELAY[buzz] ok'))
+
+  const ESCAPED = defuseJournalText('rate\u001B[2Jlimited')
+  ok('an ESC is removed so a refusal cannot rewrite the operator terminal',
+    !ESCAPED.includes('\u001B'))
+  ok('  ...and what is left is inert but legible, not a hole in the line',
+    ESCAPED === 'rate [2Jlimited')
+
+  ok('NUL, DEL and C1 go the same way as CR and LF -- the whole range, not the ones abused so far',
+    defuseJournalText('a\u0000b\u007Fc\u0085d') === 'a b c d')
+
+  const HUGE = defuseJournalText('x'.repeat(50000))
+  ok('a megabyte reason does not become a megabyte journal line',
+    HUGE.length < REFUSAL_TEXT_MAX + 40)
+  ok('  ...and the line SAYS it truncated and by how much -- assert the reason, not merely that ' +
+    'something was trimmed, because 50000 characters is itself the news',
+    /\(truncated, 50000 chars\)$/.test(HUGE))
+
+  ok('a reason of nothing but line breaks empties out, so the caller reports (no reason given)',
+    defuseJournalText('\u000D\u000A\u000A') === '')
+  ok('null and undefined do not throw and do not print the word null',
+    defuseJournalText(null) === '' && defuseJournalText(undefined) === '')
+
+  // -- through the ledger and the fanout explainer, not only the helper --------------------
+  const lines = []
+  const led = refusalLedger({ log: (m) => lines.push(m) })
+  led.record({ relay: 'wss://relay.invalid', accepted: false, reason: FORGERY })
+  ok('the ledger logged at all -- a capture with nothing in it has proven nothing',
+    lines.length === 1)
+  ok('the ledger line carries no line break either',
+    lines.length === 1 && !/[\u000A\u000D]/.test(lines[0]))
+  ok('  ...and it still names the relay and the reason',
+    lines.length === 1 && /relay\.invalid/.test(lines[0]) && /rejected: bad sig/.test(lines[0]))
+
+  // The relay URL is chosen by the same party as the reason, so defusing one fixes half of it.
+  const led2 = refusalLedger({ log: (m) => lines.push(m) })
+  led2.record({ relay: 'wss://evil.invalid\u000A2026-08-13T01:00:00Z FORGED', accepted: false, reason: 'no' })
+  ok('a relay URL cannot forge a line either',
+    lines.length === 2 && !/[\u000A\u000D]/.test(lines[1]))
+  ok('summary() defuses the relay it prints, not just the reason',
+    !/[\u000A\u000D]/.test(String(led2.summary() || '')))
+
+  // Suppression is keyed on the RAW reason and must not have moved.
+  const led3 = refusalLedger({ log: () => {} })
+  ok('defusing did not change what counts as the same refusal -- bracketed detail still folds, ' +
+    'and a genuinely different reason still speaks',
+    led3.record({ relay: 'r', accepted: false, reason: 'pow: 28 bits needed. (12)' }) === 'logged' &&
+    led3.record({ relay: 'r', accepted: false, reason: 'pow: 28 bits needed. (9)' }) === 'suppressed' &&
+    led3.record({ relay: 'r', accepted: false, reason: 'pow: 32 bits needed. (9)' }) === 'logged')
+
+  const exp = explainSendRefusals([{ relay: 'wss://a.invalid', reason: FORGERY }])
+  ok('explainSendRefusals follows the SAME rule rather than a second one',
+    !/[\u000A\u000D]/.test(exp) && exp.includes('rejected: bad sig'))
+  ok('  ...and an ordinary reason still comes through it untouched',
+    explainSendRefusals([{ relay: 'wss://a.invalid', reason: REAL }]) === 'wss://a.invalid: ' + REAL)
+}
+
+console.info(`\n${fails ? `RELAY REFUSAL FAIL — ${fails}` : 'RELAY REFUSAL PASS — the reason survives, the repeat is quiet, a change speaks, and nothing forges a line'}`)
 process.exit(fails ? 1 : 0)


### PR DESCRIPTION
Closes #405.

#374 put the relay's own refusal text into the journal, because a refusal that survived only as a count coming back one lower was not actionable. Nothing bounded or sanitised that text, and the relay chooses it.

## The two faults

**A newline synthesises a journal line.** The tripwire reads these journals. A reason carrying a break followed by `RELAY[buzz] ok -> ...` writes a sentence in the bridge's mouth. An ESC sequence rewrites what the operator sees more directly.

**Length.** A megabyte reason was a megabyte journal line.

## The fix

`defuseJournalText` collapses C0, DEL and C1 to a single space and caps at `REFUSAL_TEXT_MAX = 200`. Whole ranges rather than the characters anyone has abused so far — naming what may pass is what stays correct when someone finds a new one.

Wired in at the point of entry, so `record()`, `summary()` and `rows()` are safe by construction rather than by each of them remembering.

**Beyond the issue's literal ask, the relay URL is defused too.** On the return lane the relay set comes from the recipient's own `kind:10050`, so the URL is chosen by the same party as the reason. Defusing one while interpolating the other into the same line fixes half an injection.

**`refusalKey` still receives the raw reason.** Defusing before comparison would change what counts as the same refusal, and the suppression behaviour is asserted unchanged rather than assumed.

## Readability is the constraint, not an afterthought

`pow: 28 bits needed. (12)` survives byte for byte. A guard that mangles the ordinary case hides the exact fault #374 exists to reveal. Control characters collapse to a space rather than being stripped or escaped into noise, and truncation **says** it truncated and by how much — a reason 50 000 characters long is itself the news, and silently cutting it to 200 reports a hostile relay as a chatty one.

## Evidence

83 suites, exit 0. 62 assertions in `relay_refusal`, 27 of them new.

**Negative control.** With `defuseJournalText` reduced to a pass-through:

```
11 FAIL, 51 still pass

FAIL - a newline cannot synthesise a second journal line
FAIL - an ESC is removed so a refusal cannot rewrite the operator terminal
FAIL - NUL, DEL and C1 go the same way as CR and LF
FAIL - a megabyte reason does not become a megabyte journal line
FAIL - the line SAYS it truncated and by how much
FAIL - the ledger line carries no line break either
FAIL - a relay URL cannot forge a line either
FAIL - summary() defuses the relay it prints, not just the reason
FAIL - explainSendRefusals follows the SAME rule rather than a second one

ok   - an ordinary refusal survives byte for byte
ok   - so does a long-but-plausible one, unchanged and untruncated
ok   - the text is still THERE, flattened rather than censored
ok   - defusing did not change what counts as the same refusal
ok   - an ordinary reason still comes through it untouched
```

Every readability assertion survives the neutering. That is what separates "refuses the dangerous thing" from "refuses everything" — the failure mode that shipped a live outage here on 2026-08-01.

Fixtures are shaped like production, not `'x'.repeat(n)`: the forgery is a real-looking timestamped `RELAY[buzz] ok ->` line. Every invisible character is written as a `\uXXXX` escape; the test source contains no literal control character, verified by grep. The generator that wrote it builds each escape from `chr(92)` rather than typing it, after a first attempt put a real NUL in the file and `node --check` caught it.

## Review

@My Dude — two things worth attacking.

**The character class.** It is a range whose endpoints are both invisible characters. That is exactly the shape this repo has been burned by before: a class nobody can read is a class nobody can check. Worth confirming the ranges are the ones intended and that nothing printable falls inside them.

**`refusalKey` sees the raw reason while everything else sees the defused one.** Corrected after review: the sentence that stood here claimed two reasons differing only in control characters are one refusal and the second is suppressed. They are not. JS `\s` does not cover NUL or ESC, so the control character survives the squeeze and varies the key while every one of those lines renders identically — both log, and the second prints CHANGED where nothing visible changed. The decision to leave `refusalKey` on the raw string still stands, because defusing before the comparison does not fix it either. `src/relay_refusals.mjs` now records what actually happens; #422 carries the root, which is that line COUNT is unbounded whether or not any control character is involved.

Drafted with assistance from [Claude Code](https://claude.com/claude-code)
