### PR TITLE
fix: report a route that lost its at-word to the WORD, not only to another route (#415)

### DIFF
--- a/console/task-route-mention.mjs
+++ b/console/task-route-mention.mjs
@@ -201,11 +201,55 @@ export function taskRouteMentioned(body, mention) {
 // about a single at-word, never about a route, which is why `carried` is resolved before
 // `suppressed` is answered.
 //
-// Returns { carried, suppressed }: `carried` maps mention key -> mention as written; `suppressed`
-// maps mention key -> { mention, by, at }, naming the longer mention that took the at-word and
-// where. The caller logs from `suppressed` — a route that silently stops receiving a carry it used
-// to receive presents as the return lane being flaky, which is the failure this repo keeps paying
-// for.
+// The at-word as written, for a near-miss line: the `@`, the route's own name, and the run of
+// mention characters that CONTINUED past it. The continuation stops at the first character outside
+// the alphabet, so it takes `@MC Claudette` out of `@MC Claudette please look` and not the rest of
+// the sentence. A space deliberately ends it: a space may be interior to a name, but a name is what
+// we are trying to identify here and swallowing them would print the whole message.
+//
+// SAFE FOR A JOURNAL BY CONSTRUCTION, not by sanitising afterwards. The prefix is the configured
+// mention, which the grammar has already refused control characters in, and the continuation is
+// drawn from `MENTION_ALPHABET` — letters, numbers and `_ . ' -` — so no newline or escape can
+// enter this string from the channel body. The cap is what bounds it: a 4 000-character word is
+// otherwise a 4 000-character journal line chosen by whoever wrote the message (cf. #405).
+const NEAR_MISS_WORD_MAX = 64
+function atWordAt(text, at, mentionLength) {
+  const tail = new RegExp(`[${MENTION_ALPHABET}]+`, 'uy')
+  tail.lastIndex = at + 1 + mentionLength
+  const run = tail.exec(text)
+  const word = `@${text.slice(at + 1, at + 1 + mentionLength)}${run ? run[0] : ''}`
+  return word.length <= NEAR_MISS_WORD_MAX ? word : `${word.slice(0, NEAR_MISS_WORD_MAX)}…`
+}
+
+// LOSING TO THE BOUNDARY IS ALSO A LOSS (#415). `suppressed` answers "which other ROUTE took this
+// at-word", and that leaves the more common case unreported: `@MC Claudette` carries to `MC` and
+// not to `MC Claude`, because the boundary correctly says the at-word did not end after `Claude`.
+// No route took it from `MC Claude` — the word itself did — so nothing was contested and nothing
+// was logged. The owner of `MC Claude` watched messages that visibly begin with their name reach
+// somebody else, with no line anywhere saying why.
+//
+// That is the same "presents as the return lane being flaky" failure the suppression log exists to
+// prevent, one case short of covered. So a route whose mention is a PREFIX of the at-word but whose
+// boundary lookahead failed is reported as a NEAR MISS, with the at-word as written, because the
+// at-word is the whole explanation: seeing `@MC Claudette` next to the route `MC Claude` ends the
+// question immediately.
+//
+// PRECEDENCE, and it matters more than it looks. carried > suppressed > near miss. A route that
+// carried anywhere in the body is not reported at all; a route already named in `suppressed` is not
+// reported twice under a second heading. Two lines about one route in one message is how a log
+// starts being skimmed instead of read.
+//
+// Returns { carried, suppressed, nearMissed }: `carried` maps mention key -> mention as written;
+// `suppressed` maps key -> { mention, by, at }, naming the longer mention that took the at-word and
+// where; `nearMissed` maps key -> { mention, word, at }, naming the at-word that continued past the
+// route's name. The caller logs from the latter two — a route that silently stops receiving a carry
+// it used to receive presents as the return lane being flaky, which is the failure this repo keeps
+// paying for.
+//
+// NOT RATE LIMITED HERE, deliberately. Both maps are keyed by mention, so one message yields at most
+// one line per route no matter how many at-words it holds. Across messages the caller's `rlDropOnce`
+// is per message id, so a channel where an agent's name is a common prefix logs once per message —
+// the same exposure `suppressed` already has, not a new one.
 export function taskRouteMentionArbitrate(body, mentions) {
   const text = String(body == null ? '' : body)
   const rows = []
@@ -216,16 +260,27 @@ export function taskRouteMentionArbitrate(body, mentions) {
     if (rows.some(row => row.key === key)) continue
     // Sticky, so a candidate is tested AT the at-word rather than anywhere after it. A non-sticky
     // test would let a mention later in the body win an at-word it does not start.
-    rows.push({ mention: m, key, re: new RegExp(`@${m.replace(RE_ESCAPE, '\\$&')}(?![${MENTION_ALPHABET}])`, 'iuy') })
+    // `re` is the real matcher. `pre` is the same pattern WITHOUT the boundary — the two together
+    // are what separate "this at-word is not your name" from "this at-word starts with your name
+    // and then keeps going", which is the whole of #415.
+    rows.push({ mention: m, key,
+      re: new RegExp(`@${m.replace(RE_ESCAPE, '\\$&')}(?![${MENTION_ALPHABET}])`, 'iuy'),
+      pre: new RegExp(`@${m.replace(RE_ESCAPE, '\\$&')}`, 'iuy') })
   }
   const carried = new Map()
   const contested = []
+  const missed = []
   for (let i = 0; i < text.length; i++) {
     if (text[i] !== '@') continue
     const hits = []
     for (const row of rows) {
       row.re.lastIndex = i
-      if (row.re.test(text)) hits.push(row)
+      if (row.re.test(text)) { hits.push(row); continue }
+      // Matched as a prefix, then the boundary said the at-word had not ended. That is a near miss,
+      // and it is recorded whether or not any OTHER route went on to take this at-word — the
+      // precedence pass below decides what is worth a line.
+      row.pre.lastIndex = i
+      if (row.pre.test(text)) missed.push({ row, at: i, word: atWordAt(text, i, row.mention.length) })
     }
     if (!hits.length) continue
     // EVERY mention of the longest length carries — the tie is not broken. See above.
@@ -239,5 +294,12 @@ export function taskRouteMentionArbitrate(body, mentions) {
     if (carried.has(row.key) || suppressed.has(row.key)) continue   // won elsewhere, or already recorded
     suppressed.set(row.key, { mention: row.mention, by, at })
   }
-  return { carried, suppressed }
+  const nearMissed = new Map()
+  for (const { row, at, word } of missed) {
+    // carried > suppressed > near miss. See the precedence note above: the quietest true statement
+    // about a route is the one worth printing, and printing two is how the log stops being read.
+    if (carried.has(row.key) || suppressed.has(row.key) || nearMissed.has(row.key)) continue
+    nearMissed.set(row.key, { mention: row.mention, word, at })
+  }
+  return { carried, suppressed, nearMissed }
 }

--- a/src/bridge.mjs
+++ b/src/bridge.mjs
@@ -2452,6 +2452,33 @@ function rlDropOnce(id) {
   return true
 }
 
+// Near-miss dedup (#425 review). A near miss is reported once per (route, at-word), not once per
+// message. `@MCX` near-missing `MC` is signal; the same channel member typing it forty more times
+// is the same one confusion, and a journal a human greps on demand loses its value by repetition.
+//
+// Deliberately NOT a frequency threshold, and that was the reviewer's point: "log the first N, then
+// go quiet" reproduces the exact failure #415 exists to stop — a route losing its at-word silently,
+// one layer down — and leaves the owner unable to tell "fixed" from "rate-limited" from the log
+// alone. Keying on content instead means every DISTINCT confusion still gets its line, and a new
+// near-miss word for the same route is a new line however long the old one has been repeating.
+//
+// A factory rather than a module-level Set so a test can hold its own and assert eviction; bounded
+// and insertion-ordered, the same shape as rlDropOnce, because this process is meant to run for
+// months and the at-words are supplied by whoever is typing in the channel.
+export function nearMissLedger({ cap = Number(process.env.NEAR_MISS_LOG_CAP || 2000) } = {}) {
+  const seen = new Set()
+  return (routeKey, word) => {
+    // Folded the same way `taskRouteMentionKey` folds, on BOTH halves: `@MCX` and `@mcx` are the
+    // same confusion, and a route is the same route whichever case its name was written in.
+    const k = `${taskRouteMentionKey(routeKey)}\n${taskRouteMentionKey(word)}`
+    if (seen.has(k)) return false
+    seen.add(k)
+    if (seen.size > cap) seen.delete(seen.values().next().value)
+    return true
+  }
+}
+const nearMissOnce = nearMissLedger()
+
 // Publish a wrap to the public relays, resolving to the count that returned OK-true. Per-relay OK is
 // the ONLY landing signal: a relay 503s or drops silently, and an explicit ["OK", id, false]
 // rejection used to read byte-identical to an accept (the loop counted any inbound frame). Finding
@@ -3503,8 +3530,11 @@ async function scanReturnLane(msgs, opts = {}) {
       // word itself are two things an operator does two different things about: the first is a
       // naming collision to resolve, the second is usually somebody typing a name that is not
       // anyone's. Collapsing them into one line would report a name clash that does not exist.
-      for (const { mention, word, at } of nearMissed.values())
-        log(`RETURN skip[longer-word]: ${String(m.id).slice(0, 12)}… @${mention} does not take the at-word at ${at} — ${word} continues past it`)
+      // Once per (route, at-word), not once per message — see nearMissLedger. The route key is the
+      // Map's own key, so this dedups on the same fold the arbitration already used.
+      for (const [routeKey, { mention, word, at }] of nearMissed)
+        if (nearMissOnce(routeKey, word))
+          log(`RETURN skip[longer-word]: ${String(m.id).slice(0, 12)}… @${mention} does not take the at-word at ${at} — ${word} continues past it`)
     }
     let carried = false
     // No break: one message fans out to EVERY matching recipient, each deduped on its own

--- a/src/bridge.mjs
+++ b/src/bridge.mjs
@@ -3492,13 +3492,19 @@ async function scanReturnLane(msgs, opts = {}) {
     // must not take an at-word from one that is.
     const contestants = recipients.filter(r => !r.dynamic && !!r.mention &&
       (!r.managedTaskRoute || r.scan_channel === String(opts.channel || '').toLowerCase()))
-    const { carried: namedHere, suppressed: shadowed } =
+    const { carried: namedHere, suppressed: shadowed, nearMissed } =
       taskRouteMentionArbitrate(body, contestants.map(r => r.mention))
     // Named, not dropped silently. This says only who took the at-word — a route can also fail to
     // carry for reasons that have nothing to do with naming, and this line does not claim otherwise.
-    if (shadowed.size && rlDropOnce(m.id)) {
+    if ((shadowed.size || nearMissed.size) && rlDropOnce(m.id)) {
       for (const { mention, by, at } of shadowed.values())
         log(`RETURN skip[longer-name]: ${String(m.id).slice(0, 12)}… @${mention} does not take the at-word at ${at} — @${by} is longer`)
+      // A DIFFERENT reason, under its own heading (#415). Losing to another route and losing to the
+      // word itself are two things an operator does two different things about: the first is a
+      // naming collision to resolve, the second is usually somebody typing a name that is not
+      // anyone's. Collapsing them into one line would report a name clash that does not exist.
+      for (const { mention, word, at } of nearMissed.values())
+        log(`RETURN skip[longer-word]: ${String(m.id).slice(0, 12)}… @${mention} does not take the at-word at ${at} — ${word} continues past it`)
     }
     let carried = false
     // No break: one message fans out to EVERY matching recipient, each deduped on its own

--- a/src/task_route_mention.mjs
+++ b/src/task_route_mention.mjs
@@ -218,11 +218,55 @@ export function taskRouteMentioned(body, mention) {
 // about a single at-word, never about a route, which is why `carried` is resolved before
 // `suppressed` is answered.
 //
-// Returns { carried, suppressed }: `carried` maps mention key -> mention as written; `suppressed`
-// maps mention key -> { mention, by, at }, naming the longer mention that took the at-word and
-// where. The caller logs from `suppressed` — a route that silently stops receiving a carry it used
-// to receive presents as the return lane being flaky, which is the failure this repo keeps paying
-// for.
+// The at-word as written, for a near-miss line: the `@`, the route's own name, and the run of
+// mention characters that CONTINUED past it. The continuation stops at the first character outside
+// the alphabet, so it takes `@MC Claudette` out of `@MC Claudette please look` and not the rest of
+// the sentence. A space deliberately ends it: a space may be interior to a name, but a name is what
+// we are trying to identify here and swallowing them would print the whole message.
+//
+// SAFE FOR A JOURNAL BY CONSTRUCTION, not by sanitising afterwards. The prefix is the configured
+// mention, which the grammar has already refused control characters in, and the continuation is
+// drawn from `MENTION_ALPHABET` — letters, numbers and `_ . ' -` — so no newline or escape can
+// enter this string from the channel body. The cap is what bounds it: a 4 000-character word is
+// otherwise a 4 000-character journal line chosen by whoever wrote the message (cf. #405).
+const NEAR_MISS_WORD_MAX = 64
+function atWordAt(text, at, mentionLength) {
+  const tail = new RegExp(`[${MENTION_ALPHABET}]+`, 'uy')
+  tail.lastIndex = at + 1 + mentionLength
+  const run = tail.exec(text)
+  const word = `@${text.slice(at + 1, at + 1 + mentionLength)}${run ? run[0] : ''}`
+  return word.length <= NEAR_MISS_WORD_MAX ? word : `${word.slice(0, NEAR_MISS_WORD_MAX)}…`
+}
+
+// LOSING TO THE BOUNDARY IS ALSO A LOSS (#415). `suppressed` answers "which other ROUTE took this
+// at-word", and that leaves the more common case unreported: `@MC Claudette` carries to `MC` and
+// not to `MC Claude`, because the boundary correctly says the at-word did not end after `Claude`.
+// No route took it from `MC Claude` — the word itself did — so nothing was contested and nothing
+// was logged. The owner of `MC Claude` watched messages that visibly begin with their name reach
+// somebody else, with no line anywhere saying why.
+//
+// That is the same "presents as the return lane being flaky" failure the suppression log exists to
+// prevent, one case short of covered. So a route whose mention is a PREFIX of the at-word but whose
+// boundary lookahead failed is reported as a NEAR MISS, with the at-word as written, because the
+// at-word is the whole explanation: seeing `@MC Claudette` next to the route `MC Claude` ends the
+// question immediately.
+//
+// PRECEDENCE, and it matters more than it looks. carried > suppressed > near miss. A route that
+// carried anywhere in the body is not reported at all; a route already named in `suppressed` is not
+// reported twice under a second heading. Two lines about one route in one message is how a log
+// starts being skimmed instead of read.
+//
+// Returns { carried, suppressed, nearMissed }: `carried` maps mention key -> mention as written;
+// `suppressed` maps key -> { mention, by, at }, naming the longer mention that took the at-word and
+// where; `nearMissed` maps key -> { mention, word, at }, naming the at-word that continued past the
+// route's name. The caller logs from the latter two — a route that silently stops receiving a carry
+// it used to receive presents as the return lane being flaky, which is the failure this repo keeps
+// paying for.
+//
+// NOT RATE LIMITED HERE, deliberately. Both maps are keyed by mention, so one message yields at most
+// one line per route no matter how many at-words it holds. Across messages the caller's `rlDropOnce`
+// is per message id, so a channel where an agent's name is a common prefix logs once per message —
+// the same exposure `suppressed` already has, not a new one.
 export function taskRouteMentionArbitrate(body, mentions) {
   const text = String(body == null ? '' : body)
   const rows = []
@@ -233,16 +277,27 @@ export function taskRouteMentionArbitrate(body, mentions) {
     if (rows.some(row => row.key === key)) continue
     // Sticky, so a candidate is tested AT the at-word rather than anywhere after it. A non-sticky
     // test would let a mention later in the body win an at-word it does not start.
-    rows.push({ mention: m, key, re: new RegExp(`@${m.replace(RE_ESCAPE, '\\$&')}(?![${MENTION_ALPHABET}])`, 'iuy') })
+    // `re` is the real matcher. `pre` is the same pattern WITHOUT the boundary — the two together
+    // are what separate "this at-word is not your name" from "this at-word starts with your name
+    // and then keeps going", which is the whole of #415.
+    rows.push({ mention: m, key,
+      re: new RegExp(`@${m.replace(RE_ESCAPE, '\\$&')}(?![${MENTION_ALPHABET}])`, 'iuy'),
+      pre: new RegExp(`@${m.replace(RE_ESCAPE, '\\$&')}`, 'iuy') })
   }
   const carried = new Map()
   const contested = []
+  const missed = []
   for (let i = 0; i < text.length; i++) {
     if (text[i] !== '@') continue
     const hits = []
     for (const row of rows) {
       row.re.lastIndex = i
-      if (row.re.test(text)) hits.push(row)
+      if (row.re.test(text)) { hits.push(row); continue }
+      // Matched as a prefix, then the boundary said the at-word had not ended. That is a near miss,
+      // and it is recorded whether or not any OTHER route went on to take this at-word — the
+      // precedence pass below decides what is worth a line.
+      row.pre.lastIndex = i
+      if (row.pre.test(text)) missed.push({ row, at: i, word: atWordAt(text, i, row.mention.length) })
     }
     if (!hits.length) continue
     // EVERY mention of the longest length carries — the tie is not broken. See above.
@@ -256,5 +311,12 @@ export function taskRouteMentionArbitrate(body, mentions) {
     if (carried.has(row.key) || suppressed.has(row.key)) continue   // won elsewhere, or already recorded
     suppressed.set(row.key, { mention: row.mention, by, at })
   }
-  return { carried, suppressed }
+  const nearMissed = new Map()
+  for (const { row, at, word } of missed) {
+    // carried > suppressed > near miss. See the precedence note above: the quietest true statement
+    // about a route is the one worth printing, and printing two is how the log stops being read.
+    if (carried.has(row.key) || suppressed.has(row.key) || nearMissed.has(row.key)) continue
+    nearMissed.set(row.key, { mention: row.mention, word, at })
+  }
+  return { carried, suppressed, nearMissed }
 }

--- a/tests/task_route_mention.mjs
+++ b/tests/task_route_mention.mjs
@@ -307,7 +307,7 @@ process.env.FORWARD_MODE = 'buzz'
 process.env.WB_STUB_SEND = '1'
 process.env.WB_NO_BOOT = '1'
 
-const { scanReturnLane, PUB, grantSet } = await import('../src/bridge.mjs')
+const { scanReturnLane, PUB, grantSet, nearMissLedger } = await import('../src/bridge.mjs')
 grantSet.set(myDude, { grantId: '1'.repeat(64), grantor: crew })
 grantSet.set(mcClaude, { grantId: '2'.repeat(64), grantor: crew })
 grantSet.set(mcOnly, { grantId: '3'.repeat(64), grantor: crew })
@@ -634,6 +634,55 @@ ok('end to end: a tie reaches BOTH agents, so the real agent is not displaced',
     captured.join(' / ').slice(0, 200))
   ok('  …and the line says which longer name took the at-word, and where',
     !!line && /@MC does not take the at-word at \d+ — @MC Claude is longer/.test(line), String(line))
+}
+
+// The NEAR MISS is a DIFFERENT reason and gets its own line (#415), deduped by content rather than
+// by count (#425 review). Driven end to end, because the dedup lives at the log site and a unit
+// test of the ledger alone would not prove the log site consults it.
+{
+  const captured = []
+  const realLog = console.log
+  console.log = (...a) => { captured.push(a.join(' ')) }
+  const nearMisses = () => captured.filter(l => l.includes('skip[longer-word]'))
+  await carriedBy('@MCX please look at this')            // @MC matched as a prefix; the word ran on
+  const first = nearMisses().length
+  await carriedBy('@MCX again, exactly the same typo')   // same (route, word) — one confusion, not two
+  const repeat = nearMisses().length
+  await carriedBy('@mcx once more, in lower case')       // the same confusion, written differently
+  const folded = nearMisses().length
+  await carriedBy('@MCY a DIFFERENT typo for the same route')
+  const distinct = nearMisses().length
+  console.log = realLog
+
+  ok('a near miss is reported, under its own heading and not as a name clash',
+    first === 1 && /@MC does not take the at-word at \d+ — @MCX continues past it/.test(nearMisses()[0] || ''),
+    (nearMisses()[0] || captured.join(' / ')).slice(0, 200))
+  ok('  …and the same at-word again is NOT reported again — one confusion, one line',
+    repeat === first, `${first} -> ${repeat}`)
+  ok('  …including in another case, because the key folds the way the route key folds',
+    folded === first, `${first} -> ${folded}`)
+  // The direction a count threshold gets wrong, and the reason the dedup is by content: a threshold
+  // cannot tell a new confusion from the fortieth repeat of an old one, so it goes quiet on real,
+  // standing drift — which is the failure #415 exists to stop, one layer down.
+  ok('NEGATIVE CONTROL — a NEW at-word for the same route still gets its own line',
+    distinct === first + 1, `${folded} -> ${distinct}`)
+}
+
+// The ledger on its own, for the bound. Its own instance, so it is not reading state the end-to-end
+// block above left behind.
+{
+  const once = nearMissLedger({ cap: 3 })
+  ok('the ledger reports a first sighting', once('mc', '@MCX') === true)
+  ok('  …and refuses the same pair', once('mc', '@MCX') === false)
+  ok('  …while a different ROUTE with the same word is a different confusion', once('my dude', '@MCX') === true)
+  ok('  …and a different WORD for the same route is too', once('mc', '@MCY') === true)
+  // Eviction, insertion-ordered: the fourth distinct pair pushes the first one out, so it reports
+  // again rather than being remembered forever on a process meant to run for months. A cap that
+  // never evicted would pass every assertion above.
+  ok('NEGATIVE CONTROL — past the cap the OLDEST pair is evicted and reports again',
+    once('mc', '@MCZ') === true && once('mc', '@MCX') === true)
+  ok('  …while the newest pair is still remembered, so eviction is ordered and not a wipe',
+    once('mc', '@MCZ') === false)
 }
 
 console.log(fails ? `\nTASK ROUTE MENTION FAIL — ${fails}` : '\nTASK ROUTE MENTION PASS — grammar, reasons, console join, boundary, arbitration, end-to-end carry')

--- a/tests/task_route_mention.mjs
+++ b/tests/task_route_mention.mjs
@@ -464,8 +464,9 @@ ok('  …and the legitimate carry still lands, so the fix suppresses rather than
 console.log('\narbitration — longest wins per at-word, both directions')
 
 const arb = (body, mentions) => {
-  const { carried, suppressed } = taskRouteMentionArbitrate(body, mentions)
-  return { won: [...carried.values()].sort(), lost: [...suppressed.values()].map(s => s.mention).sort() }
+  const { carried, suppressed, nearMissed } = taskRouteMentionArbitrate(body, mentions)
+  return { won: [...carried.values()].sort(), lost: [...suppressed.values()].map(s => s.mention).sort(),
+    near: [...nearMissed.values()].map(n => `${n.mention} in ${n.word}`).sort() }
 }
 const ROUTES = ['MC', 'MC Claude', 'My Dude']
 const ALL_ROUTES = [...ROUTES, MESNIL_LONG, 'Mesnil']
@@ -500,6 +501,68 @@ ok('the winner does not depend on route order',
 
 // Size floor — an arbitration over no routes must report nothing rather than everything.
 ok('no routes means nothing carries', arb('@MC Claude', []).won.length === 0)
+
+// ---------------------------------------------------------------------------------------------
+// Losing to the BOUNDARY is also a loss (#415). `suppressed` answers "which other route took it",
+// which left the commoner case silent: `@MC Claudette` carries to `MC` and not to `MC Claude`, no
+// route took it, nothing was logged, and the owner of `MC Claude` watched messages that visibly
+// begin with their name reach somebody else with no line anywhere saying why.
+// ---------------------------------------------------------------------------------------------
+console.log('\nnear misses — the at-word that continued past the name')
+
+ok('a route whose name is a prefix of a longer WORD is reported',
+  arb('@MC Claudette please look', ROUTES).near.join('|') === 'MC Claude in @MC Claudette',
+  JSON.stringify(arb('@MC Claudette please look', ROUTES)))
+ok('  …and the at-word as written is IN the line, because that is the whole explanation',
+  arb('@MC Claudeé said no', ROUTES).near.join('|') === 'MC Claude in @MC Claudeé')
+ok('  …a possessive counts too — a different name, not this one',
+  arb("@MC Claude's Assistant will", ROUTES).near.join('|') === "MC Claude in @MC Claude's")
+ok('  …and the shorter route still CARRIES the at-word it legitimately owns',
+  arb('@MC Claudette please look', ROUTES).won.join('|') === 'MC')
+
+// BOTH DIRECTIONS. A near-miss report that fired on every at-word would be worse than silence: the
+// log exists to be read, and one that always says something says nothing.
+ok('an at-word that is nobody-and-nothing-like is not a near miss for anyone',
+  arb('@Nobody at all', ROUTES).near.length === 0, JSON.stringify(arb('@Nobody at all', ROUTES)))
+ok('a route that WON its at-word outright is not also reported as missing it',
+  arb('@MC Claude — please look at this.', ROUTES).near.length === 0)
+ok('an unrelated route is not dragged into someone else\'s near miss',
+  !arb('@MC Claudette please look', ROUTES).near.some(n => n.startsWith('My Dude')))
+
+// PRECEDENCE — carried beats suppressed beats near miss. Two lines about one route in one message
+// is how a log starts being skimmed instead of read.
+ok('a route that carried ELSEWHERE gets no near-miss line for the at-word it lost',
+  arb('@MC Claudette and @MC Claude', ROUTES).near.length === 0,
+  JSON.stringify(arb('@MC Claudette and @MC Claude', ROUTES)))
+{
+  const both = arb('@MC Claude then @MCX', ROUTES)
+  ok('a route suppressed by another ROUTE is not ALSO reported as a near miss',
+    both.lost.join('|') === 'MC' && both.near.length === 0, JSON.stringify(both))
+}
+// The two are genuinely different findings, and the operator does different things about them, so
+// a body producing one of each must produce one of each.
+{
+  const mixed = arb('@My Dudette and @MC Claude', ROUTES)
+  ok('a body with one of each reports one of each, under its own heading',
+    mixed.lost.join('|') === 'MC' && mixed.near.join('|') === 'My Dude in @My Dudette',
+    JSON.stringify(mixed))
+}
+
+// The word is outside-controlled text on its way to a journal (#405 is the same lesson). It cannot
+// carry a control character — the continuation is drawn from the mention alphabet — and it is
+// capped, or a 4 000-character word is a 4 000-character journal line chosen by the sender.
+{
+  const long = arb(`@MC Claude${'x'.repeat(4000)} hello`, ROUTES)
+  ok('a monstrous word does not become a monstrous log line',
+    long.near.length === 1 && long.near[0].length < 120, String(long.near[0]?.length))
+  ok('  …and it SAYS it was cut, rather than silently reading as a shorter word',
+    String(long.near[0] ?? '').endsWith('…'), JSON.stringify(long.near))
+  const broken = arb('@MC Claude\u000Ayikes RETURN forged', ROUTES)
+  ok('a newline right after the name cannot get into the reported word',
+    !/[\u000A]/.test(broken.near.join('|') + broken.won.join('|')))
+  ok('  …and that body is a plain carry, not a near miss — a newline ENDS the at-word',
+    broken.won.join('|') === 'MC Claude' && broken.near.length === 0, JSON.stringify(broken))
+}
 
 // TIES ARE NOT BROKEN — the claim this fix originally rested on was false (#414 review).
 // `taskRouteMentionKey` folds with `toLowerCase()` (Unicode case MAPPING); the matcher folds with


### PR DESCRIPTION
Closes #415. **Stacked on #414** (`fix/409-longest-mention-wins`) — it extends the arbitration that PR introduces, so merge that first or this diff will not read correctly.

`RETURN skip[longer-name]` fires only when a route lost an at-word to another **route**. `@MC Claudette` carries to `MC` and not to `MC Claude`: no route took it, so nothing was contested and nothing was logged. The owner of `MC Claude` watched messages that visibly begin with their name reach somebody else, with no line anywhere saying why — the same "presents as the return lane being flaky" failure the suppression log exists to prevent, one case short of covered.

## The fix

A route whose mention is a prefix of the at-word but whose boundary lookahead failed is a **near miss**, reported under its own heading with the at-word as written:

```
RETURN skip[longer-word]: 9f2c… @MC Claude does not take the at-word at 0 — @MC Claudette continues past it
```

The at-word is the whole explanation. Seeing `@MC Claudette` next to the route `MC Claude` ends the question, which `skip[longer-name]` could never do because there was no longer name to name.

**Two headings, not one.** Losing to another route is a naming collision the operator resolves. Losing to the word is usually somebody typing a name that is not anyone's. Collapsing them into one line would report a name clash that does not exist.

**Precedence: carried > suppressed > near miss.** A route that carried anywhere in the body is not reported at all; a route already named in `suppressed` is not reported again under a second heading. One message yields at most one line per route.

## Bounding, because this is outside-controlled text on its way to a journal

Same lesson as #405. The reported word is capped at 64 characters with a visible ellipsis — a 4 000-character word would otherwise be a 4 000-character journal line chosen by whoever wrote the message. It cannot carry a control character by construction rather than by sanitising afterwards: the prefix is the configured mention, which the grammar has already refused control characters in, and the continuation is drawn from `MENTION_ALPHABET`, which is letters, numbers and `_ . ' -`.

Not rate limited beyond that, deliberately. Both maps are keyed by mention, and the caller's `rlDropOnce` is per message id, so the exposure is the one `suppressed` already has, not a new one. #415 asked the question; that is the answer.

## Evidence

83 suites, exit 0. `task_route_mention` 181 assertions, 13 new.

**Negative control**, with `nearMissed` forced to return empty:

```
174 ok, 7 FAIL   (was 181 ok, 0 FAIL)

FAIL — a route whose name is a prefix of a longer WORD is reported
FAIL —   …and the at-word as written is IN the line
FAIL —   …a possessive counts too — a different name, not this one
FAIL — a body with one of each reports one of each, under its own heading
FAIL — a monstrous word does not become a monstrous log line
FAIL —   …and it SAYS it was cut
FAIL — the shared section is byte-identical      (src neutered, console copy not)
```

**Stated plainly rather than counted as proof:** the precedence assertions and the "not a near miss for anyone" assertions all stay green under the neutered guard, because they assert an empty set and an empty set is what a dead guard produces. They are still worth having — they are what would catch a guard that fires on every at-word — but they prove nothing about this mutation and I am not claiming they do. The six that moved are the ones carrying the weight.

One fixture was changed after the first negative-control run: `long.near[0].endsWith(…)` threw on `undefined` under the neutered guard and took every later assertion down with it, so the run reported 161 ok and looked smaller rather than failing louder. It now reads through `String(… ?? '')` and fails as an assertion. A suite that dies mid-way tells you less than one that fails.

## Review

@Dennis — one thing to attack, and it is a judgement call about noise rather than correctness.

**Every at-word that merely starts with a route's name now produces a line.** `@MCX`, `@Dennisson`, `@MC Claude's` — all near misses. In a channel where an agent's name is a common word or a common prefix, that is a line per message, forever, and the operator learns to skim past exactly the heading that is supposed to tell them why a delivery went missing. I think it is right at this volume, and the per-message keying keeps it to one line per route, but the failure mode of a too-chatty log is the same as a silent one and it is worth a second opinion on whether this wants a threshold.

Drafted with assistance from [Claude Code](https://claude.com/claude-code)
