### PR TITLE
tests: verify the wire form where verifyEvent was reading a stamp (#320)

### DIFF
--- a/tests/dm_relay_list_publish.mjs
+++ b/tests/dm_relay_list_publish.mjs
@@ -61,8 +61,12 @@ const theirSk = generateSecretKey(), theirPk = getPublicKey(theirSk)
   // BOTH DIRECTIONS. A guard that refuses everything passes every assertion above.
   const right = fakeSigner(mineSk)
   const event = await signDmRelayList(right, DM_URLS, minePk, { createdAt: AT })
+  // Verify the WIRE form: fakeSigner returns finalizeEvent's own object, which nostr-tools stamps
+  // with `verifiedSymbol`, and verifyEvent short-circuits on that stamp. Confirmed: without the
+  // roundtrip, `{ ...event, sig: '0'.repeat(128) }` also passes — so the assertion carrying the
+  // "not refuse everything" direction proved only that an object existed. #320.
   test('the CORRECT identity still signs and publishes — the guard is not "refuse everything"',
-    event.kind === 10050 && event.pubkey === minePk && verifyEvent(event))
+    event.kind === 10050 && event.pubkey === minePk && verifyEvent(JSON.parse(JSON.stringify(event))))
   test('and it signed exactly once', right.calls.length === 1)
   test('the Bunker path and the local path produce byte-identical content',
     JSON.stringify(event.tags) === JSON.stringify(buildDmRelayListEvent(mineSk, DM_URLS, AT).tags))

--- a/tests/nip98_auth.mjs
+++ b/tests/nip98_auth.mjs
@@ -49,7 +49,11 @@ const built = await build({ secretKey: sk, url, method: 'POST', body: JSON.strin
 const ev = built.event
 
 ok('kind is 27235', ev.kind === 27235)
-ok('it is signed by the key given, and verifies', ev.pubkey === pk && verifyEvent(ev))
+// Verify the WIRE form. `build` above returns the finalizeEvent result directly, and nostr-tools
+// stamps `verifiedSymbol` on what it finalizes — verifyEvent short-circuits on that marker, so
+// verifying the object itself asserts nothing about the signature. Confirmed: without the
+// roundtrip, `{ ...ev, sig: '0'.repeat(128) }` also passes. #320.
+ok('it is signed by the key given, and verifies', ev.pubkey === pk && verifyEvent(JSON.parse(JSON.stringify(ev))))
 ok('the u tag is the expected URL', tag(ev, 'u') === url)
 ok('the method tag is upper-cased', tag(ev, 'method') === 'POST')
 ok('a lower-case method is still sent upper-cased',


### PR DESCRIPTION
Closes #320.

`nostr-tools` stamps what `finalizeEvent` produces with an internal `verifiedSymbol` and `verifyEvent` short-circuits on it. Verifying that object asserts nothing about the signature. Two sites did exactly that.

## The two real sites

`tests/nip98_auth.mjs:52` — `build` is defined in the test file and returns `finalizeEvent`'s result directly.

`tests/dm_relay_list_publish.mjs:65` — `fakeSigner` returns `finalizeEvent`'s own object. This is the worse of the two: it is the assertion carrying the *"the guard is not refuse-everything"* direction, so the both-directions check was resting on an object existing.

## Proven per site, not assumed

Before the fix, replacing the event with `{ ...ev, sig: '0'.repeat(128) }`:

```
ok   — it is signed by the key given, and verifies
ok - the CORRECT identity still signs and publishes — the guard is not "refuse everything"
```

After the fix, the same corruption:

```
FAIL — it is signed by the key given, and verifies
FAIL - the CORRECT identity still signs and publishes — the guard is not "refuse everything"
```

That difference is the entire point of the change, and #320 asked for it explicitly.

## A per-site read, and a correction to the estimate

The issue estimated roughly six more sites. Two were real, and **one of them was not on the list**. The rest need no change:

| site | why it is already fine |
|---|---|
| `control_state.mjs` (×2) | both go through its `wire()` helper |
| `return_lane_task_carry.mjs` (×2) | both already `JSON.parse(JSON.stringify(…))` |
| `relay_ingress.mjs` | its only match is prose in a header comment, not a call |
| `tripwire_detection.mjs` | `receivedWrap` arrives over a websocket from a separate process — already the wire form |
| `dm_relay_list_publish.mjs:13` | already round-tripped at construction |
| `nostr_signer.mjs:62` | `signEvent` returns `JSON.parse(…)` from the NIP-46 round trip |
| `nostr_signer.mjs:77` | `alarmSeal` is parsed out of a nip44 decrypt |

Changing any of those would have been noise, which is why #320 asked for a per-site read rather than a bulk edit.

## Evidence

Full suite: 83 suites, exit 0.

Tests only, so this is outside the substantive-review bar — but the negative control is the part worth checking, not the diff.

Drafted with assistance from [Claude Code](https://claude.com/claude-code)
