### PR TITLE
Collapse six hand-written scope-hash copies to one, and fix the salt divergence (#328)

### DIFF
--- a/src/bridge.mjs
+++ b/src/bridge.mjs
@@ -42,6 +42,7 @@ import { bridgePubkey, bridgeSignerMode, hasBridgeKey, openSeal, openRumor, seal
 import { verifyConsent } from './consent.mjs'   // in-door consent (#131/#132, docs/CONSENT.md §8)
 import { consentState } from './consent_state.mjs'   // one honest word per watched author (#389)
 import { createHash, randomBytes } from 'node:crypto'
+import { scopeHashSync, scopeHashOrNull } from './scope_hash.mjs'
 import { readFileSync, writeFileSync, appendFileSync, existsSync, mkdirSync, renameSync, unlinkSync, openSync, closeSync, fsyncSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -832,10 +833,10 @@ const NIPDA = (() => {
   const d = { grant: 440, revocation: 441, index: 10440, dataset: 30440, scopeTag: 'da-scope', capTag: 'da-cap' }
   try { return { ...d, ...JSON.parse(readFileSync(NIPDA_PATH, 'utf8')) } } catch { return d }
 })()
-const scopeHash = (channelId, saltHex) =>
-  createHash('sha256').update(Buffer.concat([
-    Buffer.from('waggle/da-scope/v1'), Buffer.from([0]), Buffer.from(String(channelId)), Buffer.from(saltHex, 'hex'),
-  ])).digest('hex')
+// Two sites, opposite requirements — see src/scope_hash.mjs. The grant handler below reads a
+// salt off the wire and must ignore what it cannot decode; buildConsentPrefill issues with a salt
+// this process just generated, where an undecodable salt is our own bug and must not be swallowed
+// into a published tag.
 // grantee pubkey -> Map(grantId -> grantor). A SET of grants, not one, and that is the whole of
 // #364: a grantee may legitimately hold several — one per channel, per capability, or simply
 // re-issued. This map used to hold the last one written, so revoking THAT id de-admitted a key
@@ -1094,7 +1095,10 @@ function processGrantEvent(ev, { emitFn = emit, queryFn = query } = {}) {
   if (!grantee || !scope || !cap) return
   // The salted hash binds the grant to a channel without the channel id riding publicly;
   // the bridge knows its own channel id, so it recomputes and compares.
-  if (scope[1] !== scopeHash(PUB.inbox, scope[2] || '')) return // scoped to some other channel — not ours
+  const ourScope = scopeHashOrNull(String(PUB.inbox), scope[2] || '')
+  // null = the salt on this grant is not even-length hex, so it decodes to no subject and binds
+  // to nothing. Ignored like any other foreign scope, and never thrown out of the handler.
+  if (ourScope === null || scope[1] !== ourScope) return // scoped to some other channel — not ours
   if (cap !== 'admit' && cap !== 'admit+read') return
   // Already revoked, and we simply saw the two events in the order the relay chose to serve them.
   // Refused loudly rather than silently: admitting here is what seated a revoked key in the roster,
@@ -1219,7 +1223,7 @@ function buildConsentPrefill() {
   const salt = randomBytes(16).toString('hex')
   return {
     kind: 440, created_at: Math.floor(Date.now() / 1000),
-    tags: [['p', BRIDGE_PK], ['da-scope', scopeHash(PUB.mirrorConsentHiveId, salt), salt], ['da-cap', 'mirror'], ['tos', PUB.mirrorExpectedTosHash || '']],
+    tags: [['p', BRIDGE_PK], ['da-scope', scopeHashSync(String(PUB.mirrorConsentHiveId), salt), salt], ['da-cap', 'mirror'], ['tos', PUB.mirrorExpectedTosHash || '']],
     content: '',
   }
 }

--- a/src/consent.mjs
+++ b/src/consent.mjs
@@ -15,20 +15,16 @@
 // granted. Only the grantor may revoke their own consent.
 
 import { verifyEvent } from 'nostr-tools/pure'
-import { createHash } from 'node:crypto'
+import { scopeHashOrNull } from './scope_hash.mjs'
 
 export const KIND = { grant: 440, revocation: 441 }
 export const CONSENT_CAP = 'mirror'
 
-// Identical construction to tools/grant.mjs and src/bridge.mjs (scopeHash). If this drifts, a
-// consent scoped to a community will never match the community's own recomputed hash and every
-// consent silently fails closed — so it is written to mirror them literally.
-export function scopeHash(communityId, saltHex) {
-  return createHash('sha256').update(Buffer.concat([
-    Buffer.from('waggle/da-scope/v1'), Buffer.from([0]),
-    Buffer.from(String(communityId)), Buffer.from(saltHex, 'hex'),
-  ])).digest('hex')
-}
+// The sixth hand-written copy, and one #328 did not list. Kept as an export because the suite
+// imports it; the construction now comes from src/scope_hash.mjs so it cannot drift from the
+// issuer. verifyConsent reads its salt off a candidate 440, so a salt that is not even-length hex
+// returns null and matches nothing rather than throwing.
+export const scopeHash = (communityId, saltHex) => scopeHashOrNull(String(communityId), saltHex)
 
 const tagVal = (ev, k) => (ev.tags.find(t => t[0] === k) || [])[1]
 

--- a/src/scope_hash.mjs
+++ b/src/scope_hash.mjs
@@ -1,0 +1,76 @@
+// scope_hash.mjs — the one node-side construction (#328).
+//
+// A NIP-DA grant never names its subject publicly. It carries a salted hash instead:
+//
+//     sha256( "waggle/da-scope/v1" || 0x00 || <subject> || <salt> )
+//
+// with a fresh 16-byte salt per grant, so two grants over the same subject are not linkable by
+// anyone watching the relays.
+//
+// WHY THIS FILE EXISTS. Five node copies wrote that preimage out by hand:
+//
+//     tools/grant.mjs:168 (issue) and :217 (verify), tools/mint-consent.mjs:87,
+//     tools/propose-admission.mjs:59, src/bridge.mjs:835
+//
+// Both drift directions are silent and both still produce a hash. If the ISSUER drifts, every
+// grant it signs binds to a subject nothing can match — it verifies, it goes live, it admits
+// nobody, forever. If a READER drifts, live grants stop resolving in that surface while remaining
+// valid everywhere else, so a console shows an admitted agent as unadmitted. Neither raises an
+// error, and one hash looks exactly like another.
+//
+// WHY NOT ONE FILE FOR THE WHOLE PROJECT. `console/scope-hash.mjs` is the browser copy and cannot
+// be collapsed into this one: the deploy ship list is `src tests tools …` and does NOT include
+// `console/` (deploy/deploy-runner.sh:63, deploy/deploy.sh:36), so shipped code importing from
+// there would fail to load on the box with ERR_MODULE_NOT_FOUND. It is also the wrong direction —
+// nothing under `src/` is served to a browser. So the project keeps two copies on purpose, the
+// same arrangement `console/consent-vocabulary.mjs` documents, and `tests/scope_hash.mjs` holds
+// them together by comparing both against a longhand third construction and against a hash taken
+// from a grant that is live on the relays. Six hand-written copies became two that a test binds.
+import { createHash } from 'node:crypto'
+
+const LABEL = 'waggle/da-scope/v1'
+
+// Deliberately NOT `Buffer.from(saltHex, 'hex')`, which is what the five copies used. That decodes
+// as much as it can and silently drops the rest, so '', 'zz' and 'ZZZZ' all became zero bytes and
+// hashed IDENTICALLY — while console/scope-hash.mjs threw on two of the three. A grant carrying
+// such a salt was resolvable by the bridge and unresolvable by the console, with no error on
+// either side. Matching the console's stricter rule is the behaviour change #328 asked for.
+const hexToBytes = (hex) => {
+  const s = String(hex || '')
+  if (s === '') return new Uint8Array(0)
+  if (!/^([0-9a-f]{2})+$/i.test(s)) throw new Error('salt must be an even-length hex string')
+  return Uint8Array.from(s.match(/../g).map(h => parseInt(h, 16)))
+}
+
+// The exact byte layout. The subject is hashed as its UTF-8 bytes exactly as given: a 64-hex
+// pubkey for an agent scope, a lowercase uuid for a channel scope. Callers must pass the
+// normalised form — `tools/grant.mjs` decodes npub → hex before it gets here, and passing an npub
+// would hash the npub, produce a valid-looking grant, and match nothing.
+export function scopePreimage(subject, saltHex) {
+  const enc = new TextEncoder()
+  const salt = hexToBytes(saltHex)
+  const prefix = enc.encode(LABEL)
+  const subj = enc.encode(String(subject))
+  const buf = new Uint8Array(prefix.length + 1 + subj.length + salt.length)
+  buf.set(prefix, 0)
+  buf[prefix.length] = 0
+  buf.set(subj, prefix.length + 1)
+  buf.set(salt, prefix.length + 1 + subj.length)
+  return buf
+}
+
+// Synchronous, unlike the console's, which hashes through WebCrypto to stay browser-safe. Every
+// node caller here is synchronous and two of them sit inside filters, so they cannot await.
+export const scopeHashSync = (subject, saltHex) =>
+  createHash('sha256').update(scopePreimage(subject, saltHex)).digest('hex')
+
+// For the two callers whose salt arrives OVER THE WIRE — `tools/grant.mjs list --agent/--channel`
+// and the bridge's grant handler — where a malformed salt is ordinary hostile input rather than a
+// bug in our own code. There it must mean "this grant matches nothing", never an exception thrown
+// out of a filter or an event handler. A grant whose salt nobody can decode binds to no subject,
+// so no-match is the correct answer and not merely the safe one.
+export const scopeHashOrNull = (subject, saltHex) => {
+  try { return scopeHashSync(subject, saltHex) } catch { return null }
+}
+
+export const SCOPE_LABEL = LABEL

--- a/tests/nipda_admission.mjs
+++ b/tests/nipda_admission.mjs
@@ -83,7 +83,29 @@ const forged = grant(grantorSk, strangerPk, CHAN); forged.sig = (forged.sig[0] =
 processGrantEvent(forged)
 check(!grantSet.has(strangerPk), 'forged-signature grant dropped')
 
+// A grant whose SALT is not even-length hex (#328). The salt rides publicly in the tag, so this is
+// ordinary wire input that anyone can publish — and the old construction fed it to
+// `Buffer.from(saltHex, 'hex')`, which decodes what it can and drops the rest, so '', 'zz' and
+// 'ZZZZ' all became zero bytes and hashed identically. The console threw on two of those three,
+// which is the reader-drift failure #328 names: resolvable here, unresolvable there, no error on
+// either side. Now such a salt decodes to no subject, so the grant binds to nothing.
+//
+// The load-bearing half is that it must not THROW. This runs inside the grant event handler, and
+// an exception out of it on a tag anyone can publish is a read-lane outage.
+for (const badSalt of ['zz', 'ZZZZ', 'abc']) {
+  const bad = wire(finalizeEvent({
+    kind: 440, created_at: now(),
+    tags: [['p', strangerPk], ['da-scope', 'f'.repeat(64), badSalt], ['da-cap', 'admit']], content: '',
+  }, grantorSk))
+  let threw = null
+  try { processGrantEvent(bad) } catch (e) { threw = e }
+  check(threw === null, `malformed salt ${JSON.stringify(badSalt)} does not throw out of the grant handler`)
+  check(!grantSet.has(strangerPk), `  …and does not admit — the salt decodes to no subject`)
+}
+
 // The real grant admits the stranger; the reply now routes to the community inbox.
+// Also the negative control for the six assertions above: a handler that ignored every grant would
+// satisfy all of them while admitting nobody, ever.
 const g = grant(grantorSk, strangerPk, CHAN)
 processGrantEvent(g)
 check(grantSet.has(strangerPk), 'valid grant admits the participant')

--- a/tests/scope_hash.mjs
+++ b/tests/scope_hash.mjs
@@ -181,5 +181,59 @@ for (const [name, subject] of [['an agent pubkey', OLIVER], ['a channel uuid', C
     'and the real construction still agrees, so the controls are not passing because everything differs')
 }
 
+// ── THE NODE OWNER, AND THE TWO COPIES HELD TOGETHER (#328) ─────────────────────────────────
+// Six hand-written node copies of this construction became one: src/scope_hash.mjs. It cannot be
+// merged with console/scope-hash.mjs, because the deploy ship list is `src tests tools …` and does
+// not include console/ (deploy/deploy-runner.sh:63) — shipped code importing from there would fail
+// to load on the box. So two copies remain BY NECESSITY, and this section is what stops them
+// drifting: both are compared against the longhand `reference` above and against each other.
+{
+  const node = await import('../src/scope_hash.mjs')
+
+  for (const [name, subject] of [['an agent pubkey', OLIVER], ['a channel uuid', CHANNEL]]) {
+    check(node.scopeHashSync(subject, SALT) === reference(subject, SALT),
+      `${name}: src/scope_hash.mjs matches the independent longhand implementation`)
+    check(node.scopeHashSync(subject, SALT) === await scopeHash(subject, SALT),
+      `${name}: src/scope_hash.mjs and console/scope-hash.mjs agree — the two copies are bound`)
+  }
+  check(node.SCOPE_LABEL === SCOPE_LABEL, 'both copies carry the same domain label')
+  check(Buffer.from(node.scopePreimage(OLIVER, SALT)).equals(Buffer.from(scopePreimage(OLIVER, SALT))),
+    'and the same preimage, byte for byte — the label, the separator, and the order of subject and salt')
+
+  // The strongest single assertion in this file, now applied to the node copy too: a grant that
+  // was signed and published before any of this refactor existed.
+  check(node.scopeHashSync(OLIVER, '5463a4e15781cbc705aedafa0423b08d')
+        === 'b6c00312269a4dab018e32de4102ffcdb57434d18c88d84619fd1030ee809911',
+    'LIVE VECTOR — the node copy recomputes a grant that is signed and on the relays right now')
+
+  // The malformed-salt behaviour change. The five old copies used `Buffer.from(saltHex, "hex")`,
+  // which decodes what it can and drops the rest — so these three salts all became zero bytes and
+  // hashed IDENTICALLY, while the console threw on two of them. Two of the six copies take their
+  // salt off the wire, so this was reachable: a grant the bridge resolved and the console did not.
+  const oldWay = s => createHash('sha256').update(Buffer.concat([
+    Buffer.from('waggle/da-scope/v1'), Buffer.from([0]), Buffer.from(OLIVER), Buffer.from(s, 'hex')])).digest('hex')
+  check(oldWay('') === oldWay('zz') && oldWay('zz') === oldWay('ZZZZ'),
+    'THE DEFECT — under the old construction an empty, a non-hex and a longer non-hex salt all hash the SAME')
+  for (const bad of ['zz', 'ZZZZ', 'abc']) {
+    let threw = false
+    try { node.scopeHashSync(OLIVER, bad) } catch { threw = true }
+    check(threw, `  …and src/scope_hash.mjs now refuses a malformed salt (${JSON.stringify(bad)}) instead`)
+  }
+
+  // scopeHashOrNull is what the two WIRE-FACING callers use — tools/grant.mjs `list --agent` and
+  // the bridge's grant handler. A malformed salt there is hostile input, not a bug in our code, so
+  // it must mean "matches nothing" and must never throw out of a filter or an event handler.
+  for (const bad of ['zz', 'ZZZZ', 'abc']) {
+    check(node.scopeHashOrNull(OLIVER, bad) === null,
+      `  …and scopeHashOrNull returns null for ${JSON.stringify(bad)} rather than throwing`)
+  }
+  // Both directions. Without these, an OrNull that returned null unconditionally would satisfy
+  // every assertion above while making the bridge ignore every grant ever issued.
+  check(node.scopeHashOrNull(OLIVER, SALT) === node.scopeHashSync(OLIVER, SALT),
+    'NEGATIVE CONTROL — a well-formed salt still returns the real hash through scopeHashOrNull')
+  check(node.scopeHashOrNull(OLIVER, '') === node.scopeHashSync(OLIVER, ''),
+    'and an EMPTY salt is well-defined, not malformed — it must keep working, not become null')
+}
+
 console.log(`\n${pass ? 'ALL PASS' : 'FAILURES ABOVE'}`)
 process.exit(pass ? 0 : 1)

--- a/tools/grant.mjs
+++ b/tools/grant.mjs
@@ -23,7 +23,8 @@
 // from config/nipda_kinds.json when present (NIPDA_KINDS_PATH to override).
 
 import WebSocket from 'ws'
-import { randomBytes, createHash } from 'node:crypto'
+import { randomBytes } from 'node:crypto'
+import { scopeHashSync, scopeHashOrNull } from '../src/scope_hash.mjs'
 import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { dirname, resolve } from 'node:path'
@@ -165,9 +166,7 @@ if (cmd === 'whoami') {
   // the same subject linkable, which is the exact property the salt exists to prevent.
   for (const g of grantees) {
     const salt = randomBytes(16).toString('hex')
-    const hash = createHash('sha256').update(Buffer.concat([
-      Buffer.from('waggle/da-scope/v1'), Buffer.from([0]), Buffer.from(subject), Buffer.from(salt, 'hex'),
-    ])).digest('hex')
+    const hash = scopeHashSync(subject, salt)
     const ev = await signer.sign({
       kind: NIPDA.grant,
       created_at: Math.floor(Date.now() / 1000),
@@ -214,10 +213,11 @@ if (cmd === 'whoami') {
     if (!filterSubject) return true
     const tag = e.tags.find(t => t[0] === NIPDA.scopeTag)
     if (!tag) return false
-    const recomputed = createHash('sha256').update(Buffer.concat([
-      Buffer.from('waggle/da-scope/v1'), Buffer.from([0]), Buffer.from(filterSubject), Buffer.from(tag[2] || '', 'hex'),
-    ])).digest('hex')
-    return tag[1] === recomputed
+    // The salt is WIRE-SUPPLIED here — anyone can publish a 440 with a salt that is not hex.
+    // A grant nobody can decode a salt for binds to no subject, so it matches nothing; it must
+    // not throw out of a filter and kill the listing.
+    const recomputed = scopeHashOrNull(filterSubject, tag[2] || '')
+    return recomputed !== null && tag[1] === recomputed
   }
   let shown = 0
   for (const e of evs) {

--- a/tools/mint-consent.mjs
+++ b/tools/mint-consent.mjs
@@ -23,6 +23,7 @@
 import { finalizeEvent, getPublicKey, generateSecretKey } from 'nostr-tools/pure'
 import * as nip19 from 'nostr-tools/nip19'
 import { createHash, randomBytes } from 'node:crypto'
+import { scopeHashSync } from '../src/scope_hash.mjs'
 import { writeFileSync, mkdtempSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { resolve } from 'node:path'
@@ -83,9 +84,7 @@ if (cmd === 'revoke') {
 
 // Build the consent 440 — the SAME shape the bridge's disclosure DM would prefill.
 const salt = randomBytes(16).toString('hex')
-const scopeHash = createHash('sha256').update(Buffer.concat([
-  Buffer.from('waggle/da-scope/v1'), Buffer.from([0]), Buffer.from(HIVE), Buffer.from(salt, 'hex'),
-])).digest('hex')
+const scopeHash = scopeHashSync(HIVE, salt)
 
 // tos hash: from the canonical block (one producer), unless overridden.
 let tosHash = flag('--tos-hash')

--- a/tools/propose-admission.mjs
+++ b/tools/propose-admission.mjs
@@ -31,6 +31,7 @@ import { finalizeEvent, getPublicKey } from 'nostr-tools/pure'
 import * as nip19 from 'nostr-tools/nip19'
 import { createHash } from 'node:crypto'
 import { randomBytes } from 'node:crypto'
+import { scopeHashSync } from '../src/scope_hash.mjs'
 
 const arg = (n, d) => { const i = process.argv.indexOf(n); return i > -1 && process.argv[i + 1] ? process.argv[i + 1] : d }
 const die = (m) => { console.error(`propose-admission: ${m}`); process.exit(1) }
@@ -55,9 +56,7 @@ const DRY = !!process.env.DRY_RUN
 // The scope hash — IDENTICAL construction to tools/grant.mjs and the console. If this drifts, the
 // bridge computes a different hash from its own channel id and the admission silently never matches.
 const salt = randomBytes(16).toString('hex')
-const scopeHash = createHash('sha256').update(Buffer.concat([
-  Buffer.from('waggle/da-scope/v1'), Buffer.from([0]), Buffer.from(channel), Buffer.from(salt, 'hex'),
-])).digest('hex')
+const scopeHash = scopeHashSync(channel, salt)
 
 // The UNSIGNED 440 draft. Same shape grant.mjs signs: p=grantee, da-scope=(hash,salt), da-cap=admit.
 const draft = {


### PR DESCRIPTION
Closes #328.

Six non-test copies, not five. `src/consent.mjs:26` is the sixth and it is a verify path — the issue's list missed it. All six now call `src/scope_hash.mjs`.

## They did not all agree

The issue said "present agreement, not present divergence". That holds for a well-formed 16-byte salt. It does not hold for a malformed one, and three of the six copies take their salt off the wire.

Every copy decoded with `Buffer.from(saltHex, 'hex')`, which decodes what it can and silently drops the rest:

```
""      -> 0 bytes      ""     -> 23-byte preimage
"zz"    -> 0 bytes      "zz"   -> THROWS
"ZZZZ"  -> 0 bytes      "ZZZZ" -> THROWS
"abc"   -> 1 byte       "abc"  -> THROWS
        node side              console/scope-hash.mjs
```

So `''`, `'zz'` and `'ZZZZ'` hash **identically** on the node side while the console refuses two of the three. A grant carrying such a salt resolved on the bridge and raised in the console, with no error on either side — failure mode #2 in the issue, an admitted agent displayed as unadmitted. Reachable by anyone, since the salt rides publicly in the tag.

## Two exports, because issue and verify need opposite things

| | behaviour | used by |
|---|---|---|
| `scopeHashSync` | throws on a malformed salt | the three issuer sites, where the salt is 16 CSPRNG bytes and a bad one is our own bug |
| `scopeHashOrNull` | returns `null` | the three wire-facing sites, where a bad salt is hostile input and must mean "matches nothing", never an exception out of an event handler |

`src/bridge.mjs` had **one** helper serving both — `:1098` reads a wire salt, `:1223` issues with a locally generated one. Split, so neither site inherits the other's requirement.

This is item 3 of the issue, adopting the console's stricter rule deliberately.

## Why two copies remain, and what holds them together

`console/scope-hash.mjs` stays. The deploy ship list is `src tests tools package.json …` and does **not** include `console/` (`deploy/deploy-runner.sh:63`, `deploy/deploy.sh:36`), so shipped code importing from there fails to load on the box with `ERR_MODULE_NOT_FOUND`. It is also the wrong direction — nothing under `src/` is served to a browser. This is the arrangement `console/consent-vocabulary.mjs` already documents.

So six copies become two, and `tests/scope_hash.mjs` binds them: both are compared against a longhand third implementation written out in the test file, against each other byte-for-byte at the preimage, and against the live vector.

Item 2 of the issue is respected — the four `tests/` copies keep recomputing independently.

## Proof, not a green run

Three drifts applied to `src/scope_hash.mjs` and reverted:

| drift | `scope_hash.mjs` | `nipda_admission.mjs` |
|---|---|---|
| label `v1` → `v2` | 8 fail | 12 fail |
| `0x00` separator → `0x01` | 7 fail | 12 fail |
| `scopeHashOrNull` forced to `null` | 3 fail | 12 fail |

The third matters most: it is the one a "safe" refactor would introduce, and it fails the negative controls rather than the refusal assertions.

**The live vector recomputes unchanged** — grant `01a41ce2…`, signed by `tools/grant.mjs` on 2026-08-09 and readable on the relays, now hashed through the new module. That is what shows the refactor did not move any real hash, and it is the only check that would survive every copy drifting together.

New at the bridge level: a grant with a malformed salt is ignored **and does not throw**, for three salts, paired with the existing "valid grant admits the participant" as the negative control — a handler that ignored everything would satisfy all six otherwise.

Full suite green, 0 failures.

## Found on the way, filed separately

`tools/relay-invite.mjs:53` imports `../console/nip98.mjs`, and `tools/` ships while `console/` does not. Reproduced against a simulated ship-set tree: `ERR_MODULE_NOT_FOUND`. Not touched here.

---

Substantive — it changes the grant admission path in `src/bridge.mjs` and the consent verify path. Please read the issuer/verifier split before merging; that is where I would look for a mistake. @My Dude

Drafted with assistance from [Claude Code](https://claude.com/claude-code)
