### PR TITLE
Defuse the invisibles that reorder a journal line, not only the controls (#423)

### DIFF
--- a/src/relay_refusals.mjs
+++ b/src/relay_refusals.mjs
@@ -52,13 +52,46 @@
 /// cutting it to 200 reports a hostile relay as a chatty one.
 export const REFUSAL_TEXT_MAX = 200
 
+/// Everything that can change what a line LOOKS like without being visible in it (#423).
+///
+/// Named by Unicode category rather than by codepoint — the same principle as the original C0/C1
+/// range, and the reason that one has held. Naming what may pass stays correct when somebody finds
+/// a control nobody had listed.
+///
+///   \p{Cc}  the 65 C0/C1/DEL controls this function already collapsed
+///   \p{Cf}  format characters: U+202E RIGHT-TO-LEFT OVERRIDE and the U+2066-U+2069 isolates,
+///           which REORDER the line with no C0 or C1 character anywhere in it; plus the zero-width
+///           set (U+200B, U+200C, U+200D, U+2060, U+FEFF), U+00AD SOFT HYPHEN and the bidi marks
+///   \p{Zl}  U+2028 LINE SEPARATOR
+///   \p{Zp}  U+2029 PARAGRAPH SEPARATOR
+///   \p{Zs}  the space separators, including U+00A0 NO-BREAK SPACE
+///
+/// U+202E is the one with teeth. The journal is text an operator reads and acts on — the premise
+/// the whole of #405 rests on — and an override reorders it while every byte-level check keeps
+/// passing. An unterminated isolate does the same to whatever prints on the line AFTER this one.
+///
+/// U+00A0 is here having been thought about rather than collapsed reflexively: it already renders
+/// as a space, so mapping it to one costs nothing visible, and "already looks fine" is not the same
+/// as "is a space". The suite asserts it now IS one.
+///
+/// EVERYTHING BECOMES A SPACE, including the zero-width characters, where deleting them would look
+/// tidier. Deleting can JOIN two tokens into one that never existed; spacing can only ever separate.
+/// A visible extra space is honest, and a fabricated word is not.
+///
+/// The cost, stated rather than discovered: an emoji sequence joined by U+200D comes apart into its
+/// components. A relay refusal is not where emoji families belong, and ZWJ is itself a way to hide
+/// what a string contains, so the trade is deliberate — but the ordinary case is the constraint, and
+/// `pow: 28 bits needed. (12)` and non-ASCII relay wording are both asserted to survive intact.
+// Exported as the SOURCE STRING, not as a compiled /g regex: the suite sweeps the plane against
+// this exact class, and a /g regex carries `lastIndex` between calls, so a shared one would
+// report a different answer on the second character it was asked about (#423).
+export const INVISIBLE_CLASS = '[\\p{Cc}\\p{Cf}\\p{Zl}\\p{Zp}\\p{Zs}]'
+const INVISIBLE = new RegExp(`${INVISIBLE_CLASS}+`, 'gu')
+
 export function defuseJournalText(value, max = REFUSAL_TEXT_MAX) {
   const raw = String(value ?? '')
-  // C0 (U+0000-U+001F: CR, LF, TAB, ESC, NUL), DEL (U+007F), and C1 (U+0080-U+009F, which some
-  // terminals still act on). Whole ranges rather than the characters anyone has abused so far —
-  // naming what may pass is what stays correct when someone finds a new one.
   const flat = raw
-    .replace(/[\u0000-\u001F\u007F-\u009F]+/g, ' ')
+    .replace(INVISIBLE, ' ')
     .replace(/ {2,}/g, ' ')
     .trim()
   if (flat.length <= max) return flat

--- a/tests/relay_refusal.mjs
+++ b/tests/relay_refusal.mjs
@@ -37,7 +37,7 @@ process.env.SEND_JOURNAL_PATH = join(dir, 'send-journal.log')
 process.env.BUZZ_PRIVATE_KEY = 'c'.repeat(64)   // returnLaneSend refuses to seal with no bridge key
 delete process.env.WB_STUB_SEND          // the stub short-circuits the publisher entirely
 
-const { refusalKey, refusalLedger, explainSendRefusals, defuseJournalText, REFUSAL_TEXT_MAX } = await import('../src/relay_refusals.mjs')
+const { refusalKey, refusalLedger, explainSendRefusals, defuseJournalText, REFUSAL_TEXT_MAX, INVISIBLE_CLASS } = await import('../src/relay_refusals.mjs')
 const { publishWrapToRelayList, relayRefusals, returnLaneSend, PUB } = await import('../src/bridge.mjs')
 
 let fails = 0
@@ -399,6 +399,104 @@ const ok = (n, c) => { console.info(`${c ? 'ok  ' : 'FAIL'} — ${n}`); if (!c) 
     !/[\u000A\u000D]/.test(exp) && exp.includes('rejected: bad sig'))
   ok('  ...and an ordinary reason still comes through it untouched',
     explainSendRefusals([{ relay: 'wss://a.invalid', reason: REAL }]) === 'wss://a.invalid: ' + REAL)
+}
+
+
+// ---- invisible controls beyond C0/C1 (#423) -----------------------------------------------------
+// From the #420 review. `defuseJournalText` collapsed exactly the 65 Cc codepoints — no printable
+// character inside, none outside — and everything else survived. The one with teeth is U+202E
+// RIGHT-TO-LEFT OVERRIDE: it reorders what the operator reads with no C0 or C1 character anywhere
+// in the string, and the journal being text an operator reads and acts on is the premise the whole
+// of #405 rests on. The isolates U+2066-U+2069 do the same more selectively, and an unterminated
+// one bleeds into whatever prints on the next line.
+//
+// Every character below is written as an escape. A NUL probe and a non-breaking space inside a
+// character class have each broken tooling in this repo, and a literal invisible in a fixture is a
+// fixture nobody can review.
+{
+  const RTLO = '\u202E', LRO = '\u202D', LRI = '\u2066', RLI = '\u2067', FSI = '\u2068', PDI = '\u2069'
+  const ZWSP = '\u200B', ZWNJ = '\u200C', ZWJ = '\u200D', WJ = '\u2060', BOM = '\uFEFF'
+  const SHY = '\u00AD', NBSP = '\u00A0', LS = '\u2028', PS = '\u2029', ALM = '\u061C'
+
+  // READABILITY FIRST, as in #405. If the ordinary case does not survive byte for byte, the guard
+  // hides the fault the journal exists to reveal, and nothing below is worth having.
+  ok('the ordinary refusal still survives the widened class byte for byte',
+    defuseJournalText('pow: 28 bits needed. (12)') === 'pow: 28 bits needed. (12)')
+  ok('a non-ASCII relay message is untouched — accented letters are not controls',
+    defuseJournalText('relais refusé: événement trop grand') === 'relais refusé: événement trop grand')
+  ok('and so is non-Latin wording, which has no Cf or Zs in it at all',
+    defuseJournalText('拒绝: 事件过大') === '拒绝: 事件过大')
+
+  // The attack the issue is about, stated as the property: the override does not reach the line.
+  const spoof = `blocked: ${RTLO}deriuqer stib 82${PDI} — retry`
+  ok('U+202E does not reach the journal line', !defuseJournalText(spoof).includes(RTLO))
+  ok('and the U+2069 that terminated it does not either', !defuseJournalText(spoof).includes(PDI))
+  ok('what is left is still readable rather than emptied',
+    /blocked:.*retry/.test(defuseJournalText(spoof)) && defuseJournalText(spoof).length > 20)
+
+  for (const [name, ch] of [['U+202D LRO', LRO], ['U+2066 LRI', LRI], ['U+2067 RLI', RLI],
+    ['U+2068 FSI', FSI], ['U+2069 PDI', PDI], ['U+200B ZWSP', ZWSP], ['U+200C ZWNJ', ZWNJ],
+    ['U+200D ZWJ', ZWJ], ['U+2060 WJ', WJ], ['U+FEFF BOM', BOM], ['U+00AD SHY', SHY],
+    ['U+2028 LS', LS], ['U+2029 PS', PS], ['U+061C ALM', ALM]]) {
+    ok(`${name} is collapsed, not carried`, !defuseJournalText(`a${ch}b`).includes(ch))
+  }
+
+  // U+00A0 is the one to think about rather than collapse reflexively: it already renders as a
+  // space, so mapping it to one costs nothing visible. "Already looks fine" is not "is a space",
+  // which is why this asserts the codepoint rather than the appearance.
+  ok('U+00A0 becomes an actual space, not something that merely looks like one',
+    defuseJournalText(`pow:${NBSP}28 bits`) === 'pow: 28 bits')
+
+  // Zero-width characters become a space rather than being deleted. Deleting can JOIN two tokens
+  // into a word that never existed; spacing can only ever separate.
+  ok('a zero-width space separates rather than fusing two tokens',
+    defuseJournalText(`ab${ZWSP}cd`) === 'ab cd')
+
+  // A run of mixed invisibles is one space, not one space each — the squeeze still applies.
+  ok('a run of mixed invisibles collapses to a single space',
+    defuseJournalText(`a${RTLO}${ZWSP}${NBSP}${SHY}b`) === 'a b')
+
+  // Leading and trailing invisibles must not survive as padding that hides the shape of the line.
+  ok('invisibles at the edges are trimmed away entirely',
+    defuseJournalText(`${BOM}${NBSP}pow: 28 bits needed.${RTLO}`) === 'pow: 28 bits needed.')
+
+  // THE NEGATIVE CONTROL IS THE SWEEP, not a spot check. Two directions, because a class that
+  // catches everything and a class that catches nothing both make the list above pass or fail as a
+  // block. This asserts the class catches exactly the invisible categories and no printable
+  // character anywhere in the plane.
+  const single = new RegExp(`^${INVISIBLE_CLASS}$`, 'u')
+  let caught = 0, printableCaught = []
+  const PRINTABLE_SAMPLE = 'Aa0!~ßé中カ😀→'   // Latin, digit, punctuation, accented, CJK, kana, emoji, arrow
+  for (let cp = 0; cp <= 0x10FFFF; cp++) {
+    if (cp >= 0xD800 && cp <= 0xDFFF) continue          // lone surrogates are not characters
+    if (single.test(String.fromCodePoint(cp))) caught++
+  }
+  // A floor, because a sweep that examined nothing reports every character clean. Deliberately LOW:
+  // it exists to prove the loop ran, not to assert the size of the class. Set near the real count it
+  // would report INCONCLUSIVE for the very regression this block exists to catch - reverting to
+  // Cc alone catches 65, which is a correct sweep of a wrong class and must read as FAIL.
+  if (caught < 10) {
+    console.error(`relay_refusal: INCONCLUSIVE — the plane sweep caught only ${caught} codepoints`)
+    console.error('  This is NOT an all-clear: the class was not exercised against the plane.')
+    process.exit(3)
+  }
+  ok(`the class catches ${caught} codepoints across the whole plane, and they are all invisible`,
+    caught > 100 && caught < 5000)
+  for (const ch of PRINTABLE_SAMPLE) if (single.test(ch)) printableCaught.push(ch)
+  ok(`NEGATIVE CONTROL — no printable character is caught (${PRINTABLE_SAMPLE})`,
+    printableCaught.length === 0)
+  ok('NEGATIVE CONTROL — the sweep CAN catch, so the zero above is a measurement',
+    single.test(RTLO) && single.test(ZWSP) && single.test('\u0020'))
+
+  // The 65 Cc codepoints the original class covered are still covered. A widening that quietly
+  // dropped the thing it was widening would otherwise pass everything above.
+  let cc = 0
+  // The three Cc ranges by hand, NOT `cp <= 0x9F`: that span also contains U+0020 SPACE, which
+  // \p{Zs} now catches, so the naive loop counted 66 and failed against a correct class.
+  for (const [lo, hi] of [[0x00, 0x1F], [0x7F, 0x7F], [0x80, 0x9F]]) {
+    for (let cp = lo; cp <= hi; cp++) if (single.test(String.fromCodePoint(cp))) cc++
+  }
+  ok(`the original C0/C1/DEL coverage is intact (${cc} of 65 control codepoints still caught)`, cc === 65)
 }
 
 console.info(`\n${fails ? `RELAY REFUSAL FAIL — ${fails}` : 'RELAY REFUSAL PASS — the reason survives, the repeat is quiet, a change speaks, and nothing forges a line'}`)


### PR DESCRIPTION
Closes #423. **Based on `fix/405-defuse-refusal-reason` (#420), not `main`** — this is the fix that review asked for. Merge #420 first and this retargets to `main` cleanly.

## What survived

`defuseJournalText` collapsed exactly the 65 Cc codepoints — no printable character inside the class, none outside it. Everything else got through, including U+202E RIGHT-TO-LEFT OVERRIDE, which **reorders what the operator reads with no C0 or C1 character anywhere in the string**. The journal being text an operator reads and acts on is the premise the whole of #405 rests on. The U+2066–U+2069 isolates do the same more selectively, and an unterminated one bleeds into whatever prints on the *next* line.

## The class

Named by Unicode category rather than by codepoint — `\p{Cc}\p{Cf}\p{Zl}\p{Zp}\p{Zs}`. Same principle as the original C0/C1 range and the reason that one has held: naming what may pass stays correct when somebody finds a control nobody had listed. It picks up the bidi controls and marks, the zero-width set, U+00AD, U+2028/U+2029 and U+00A0.

Two decisions worth arguing with:

- **Everything becomes a space, including the zero-width characters** where deleting them would look tidier. Deleting can JOIN two tokens into a word that never existed; spacing can only ever separate. A visible extra space is honest; a fabricated word is not.
- **The stated cost:** an emoji sequence joined by U+200D comes apart into its components. A relay refusal is not where emoji families belong, and ZWJ is itself a way to hide what a string contains — but it is a real loss and it is in the header rather than left to be discovered.

The class is exported as a **source string**, not a compiled `/g` regex: the suite sweeps the plane against it, and a shared `/g` regex carries `lastIndex` between calls, so it would give a different answer on the second character it was asked about.

## Verification, as the issue specified it

**Readability first.** `pow: 28 bits needed. (12)` survives byte for byte; so do `relais refusé: événement trop grand` and `拒绝: 事件过大`. A guard that mangles the ordinary case hides the fault the journal exists to reveal.

**U+00A0 is asserted to BECOME a space**, not to look like one — "already renders fine" is not "is a space".

**The negative control is the sweep, not a spot check.** U+0000–U+10FFFF against the lifted class: 254 codepoints caught, zero printable characters from a sample spanning Latin, digits, punctuation, accents, CJK, kana, emoji and arrows. Paired with a control proving the sweep *can* catch, so the zero is a measurement.

**The original coverage is intact** — 65 Cc codepoints, counted over the three Cc ranges by hand. A naive `cp <= 0x9F` loop counts **66**, because that span also holds U+0020, which `\p{Zs}` now catches. It failed against a correct class before being fixed, which is the loop earning its keep.

**Mutation control:** reverting to `\p{Cc}` alone fails 22 assertions, the first being that U+202E reaches the journal line. An earlier draft failed that mutation with **exit 3** instead of 1 — the sweep floor sat at 100, so a *correct sweep of the wrong class* (65 caught) read as INCONCLUSIVE. Floor lowered to 10, which is what a floor is for: proving the loop ran, not asserting the class size.

Every invisible in the fixture is a `\uXXXX` escape, and the fixture is asserted to contain no literal one.

`npm test` green, `npm run lint` clean. **No new suite** — this extends the guard #405 landed, so the count is unchanged and this does not join the 84-count collision.

## Note

The issue records that `tools/tripwire.mjs` splits on `'\n'` only, so none of these characters synthesises a journal *line* for the alarm — they are terminal-rendering only. That is unchanged here. The unbounded line **count** is #422 and still open.

Drafted with assistance from [Claude Code](https://claude.com/claude-code)
