### PR TITLE
Cap the journal lines one relay can cause, and say when it trips (#422)

### DIFF
--- a/src/relay_refusals.mjs
+++ b/src/relay_refusals.mjs
@@ -127,18 +127,52 @@ export function refusalKey(reason) {
     .trim()
 }
 
+/// A cap on LOGGED LINES per relay per window (#422). Separate from `cap` below, and answering a
+/// different attack: `cap` bounds how many relays the ledger REMEMBERS, and does nothing about how
+/// many lines one of them can cause.
+///
+/// The suppression in `record()` is keyed on the reason, and genuinely different is the relay's
+/// choice. 500 sends whose wording it varies by a request id or a counter is 500 journal lines,
+/// with nothing invalid and no invisible character anywhere in them, on a box whose journals the
+/// tripwire reads. Measured on `main` at `0efe7cd1` in the #420 review, where the ledger stayed at
+/// one row throughout — exactly as designed, and why a better key is not the fix.
+///
+/// THE CAP MUST NEVER BE SILENT. A ledger that quietly stops writing is indistinguishable from a
+/// relay that stopped refusing, which is the #374 failure one level up. Three things say it:
+///
+///   1. the line that TRIPS the cap names it, so there is no gap between the last logged refusal
+///      and the operator knowing why the next one is missing. Once per window — repeating it per
+///      withheld line would be the flood again, in the bridge's own voice;
+///   2. the window ROLL reports the count that was withheld;
+///   3. `summary()` carries the running count, because a flood that STOPS never rolls its window,
+///      and the periodic report is then the only surface that would ever mention it.
+///
+/// The reason is still RECORDED when a line is capped — only the per-line news is withheld, so
+/// `rows()` and `summary()` show the current reason. The cap costs the operator timeliness, never
+/// fact. It cannot be made free: a relay already at its cap whose reason then changes to something
+/// genuinely actionable has that one line folded into a count. That is the trade, and it is why the
+/// cap is per relay rather than global — a flooding relay must not eat a quiet one's line.
+const LINES_PER_WINDOW = 10
+const WINDOW_SECONDS = 3600
+
 /// A bounded per-relay ledger. Keyed on the relay, so it is bounded by the size of the relay set no
 /// matter how inventive the messages get; `cap` is a backstop for a caller that fans out to a list
 /// built from something an outsider controls.
 ///
 /// `log` is injected rather than imported so the suppression rule can be driven with no journal.
-export function refusalLedger({ cap = 64, log = () => {} } = {}) {
-  const rows = new Map()   // relay -> { refused, accepted, reason, key, firstAt, lastAt }
+export function refusalLedger({
+  cap = 64,
+  log = () => {},
+  linesPerWindow = LINES_PER_WINDOW,
+  windowSeconds = WINDOW_SECONDS,
+} = {}) {
+  const rows = new Map()   // relay -> { refused, accepted, reason, key, firstAt, lastAt, window* }
 
   const row = (relay) => {
     let r = rows.get(relay)
     if (!r) {
-      r = { relay, refused: 0, accepted: 0, reason: null, key: null, firstAt: null, lastAt: null }
+      r = { relay, refused: 0, accepted: 0, reason: null, key: null, firstAt: null, lastAt: null,
+        windowStart: null, windowLogged: 0, windowWithheld: 0 }
       // Insertion-ordered eviction. Dropping the OLDEST rather than refusing to add: a full ledger
       // must not make a newly-added relay invisible, which would hide exactly the relay whose
       // behaviour nobody has seen yet.
@@ -179,6 +213,25 @@ export function refusalLedger({ cap = 64, log = () => {} } = {}) {
       r.reason = defuseJournalText(reason)
       const shown = r.reason || '(no reason given)'
       const shownRelay = defuseJournalText(url)
+
+      // The window rolls on the first refusal that falls outside it, and reports what it withheld
+      // on the way out (#422).
+      if (r.windowStart === null || at - r.windowStart >= windowSeconds) {
+        if (r.windowWithheld > 0) {
+          log(`RELAY REFUSAL FLOOD ENDED ${shownRelay}: ${r.windowWithheld} further changed reason(s) were counted, not logged, in the preceding ${windowSeconds}s (#422)`)
+        }
+        r.windowStart = at
+        r.windowLogged = 0
+        r.windowWithheld = 0
+      }
+      if (r.windowLogged >= linesPerWindow) {
+        r.windowWithheld++
+        if (r.windowWithheld === 1) {
+          log(`RELAY REFUSAL FLOOD ${shownRelay}: ${linesPerWindow} changed reasons logged within ${windowSeconds}s — further ones are counted, not logged, until the window rolls (#422). Latest: ${shown}`)
+        }
+        return 'capped'
+      }
+      r.windowLogged++
       log(was === null
         ? `RELAY REFUSED ${shownRelay}: ${shown} — first time; further identical refusals are counted, not logged (#374)`
         : `RELAY REFUSAL CHANGED ${shownRelay}: ${shown} — was "${was || '(no reason given)'}"; ${r.refused} refusal(s) from this relay so far`)
@@ -193,7 +246,14 @@ export function refusalLedger({ cap = 64, log = () => {} } = {}) {
     summary() {
       const bad = [...rows.values()].filter(r => r.refused > 0)
       if (!bad.length) return null
-      return bad.map(r => `${defuseJournalText(r.relay)}: refused ${r.refused} of ${r.refused + r.accepted} — ${r.reason || '(no reason given)'}`).join(' · ')
+      return bad.map(r => {
+        // The flood's count travels with the periodic report, not only with the window roll: a
+        // relay that floods and then goes quiet never rolls, so this is the only place it surfaces.
+        const withheld = r.windowWithheld > 0
+          ? ` (+${r.windowWithheld} changed reason(s) counted, not logged — flooding, #422)`
+          : ''
+        return `${defuseJournalText(r.relay)}: refused ${r.refused} of ${r.refused + r.accepted} — ${r.reason || '(no reason given)'}${withheld}`
+      }).join(' · ')
     },
 
     size() { return rows.size },

--- a/tests/relay_refusal.mjs
+++ b/tests/relay_refusal.mjs
@@ -499,5 +499,124 @@ const ok = (n, c) => { console.info(`${c ? 'ok  ' : 'FAIL'} — ${n}`); if (!c) 
   ok(`the original C0/C1/DEL coverage is intact (${cc} of 65 control codepoints still caught)`, cc === 65)
 }
 
+
+// ── a relay cannot cause unbounded journal LINES (#422) ──────────────────────────────────────────
+// #405 bounded the LENGTH of one line. Nothing bounded the COUNT, and the two are different
+// attacks: the suppression here is keyed on the reason, "genuinely different" is the relay's
+// choice, and 500 sends whose wording it varies by a request id is 500 lines with nothing invalid
+// in any of them. The fixture below therefore varies the VISIBLE text and contains no control
+// character at all — the control-character variant passes for the wrong reason.
+{
+  const SENDS = 500
+  const NOISY = 'wss://noisy.example'
+  const varied = (i) => `pow: 28 bits needed. (12) req=${i}`   // outside the brackets, so the key varies
+  const flood = (opts) => {
+    const lines = []
+    const L = refusalLedger({ log: (m) => lines.push(m), ...opts })
+    for (let i = 0; i < SENDS; i++) {
+      L.record({ relay: NOISY, accepted: false, reason: varied(i), at: 1000 + i })
+    }
+    return { lines, L }
+  }
+
+  // THE VACUITY GUARD, run first. Every assertion below is of the form "the cap held", and every
+  // one of them passes against a fixture that never flooded. So measure the uncapped case and
+  // refuse to report on the capped one until the flood is a fact.
+  const { lines: uncapped } = flood({ linesPerWindow: Number.MAX_SAFE_INTEGER })
+  if (uncapped.length < 100) {
+    console.error(`relay_refusal: INCONCLUSIVE — the uncapped fixture produced only ${uncapped.length} lines`)
+    console.error('  This is NOT an all-clear: nothing below tests a cap that was never reached.')
+    process.exit(3)
+  }
+  ok(`NEGATIVE CONTROL — uncapped, the same fixture DOES flood (${uncapped.length} lines from ${SENDS} sends)`,
+    uncapped.length > SENDS * 0.9)
+  // Escapes, never literals — a literal invisible in a fixture is a fixture nobody can review.
+  ok('NEGATIVE CONTROL — and the flood needs no control character; every reason is plain ASCII',
+    !uncapped.some(l => new RegExp(INVISIBLE_CLASS.replace('\\p{Zs}', ''), 'u').test(l)))
+
+  const { lines: capped, L: floodedLedger } = flood({})
+  ok(`the same ${SENDS} sends are bounded to ${capped.length} lines by the default cap`,
+    capped.length <= 12)
+
+  // The cap must never be silent: a ledger that quietly stops writing looks exactly like a relay
+  // that stopped refusing, which is the #374 failure one level up.
+  const trip = capped.filter(l => l.startsWith('RELAY REFUSAL FLOOD ') && !l.startsWith('RELAY REFUSAL FLOOD ENDED'))
+  ok('the cap SAYS it tripped', trip.length === 1)
+  ok('and said it ONCE — a line per withheld line would be the flood again, in the bridge\'s voice',
+    capped.filter(l => l.includes('#422')).length === 1)
+  ok('the trip line names the relay, what it is now doing instead, and the issue',
+    trip.length === 1 && trip[0].includes('noisy.example') &&
+    /counted, not logged/.test(trip[0]) && trip[0].includes('#422'))
+
+  // BOTH DIRECTIONS. A cap that eats the one line a quiet relay had to say is worse than the flood.
+  {
+    const lines = []
+    const L = refusalLedger({ log: (m) => lines.push(m), linesPerWindow: 2 })
+    L.record({ relay: 'wss://quiet.example', accepted: false, reason: 'pow: 28 bits needed. (12)', at: 1000 })
+    L.record({ relay: 'wss://quiet.example', accepted: false, reason: 'blocked: not on the allowlist', at: 1100 })
+    ok('a quiet relay whose reason genuinely changes still prints, both lines',
+      lines.length === 2 && lines[0].startsWith('RELAY REFUSED') && lines[1].startsWith('RELAY REFUSAL CHANGED'))
+  }
+
+  // And the cap is per relay, so a flooding relay cannot spend a quiet one's budget.
+  {
+    const lines = []
+    const L = refusalLedger({ log: (m) => lines.push(m), linesPerWindow: 2 })
+    for (let i = 0; i < 50; i++) L.record({ relay: NOISY, accepted: false, reason: varied(i), at: 1000 + i })
+    L.record({ relay: 'wss://quiet.example', accepted: false, reason: 'pow: 28 bits needed. (12)', at: 1060 })
+    ok('a flooding relay does not eat a quiet one\'s line — the cap is per relay, not global',
+      lines.filter(l => l.includes('quiet.example')).length === 1)
+  }
+
+  // An identical repeat is already suppressed by #374, and must not spend the #422 budget: if it
+  // did, a steadily-refusing relay would go silent for the wrong reason.
+  {
+    const lines = []
+    const L = refusalLedger({ log: (m) => lines.push(m), linesPerWindow: 2 })
+    for (let i = 0; i < 100; i++) {
+      L.record({ relay: 'wss://steady.example', accepted: false, reason: 'pow: 28 bits needed. (12)', at: 1000 + i })
+    }
+    L.record({ relay: 'wss://steady.example', accepted: false, reason: 'blocked: not on the allowlist', at: 1200 })
+    ok('an identical repeat is suppressed by #374 and does not spend the #422 budget', lines.length === 2)
+  }
+
+  // The count is the finding. "This relay caused 500 refusal lines in an hour" is what an operator
+  // acts on, and it currently exists only as 500 lines that each look like news.
+  ok('record() returns \'capped\', which a caller can tell from \'suppressed\'',
+    floodedLedger.record({ relay: NOISY, accepted: false, reason: varied(9999), at: 1500 }) === 'capped')
+  ok('the reason is still RECORDED while capped — the cap costs timeliness, not fact',
+    /req=9999/.test(floodedLedger.rows()[0].reason))
+  ok('summary() carries the withheld count, because a flood that STOPS never rolls its window',
+    /\+\d{3} changed reason\(s\) counted, not logged/.test(floodedLedger.summary() || ''))
+  ok('and summary() still leads with the current reason rather than replacing it with the count',
+    (floodedLedger.summary() || '').includes('pow: 28 bits needed. (12) req=9999'))
+
+  // The window roll reports what it withheld, and then speaks normally again.
+  {
+    const lines = []
+    const L = refusalLedger({ log: (m) => lines.push(m), linesPerWindow: 2, windowSeconds: 100 })
+    for (let i = 0; i < 20; i++) L.record({ relay: NOISY, accepted: false, reason: varied(i), at: 1000 + i })
+    const before = lines.length
+    L.record({ relay: NOISY, accepted: false, reason: varied(999), at: 1200 })
+    const ended = lines.filter(l => l.startsWith('RELAY REFUSAL FLOOD ENDED'))
+    ok('the window roll reports the exact count it withheld', ended.length === 1 && / 18 further changed reason/.test(ended[0]))
+    ok('and the refusal that rolled the window is itself logged, not eaten', lines.length === before + 2)
+    ok('NEGATIVE CONTROL — without the roll, the same refusal is capped',
+      L.record({ relay: NOISY, accepted: false, reason: varied(1000), at: 1201 }) === 'logged' &&
+      L.record({ relay: NOISY, accepted: false, reason: varied(1001), at: 1202 }) === 'capped')
+  }
+
+  // A relay that never floods must never see any of this vocabulary — the same shape as the class
+  // sweep above: a guard that fires on everything and one that fires on nothing read identically.
+  {
+    const lines = []
+    const L = refusalLedger({ log: (m) => lines.push(m) })
+    L.record({ relay: 'wss://ordinary.example', accepted: false, reason: 'pow: 28 bits needed. (12)', at: 1000 })
+    L.record({ relay: 'wss://ordinary.example', accepted: true, at: 1001 })
+    ok('NEGATIVE CONTROL — an ordinary relay\'s journal gains no flood vocabulary at all',
+      lines.length === 1 && !lines[0].includes('#422') && !(L.summary() || '').includes('#422'))
+  }
+}
+
 console.info(`\n${fails ? `RELAY REFUSAL FAIL — ${fails}` : 'RELAY REFUSAL PASS — the reason survives, the repeat is quiet, a change speaks, and nothing forges a line'}`)
 process.exit(fails ? 1 : 0)


### PR DESCRIPTION
Closes #422.

**Stacked three deep.** Base is `fix/423-bidi-controls` (PR #441), whose base is `fix/405-defuse-refusal-reason` (PR #420). Merge #420, then #441, then this. The diff against `main` would otherwise carry all three; against its stated base it is two files.

## The gap

`defuseJournalText` bounds the LENGTH of a refusal line. Nothing bounds the COUNT.

The suppression in `refusalLedger` is keyed on the reason, and *genuinely different* is the relay's choice. 500 sends whose wording it varies by a request id or a counter is 500 journal lines, with nothing invalid and no invisible character anywhere in them, on a box whose journals the tripwire reads. Measured on `main` at `0efe7cd1` in the #420 review — the ledger stayed at one row throughout, exactly as designed, which is why a better key is not the fix. The control-character angle (#423) is a special case of this, not the root.

## The change

`refusalLedger` takes `linesPerWindow` (default 10) and `windowSeconds` (default 3600), applied **per relay**. Past the cap, a changed reason is counted rather than logged, and `record()` returns `'capped'`.

Per relay rather than global, so a flooding relay cannot spend a quiet one's budget. `src/bridge.mjs` is the only production caller and discards the return value, so `'capped'` is additive.

## Why the cap is never silent

A ledger that quietly stops writing is indistinguishable from a relay that stopped refusing — the #374 failure one level up. Three surfaces say it:

1. the line that **trips** the cap names it, once per window (a line per withheld line would be the flood again, in the bridge's own voice);
2. the window **roll** reports the exact count it withheld;
3. **`summary()`** carries the running count — the only surface a flood that *stops* ever reaches, because it never rolls its window.

The reason is still recorded while capped, so `rows()` and `summary()` show the current one. The cap costs the operator timeliness, not fact.

**Stated cost:** a relay already at its cap whose reason then changes to something genuinely actionable has that one line folded into a count. That is inherent to any cap; it is bounded by making the cap per relay and by keeping the current reason in the summary.

## Verification

17 new checks in `tests/relay_refusal.mjs`. The fixture varies visible ASCII (`req=${i}` outside the brackets `refusalKey` strips) and contains **no control character** — the control-character variant passes for the wrong reason.

- **Vacuity guard first.** Every assertion in the block is of the form "the cap held", and every one of them passes against a fixture that never flooded. So the uncapped case is measured first and the block exits **3 INCONCLUSIVE** if it produced under 100 lines. It produces 500.
- **Both directions.** A quiet relay whose reason genuinely changes still prints both lines; an identical repeat is suppressed by #374 and does not spend the #422 budget; a relay that never floods gains none of this vocabulary, in the journal or the summary.
- **Three mutations, each exit 1.** Cap disabled → 9 FAIL. Trip line silenced → 3 FAIL. `summary()` count dropped → 1 FAIL. Restored → exit 0.
- `npm test` green on the branch.

Adds no suite, so it does not touch the suite count that #433/#436/#437/#438/#440 are all claiming.

Drafted with assistance from [Claude Code](https://claude.com/claude-code)
