### PR TITLE
Say WHICH absence a missing DEPLOYED_SHA is (#378)

### DIFF
--- a/tests/deploy_runner.mjs
+++ b/tests/deploy_runner.mjs
@@ -17,7 +17,7 @@
 // Run: node tests/deploy_runner.mjs   (exit 0 = pass, 1 = fail)
 
 import { execFileSync, execSync } from 'node:child_process'
-import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync, existsSync } from 'node:fs'
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync, existsSync, readdirSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -96,9 +96,28 @@ catch {
 // Report the absence instead, carrying the tick's output, and return a value no sha and no
 // content regex can match. The assertion is unchanged and absence is still a failure — it is now
 // a legible one, and the checks after it still run.
+//
+// #410 made the absence legible. It did not make it DIAGNOSABLE, and those are different: an
+// absent watermark has two causes that print identically and want opposite investigations.
+// Either the tick refused and deliberately wrote nothing — a real finding, and its output says
+// why — or the tree is not on disk at all, in which case the tick's output is beside the point
+// and no amount of reading it will help. #378 has been chased down the first road twice.
+// So say which one it is, out of the filesystem rather than out of the reader's assumption.
 const readOrReport = (path, tick) => {
   if (existsSync(path)) return readFileSync(path, 'utf8')
-  console.error(`  ↳ ${path} does not exist. The runner tick that should have written it said:`)
+  const dir = dirname(path)
+  let where
+  if (!existsSync(dir)) {
+    where = `Its directory ${dir} IS NOT THERE EITHER, so the tree went away — this is not a refusal, and the tick output below is not the explanation.`
+  } else {
+    let entries = null
+    try { entries = readdirSync(dir) } catch { /* listed below as unreadable */ }
+    where = entries === null
+      ? `Its directory ${dir} exists but could not be listed.`
+      : `Its directory ${dir} exists and holds ${entries.length} entr${entries.length === 1 ? 'y' : 'ies'} [${entries.slice(0, 12).join(' ') || 'empty'}], so the tree is intact and the tick refused.`
+  }
+  console.error(`  ↳ ${path} does not exist. ${where}`)
+  console.error('    The runner tick that should have written it said:')
   console.error(((tick && tick.out) || '(no output captured)').replace(/^/gm, '      '))
   return ''
 }
@@ -109,9 +128,35 @@ const probe = mkdtempSync(join(tmpdir(), 'wb-runner-probe-'))
 writeFileSync(join(probe, 'present'), 'a-sha\n')
 check(readOrReport(join(probe, 'present'), { out: '' }).trim() === 'a-sha',
   'watermark reader returns file content when the file is there')
-console.log('  (the next two lines are this suite exercising its own absence reporter — not a failure)')
-check(readOrReport(join(probe, 'absent'), { out: 'stub tick output' }) === '',
+
+// Capture rather than print: the reporter's message is the thing an operator acts on, so assert
+// the REASON it gives and not merely that it declined to throw. A reporter that always says
+// "the tree went away" and one that always says "the tick refused" both pass a bare !throw check.
+const saidWhenReading = (path, tick) => {
+  const said = []
+  const real = console.error
+  console.error = (...a) => said.push(a.join(' '))
+  try { return { value: readOrReport(path, tick), said: said.join('\n') } }
+  finally { console.error = real }
+}
+
+const gone = saidWhenReading(join(probe, 'absent'), { out: 'stub tick output' })
+check(gone.value === '',
   'watermark reader reports an absent file instead of throwing ENOENT and killing the suite')
+check(/exists and holds \d+ entr/.test(gone.said) && /the tick refused/.test(gone.said),
+  'absent file in a tree that IS there -> says the tree is intact, so the tick is what to read')
+check(gone.said.includes('stub tick output'),
+  'and it still carries the tick output, which is the explanation in that case')
+
+// The other direction, which is the whole point: the same absence with the tree removed must
+// NOT say the tick refused, or #378 gets chased down the tick-output road a third time.
+const vanished = join(probe, 'no-such-tree', 'DEPLOYED_SHA')
+const reaped = saidWhenReading(vanished, { out: 'stub tick output' })
+check(reaped.value === '', 'a watermark under a missing tree is reported, not thrown')
+check(/IS NOT THERE EITHER/.test(reaped.said) && /not a refusal/.test(reaped.said),
+  'NEGATIVE CONTROL — tree absent -> names the tree, and says the tick output is NOT the explanation')
+check(!/the tick refused/.test(reaped.said),
+  'NEGATIVE CONTROL — and does not also claim the tick refused; the two diagnoses are exclusive')
 rmSync(probe, { recursive: true, force: true })
 
 const work = mkdtempSync(join(tmpdir(), 'wb-runner-'))

--- a/tests/deploy_runner.mjs
+++ b/tests/deploy_runner.mjs
@@ -112,9 +112,17 @@ const readOrReport = (path, tick) => {
   } else {
     let entries = null
     try { entries = readdirSync(dir) } catch { /* listed below as unreadable */ }
+    // Three states, not two. An EMPTY directory is neither of the others: the tree has not gone
+    // away, but it is not intact either — it is a tree wiped to its root, or a mountpoint that came
+    // up without its contents. Folding it into the intact branch sends the reader to the tick
+    // output, which is the road #378 has already been chased down twice. This is not hypothetical
+    // for this runner: `deploy-runner@.service:51` documents a window where rsync has landed and
+    // neither the restart nor the DEPLOYED_SHA write has, so a partial tree is a known shape here.
     where = entries === null
       ? `Its directory ${dir} exists but could not be listed.`
-      : `Its directory ${dir} exists and holds ${entries.length} entr${entries.length === 1 ? 'y' : 'ies'} [${entries.slice(0, 12).join(' ') || 'empty'}], so the tree is intact and the tick refused.`
+      : entries.length === 0
+        ? `Its directory ${dir} exists but is EMPTY, so the tree is present in name only — the tick output below is not the explanation.`
+        : `Its directory ${dir} exists and holds ${entries.length} entr${entries.length === 1 ? 'y' : 'ies'} [${entries.slice(0, 12).join(' ')}], so the tree is intact and the tick refused.`
   }
   console.error(`  ↳ ${path} does not exist. ${where}`)
   console.error('    The runner tick that should have written it said:')
@@ -157,6 +165,21 @@ check(/IS NOT THERE EITHER/.test(reaped.said) && /not a refusal/.test(reaped.sai
   'NEGATIVE CONTROL — tree absent -> names the tree, and says the tick output is NOT the explanation')
 check(!/the tick refused/.test(reaped.said),
   'NEGATIVE CONTROL — and does not also claim the tick refused; the two diagnoses are exclusive')
+
+// The third state, and the reason it needs its own fixture: an empty directory answers `true` to
+// existsSync and `[]` to readdirSync, so it satisfies the intact branch's condition while being
+// the opposite of intact. Assert it against BOTH of the other two wordings, because the failure
+// mode is not a missing message — it is a confident wrong one.
+const hollow = join(probe, 'hollow-tree')
+mkdirSync(hollow, { recursive: true })
+const emptied = saidWhenReading(join(hollow, 'DEPLOYED_SHA'), { out: 'stub tick output' })
+check(emptied.value === '', 'a watermark under an EMPTY tree is reported, not thrown')
+check(/is EMPTY/.test(emptied.said) && /present in name only/.test(emptied.said),
+  'empty tree -> names the emptiness as the finding, not the tick')
+check(!/the tick refused/.test(emptied.said),
+  'NEGATIVE CONTROL — an empty tree is NOT reported as a refusal; that is the third road #378 gets chased down')
+check(!/IS NOT THERE EITHER/.test(emptied.said),
+  'NEGATIVE CONTROL — nor as a vanished tree; all three diagnoses are mutually exclusive')
 rmSync(probe, { recursive: true, force: true })
 
 const work = mkdtempSync(join(tmpdir(), 'wb-runner-'))


### PR DESCRIPTION
Closes nothing yet — **this does not fix the flake and does not claim to.** It makes the next occurrence say which of two hypotheses it is, which is what the investigation has lacked twice.

## What this changes

`readOrReport` (landed by #410) turns an absent `DEPLOYED_SHA` into a named check failure carrying the tick's output, instead of an uncaught ENOENT that kills the suite. That made the absence **legible**. It did not make it **diagnosable**, and those are different.

An absent watermark has two causes that print identically and want opposite investigations:

- the tick **refused** and deliberately wrote nothing — the tick output below it is the explanation, and reading it is the right move;
- the **tree is not on disk at all** — the tick output is beside the point, and no amount of reading it will help.

`readOrReport` now checks the parent directory and says which. An intact tree is reported with its entry count and the words "the tick refused"; a missing tree is reported as "IS NOT THERE EITHER … this is not a refusal, and the tick output below is not the explanation."

## What I found, and did not find

**No reproduction.** 30 iterations under 14-way CPU load, plus four full `npm test` runs, all green. Across the last 40 CI runs there was exactly **one** failure and it was on `fix/432-nip98-ship`, unrelated to this suite. I am not calling the flake fixed; I could not make it happen.

**The issue's leading hypothesis is ruled out.** It asks "whether any other suite writes into `os.tmpdir()` with a pattern that could collide with `wb-runner-*`". `package.json`'s `test` script is a single sequential `&&` chain, so **no two suites ever run concurrently** — a sibling cannot reap the tree. Nothing else in `tests/` touches `tmpdir()` outside its own `mkdtempSync`, and nothing matches `wb-runner-*`.

**One smell raised and retracted.** `deploy/verify-deployed.sh` appears to run `git ls-tree` in the caller's directory. It does not — it does `cd "$(dirname "$0")/.."` first, so it resolves against the hub. Not a bug.

That leaves the tree-vanishing hypothesis neither confirmed nor excluded, which is exactly why the message needs to distinguish it.

## Verification

- Both diagnoses asserted, and asserted as **reasons** rather than as "did not throw". A reporter that always says "the tree went away" and one that always says "the tick refused" both pass a bare `!throw` check — that is the #374/#405 shape and it is the whole reason this file already carries a paired reporter test.
- The two diagnoses are checked to be **exclusive**: the tree-absent case is asserted *not* to also claim the tick refused.
- Messages are **captured rather than printed**, so a red run's output is not polluted by the suite exercising its own reporter.
- Full suite green: **2604 checks, exit 0**.

One thing worth recording for whoever picks this up: `tests/install_state.mjs` fails in a fresh worktree with `node_modules not present — run: npm ci`. That is environmental, not this branch — it passes in every worktree that has the symlink, and I confirmed it by running that one suite in three worktrees before touching anything.

Drafted with assistance from [Claude Code](https://claude.com/claude-code)