### PR TITLE
The install checklist asks one inbound question (#337)

### DIFF
--- a/docs/DESIGN_CONNECT_REMOTE_AGENT.md
+++ b/docs/DESIGN_CONNECT_REMOTE_AGENT.md
@@ -30,8 +30,8 @@ Three suites cover the new code — `capability_vocabulary`, `connect_plan`, `ag
 each with a negative control that fires. **None of it has run in production**, and a green suite is
 not a live proof.
 
-The short version: **an agent is not one artifact, it is eleven**, spread across two machines, three
-checkouts and a public relay network. Nine of the eleven have no tool that creates them. Every
+The short version: **an agent is not one artifact, it is fourteen**, spread across two machines,
+three checkouts and a public relay network. Nine of the fourteen have no tool that creates them. Every
 omission fails the same way — silently, with the agent appearing to work. That is the problem to
 solve, and convenience is not the reason to solve it.
 
@@ -57,8 +57,16 @@ produce this artifact*; a documented instruction to type something by hand is no
 | 11 | Runtime state directories | agent root | **nothing** — the channel dies on the missing one |
 | 12 | MCP-channel keypair | `mcp-channel/id_ed25519` | **nothing** |
 | 13 | Registration as an MCP server | Claude Code user config | **nothing** |
+| 14 | kind 10050 inbound DM relay list | public relays | `tools/publish-dm-relay-list.mjs` ✅ (Bunker path added #381) — **but no step invokes it** |
 
-Thirteen, not eleven; the count grew twice while writing this, which is itself the finding.
+Fourteen. It was eleven when this document was started: the count grew twice while it was being
+written and again afterwards, which is itself the finding.
+
+Row 14 is the one that broke the pattern. Every other artifact here is something the agent needs in
+order to **act**; that one is the only thing that lets anything **reach** it, and it was absent from
+the inventory entirely until #337 — after an admitted agent spent a day posting successfully into
+the channel while structurally unable to receive a single message. The tool existed. No step ran it,
+and nothing asked.
 
 ### The failure signature is always the same
 
@@ -234,7 +242,7 @@ properties matter more than the layout:
 
 ## Part IV — Architecture
 
-**"Connect Remote Agent" is one workflow with one job: make the thirteen artifacts, verify each one,
+**"Connect Remote Agent" is one workflow with one job: make the fourteen artifacts, verify each one,
 and refuse to continue when it cannot.**
 
 ### Principles
@@ -248,7 +256,7 @@ and refuse to continue when it cannot.**
    wrong-identity pairing survived precisely because its guard could not execute and the step around
    it looked fine.
 4. **Default closed, and resumable.** The flow is interrupted constantly in practice — a Bunker to
-   click, a name to register. It must be re-enterable and report exactly which of the thirteen are
+   click, a name to register. It must be re-enterable and report exactly which of the fourteen are
    present, which are missing, and which are present but unverified. Three states, never two.
 5. **Nothing the wizard writes is a template string.** Placeholder text must be structurally
    incapable of reaching a signature.

--- a/src/agent_install_state.mjs
+++ b/src/agent_install_state.mjs
@@ -1,6 +1,6 @@
 // agent_install_state.mjs — what does this agent still need, and what is merely CLAIMED to be done?
 //
-// Seating an agent produces thirteen artifacts across two machines, three checkouts and a public
+// Seating an agent produces fifteen artifacts across two machines, three checkouts and a public
 // relay network. Nine of them have no tool that creates them, and every omission fails the same
 // way: silently, with the agent appearing to work. A wrong-identity pairing signs and seals
 // perfectly. A denied nip44 permission is byte-identical to an empty inbox. A missing kind 0
@@ -53,6 +53,13 @@ export const ARTIFACTS = [
     why: 'Without it the agent renders as a bare key everywhere. It works perfectly and has no name.' },
   { key: 'admit-grant', title: 'Admitted to the channel', blocking: true,
     why: 'The door. Enforced by the bridge, re-read periodically — so it can stop applying without anything failing.' },
+  // #337. Every other artifact here asks whether the agent can ACT. This is the only one that asks
+  // whether anything can reach it, and it was missing from a fourteen-item checklist that verified
+  // nothing inbound. An agent was admitted, posted successfully, and was structurally incapable of
+  // receiving a single message — the bridge had been logging `RETURN not sent — no valid kind:10050
+  // recipient DM relay list` since its first attempt, and nothing in the agent's own tooling said so.
+  { key: 'dm-relays', title: 'Inbound DM relay list (kind 10050)', blocking: true,
+    why: 'The only inbound path an external key has, because the community relay will not serve it. Without one the agent is write-only, and an empty inbox looks identical to an inbox that cannot exist.' },
   { key: 'manifest', title: 'Runtime manifest', blocking: true,
     why: 'Six tools read it and none write it. Every field is validated; one bad field refuses the whole runtime.' },
   { key: 'state-dirs', title: 'Runtime directories', blocking: true,

--- a/tests/agent_install_state.mjs
+++ b/tests/agent_install_state.mjs
@@ -14,8 +14,10 @@
 //
 //   node tests/agent_install_state.mjs
 
-import { readFileSync } from 'node:fs'
+import { readFileSync, readdirSync, mkdtempSync, rmSync } from 'node:fs'
 import { dirname, join, resolve } from 'node:path'
+import { tmpdir } from 'node:os'
+import { execFileSync } from 'node:child_process'
 import { fileURLToPath } from 'node:url'
 import { installState, renderState, foreignNvoyServers, ARTIFACTS, ARTIFACT_KEYS, PRESENT, UNVERIFIED, MISSING, UNKNOWN }
   from '../src/agent_install_state.mjs'
@@ -206,10 +208,13 @@ check(ARTIFACTS.some(a => a.blocking) && ARTIFACTS.some(a => !a.blocking),
 
 // ── The checklist asks one inbound question, and the tool has to ask it (#337) ───────────────
 //
-// Thirteen artifacts verified whether the agent could ACT. None asked whether anything could reach
-// it, and an admitted agent was live for a day posting successfully while structurally unable to
-// receive a single message. Two separate things are pinned here, because closing only the first
-// leaves the same hole one refactor away.
+// Every artifact on the checklist verified whether the agent could ACT. None asked whether anything
+// could reach it, and an admitted agent was live for a day posting successfully while structurally
+// unable to receive a single message. Two separate things are pinned here, because closing only the
+// first leaves the same hole one refactor away.
+//
+// (No count in that sentence on purpose. This PR's own thesis is that the artifact count drifted
+// three times without anyone noticing, and a prose count is exactly the thing that drifts.)
 {
   const inbound = ARTIFACTS.find(a => a.key === 'dm-relays')
   check(!!inbound, 'the checklist carries an inbound-reachability artifact at all')
@@ -250,9 +255,68 @@ check(ARTIFACTS.some(a => a.blocking) && ARTIFACTS.some(a => !a.blocking),
   check(seen.length > 5, `the scan found ${seen.length} see() calls, so it is reading the tool`)
   const unreported = ARTIFACT_KEYS.filter(k => !seen.includes(k))
   check(unreported.length === 0,
-    `every artifact is reported by connect-agent.mjs${unreported.length ? ` — unreported: ${unreported.join(', ')}` : ''}`)
+    `every artifact has a see() call in connect-agent.mjs${unreported.length ? ` — unreported: ${unreported.join(', ')}` : ''}`)
   check(!seen.includes('no-such-artifact-key'),
     'NEGATIVE CONTROL — the scan does not report a key the tool never mentions')
+
+  // …and the scan above is weaker than the property it is written for. It matches SOURCE TEXT, so
+  // commenting a see() call out, or moving one behind a branch that never runs, leaves it green
+  // while the tool reports nothing for that artifact — the exact silence this is here to prevent.
+  //
+  // So run the tool. `--check` writes nothing (!CHECK guards every mkdirSync/writeFileSync) and
+  // renders every row, so the property becomes what an operator would actually see. The text scan
+  // stays above because it gives the better failure message: a key name, not a missing line.
+  const probeRoot = mkdtempSync(join(tmpdir(), 'wb-connect-probe-'))
+  let rendered = null
+  try {
+    // Exit is non-zero by design here — nothing is installed under a fresh root — so capture rather
+    // than throw. It shells out to `claude mcp list`, which connect-agent catches on absence.
+    rendered = execFileSync(process.execPath,
+      [join(ROOT, 'tools', 'connect-agent.mjs'), '--name', 'probe', '--check', '--root', probeRoot],
+      { encoding: 'utf8', timeout: 60000, stdio: ['ignore', 'pipe', 'pipe'] })
+  } catch (e) {
+    rendered = typeof e?.stdout === 'string' ? e.stdout : null
+    // A tool that could not run at all has told us nothing about which artifacts it reports.
+    // That is INCONCLUSIVE, not a pass — being unable to check is not the same as being fine.
+    if (e?.signal || e?.code === 'ETIMEDOUT') rendered = null
+  }
+  if (rendered === null || rendered.length < 500) {
+    console.error(`agent_install_state: INCONCLUSIVE — connect-agent.mjs --check produced ${rendered === null ? 'no output' : `only ${rendered.length} bytes`}`)
+    console.error('  This is NOT an all-clear: the tool was never observed reporting anything.')
+    rmSync(probeRoot, { recursive: true, force: true })
+    process.exit(3)
+  }
+  // Assert the NOTE, not the title. renderState prints a row for every entry in ARTIFACTS whether
+  // or not the tool observed it, so "the title appears" is true even when the see() call is gone —
+  // a check written that way passes the very mutation it exists to catch, which was measured here
+  // rather than reasoned about. What the tool actually contributes is the note, and that is also
+  // the operator-facing remedy: the line saying which command settles the row. An artifact nobody
+  // asked about renders bare —
+  //
+  //   [ - ] Inbound DM relay list (kind 10050) UNKNOWN
+  //
+  // against a row that was asked about and legitimately cannot be answered here —
+  //
+  //   [ - ] Name in the directory              UNKNOWN  — not checked here — resolve <name>@…
+  //
+  // so "carries a note" separates "the tool asked" from "the tool never mentioned it", which
+  // scanning for UNKNOWN cannot do: four artifacts are legitimately UNKNOWN in a --check run.
+  const rows = new Map(ARTIFACTS.map(a => [a.key, rendered.split('\n').find(l => l.includes(a.title))]))
+  const missingRow = ARTIFACTS.filter(a => !rows.get(a.key)).map(a => a.key)
+  check(missingRow.length === 0,
+    `and every artifact is RENDERED by a real --check run${missingRow.length ? ` — absent: ${missingRow.join(', ')}` : ''}`)
+  const noteless = ARTIFACTS
+    .filter(a => rows.get(a.key) && !/—\s*\S/.test(rows.get(a.key).slice(rows.get(a.key).indexOf(a.title) + a.title.length)))
+    .map(a => a.key)
+  check(noteless.length === 0,
+    'and every rendered row carries the tool\'s note, so the tool ASKED about it' +
+    `${noteless.length ? ` — silent: ${noteless.join(', ')}` : ''}`)
+  check(!rendered.includes('No such artifact, invented for this check'),
+    'NEGATIVE CONTROL — the run does not render a title the tool never had')
+  // `--check` is what makes running it safe in a suite. Prove that rather than trusting the flag.
+  check(readdirSync(probeRoot).length === 0,
+    'NEGATIVE CONTROL — and --check wrote nothing into the probe root, so running the tool is side-effect free')
+  rmSync(probeRoot, { recursive: true, force: true })
 }
 
 console.log(`\n${pass ? 'ALL PASS' : 'FAILURES ABOVE'}`)

--- a/tests/agent_install_state.mjs
+++ b/tests/agent_install_state.mjs
@@ -14,8 +14,13 @@
 //
 //   node tests/agent_install_state.mjs
 
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { installState, renderState, foreignNvoyServers, ARTIFACTS, ARTIFACT_KEYS, PRESENT, UNVERIFIED, MISSING, UNKNOWN }
   from '../src/agent_install_state.mjs'
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..')
 
 let pass = true
 const check = (cond, label) => { console.log(`${cond ? 'ok  ' : 'FAIL'} — ${label}`); if (!cond) pass = false }
@@ -197,6 +202,57 @@ check(ARTIFACTS.some(a => a.blocking) && ARTIFACTS.some(a => !a.blocking),
     'and being unable to run `claude mcp list` is INCONCLUSIVE (3), never clean (0)')
   check(installState(complete).exitCode === 0,
     'while an exclusive registration still reaches exit 0 — the new artifact is satisfiable')
+}
+
+// ── The checklist asks one inbound question, and the tool has to ask it (#337) ───────────────
+//
+// Thirteen artifacts verified whether the agent could ACT. None asked whether anything could reach
+// it, and an admitted agent was live for a day posting successfully while structurally unable to
+// receive a single message. Two separate things are pinned here, because closing only the first
+// leaves the same hole one refactor away.
+{
+  const inbound = ARTIFACTS.find(a => a.key === 'dm-relays')
+  check(!!inbound, 'the checklist carries an inbound-reachability artifact at all')
+  check(inbound?.blocking === true,
+    'and it is blocking — write-only is not a cosmetic shortfall, it is an agent that cannot be talked to')
+
+  // The property, not the mechanism: an install perfect in every other respect must not read clean
+  // while the one inbound question is unanswered.
+  const everythingElse = Object.fromEntries(
+    ARTIFACT_KEYS.filter(k => k !== 'dm-relays').map(k => [k, { found: true, verified: true }]))
+  const writeOnly = installState({ ...everythingElse, 'dm-relays': { found: false } })
+  check(writeOnly.exitCode === 1 && writeOnly.missing.includes('dm-relays'),
+    `an otherwise-complete agent with no kind:10050 does NOT read clean (exit ${writeOnly.exitCode})`)
+  const unasked = installState(everythingElse)
+  check(unasked.exitCode === 3 && unasked.unknown.includes('dm-relays'),
+    'and not looking is INCONCLUSIVE, never clean — the failure mode was nobody asking')
+
+  // BOTH DIRECTIONS. A guard that refuses everything is indistinguishable from one that refuses the
+  // dangerous thing, so prove the new artifact is satisfiable and does not wedge the report at 3.
+  const reachable = installState({ ...everythingElse, 'dm-relays': { found: true, verified: true } })
+  check(reachable.exitCode === 0 && reachable.outcome === 'complete',
+    'while a published and read-back list reaches exit 0 — the artifact is satisfiable')
+}
+
+// ── …and every artifact is actually REPORTED by the tool that produces the observations ───────
+//
+// The gap #337 names is not that the checklist judged inbound reachability wrongly. It is that
+// nothing asked. An artifact absent from `connect-agent.mjs` sits at UNKNOWN forever with no note,
+// and the note is the remedy — it is the line telling an operator which command settles it. So the
+// tool must name every key, and this fails when someone adds an artifact and stops there.
+{
+  const src = readFileSync(join(ROOT, 'tools', 'connect-agent.mjs'), 'utf8')
+  if (src.length < 2000) {
+    console.error(`agent_install_state: INCONCLUSIVE — connect-agent.mjs read back only ${src.length} bytes`)
+    process.exit(3)
+  }
+  const seen = [...src.matchAll(/see\(\s*'([a-z0-9-]+)'/g)].map(m => m[1])
+  check(seen.length > 5, `the scan found ${seen.length} see() calls, so it is reading the tool`)
+  const unreported = ARTIFACT_KEYS.filter(k => !seen.includes(k))
+  check(unreported.length === 0,
+    `every artifact is reported by connect-agent.mjs${unreported.length ? ` — unreported: ${unreported.join(', ')}` : ''}`)
+  check(!seen.includes('no-such-artifact-key'),
+    'NEGATIVE CONTROL — the scan does not report a key the tool never mentions')
 }
 
 console.log(`\n${pass ? 'ALL PASS' : 'FAILURES ABOVE'}`)

--- a/tools/connect-agent.mjs
+++ b/tools/connect-agent.mjs
@@ -88,6 +88,13 @@ see('nip05', null, false, 'not checked here — resolve <name>@<host>/.well-know
 see('profile', null, false, 'not checked here — a kind 0 fetched back BY ID from a fresh connection')
 see('admit-grant', null, false,
   pubkey ? 'not checked here — cold-read the 440 per relay and report EOSE/ERROR/TIMEOUT separately' : 'no --pubkey given')
+// The inbound half (#337). Named here rather than left silent because the note IS the remedy: an
+// operator who cannot see this question does not know to ask it, which is how an agent shipped
+// write-only and only the bridge's own journal knew.
+see('dm-relays', null, false,
+  pubkey
+    ? 'not checked here — publish with tools/publish-dm-relay-list.mjs (prefer NVOY_BUNKER), which cold-reads it back by id'
+    : 'no --pubkey given, so nothing to look up')
 
 // ── The manifest. Six tools read it; nothing writes it. This is that nothing. ────────────────
 const instDir = join(HERE, 'instances')


### PR DESCRIPTION
Fourteen artifacts in the install checklist verified whether an agent could **act**. None asked whether anything could **reach** it.

That gap has a live cost. An admitted agent spent a day posting successfully into the channel while structurally unable to receive a single message: it had no `kind:10050`, so the return lane — the only inbound path an external key has, because the community relay will not serve it — had nowhere to deliver. The bridge had been logging `RETURN not sent — no valid kind:10050 recipient DM relay list` since its first attempt. Nothing in the agent's own tooling said so, and an empty inbox is byte-identical to an inbox that cannot exist.

## What changed

- `src/agent_install_state.mjs` — `dm-relays` joins `ARTIFACTS` as **blocking**. Write-only is not a cosmetic shortfall like a missing `kind:0`; it is an agent that cannot be talked to.
- `tools/connect-agent.mjs` — reports it in the relay-side block alongside `admit-grant`, as UNKNOWN with the command that settles it. That tool opens no sockets on purpose, so the note *is* the remedy: an operator who never sees the question does not know to ask it.
- `tests/agent_install_state.mjs` — see below.
- `docs/DESIGN_CONNECT_REMOTE_AGENT.md` — inventory row 14, plus four stale counts corrected.

## Tests

Two properties, because closing only the first leaves the same hole one refactor away.

1. The artifact exists, is blocking, and **both directions** hold: exit 1 when looked for and absent, exit 3 when nobody looked, exit 0 only once it is published and read back. A refusal assertion alone cannot tell "refuses the unreachable agent" from "refuses everything".
2. Every `ARTIFACT_KEY` appears in a `see()` call in `connect-agent.mjs`. An artifact cannot be added to the checklist and left silent in the tool that produces the observations. The scan has a size floor and a negative control.

Mutation-proven:

| mutation | result |
|---|---|
| rename the new `see()` key | `FAIL — every artifact is reported by connect-agent.mjs — unreported: dm-relays` |
| `blocking: false` | two FAILs, incl. `an otherwise-complete agent with no kind:10050 does NOT read clean (exit 3)` |

`node tests/agent_install_state.mjs` → 92 ok. `npm test` → 0 failures. `npx eslint src tools tests` clean.

## Two things a reviewer should push on

**The doc table and `ARTIFACTS` are deliberately not cross-pinned.** The table has 14 numbered rows, the code list has 15 entries. They are different decompositions of the same seating, not a count that drifted, so each is fixed against its own list. I started to write a test pinning one to the other and stopped — it would have been a false invariant that fails on the next legitimate split.

**The counts were already stale before this change.** The doc said eleven in its summary and thirteen in its table; `agent_install_state.mjs` said thirteen while already holding fourteen. That the count drifted three times unnoticed is the same failure mode as the missing artifact.

## Scope

Closes the operator-facing half of #337 part 2. Part 1 is #336 (closed); part 3 is nvoy #183 (open). The definition of done — a message from one admitted agent to another arriving without the maintainer touching it — needs a live proof I cannot run from here.

I wrote this, so it needs a reader who did not. Suggest **@My Dude**: the blocking/non-blocking call is a judgement about what "installed" means, and the `see()` scan is a new class of test in this repo.

Drafted with assistance from [Claude Code](https://claude.com/claude-code)
