### PR TITLE
SECURITY: the MCP path gets the EXPECT_PUBKEY it never had (#338)

### DIFF
--- a/docs/DESIGN_CONNECT_REMOTE_AGENT.md
+++ b/docs/DESIGN_CONNECT_REMOTE_AGENT.md
@@ -30,8 +30,8 @@ Three suites cover the new code — `capability_vocabulary`, `connect_plan`, `ag
 each with a negative control that fires. **None of it has run in production**, and a green suite is
 not a live proof.
 
-The short version: **an agent is not one artifact, it is fourteen**, spread across two machines,
-three checkouts and a public relay network. Nine of the fourteen have no tool that creates them. Every
+The short version: **an agent is not one artifact, it is fifteen**, spread across two machines,
+three checkouts and a public relay network. Nine of the fifteen have no tool that creates them. Every
 omission fails the same way — silently, with the agent appearing to work. That is the problem to
 solve, and convenience is not the reason to solve it.
 
@@ -58,15 +58,26 @@ produce this artifact*; a documented instruction to type something by hand is no
 | 12 | MCP-channel keypair | `mcp-channel/id_ed25519` | **nothing** |
 | 13 | Registration as an MCP server | Claude Code user config | **nothing** |
 | 14 | kind 10050 inbound DM relay list | public relays | `tools/publish-dm-relay-list.mjs` ✅ (Bunker path added #381) — **but no step invokes it** |
+| 15 | Proof that the registered server answers as THIS agent | the running session | `tools/connect-agent.mjs --whoami` ✅ (#338) — the operator captures `nvoy_whoami` and the tool compares |
 
-Fourteen. It was eleven when this document was started: the count grew twice while it was being
-written and again afterwards, which is itself the finding.
+Fifteen. It was eleven when this document was started: the count has grown four times since, twice
+while it was being written, which is itself the finding.
 
 Row 14 is the one that broke the pattern. Every other artifact here is something the agent needs in
 order to **act**; that one is the only thing that lets anything **reach** it, and it was absent from
 the inventory entirely until #337 — after an admitted agent spent a day posting successfully into
 the channel while structurally unable to receive a single message. The tool existed. No step ran it,
 and nothing asked.
+
+Row 15 is not a thing you make; it is a thing you prove, and it is here because the other fourteen
+can all be correct while the session acts as someone else. An agent was handed a session whose
+attached MCP server answered `whoami` with a different agent's identity — it would have read that
+identity's sealed inbox and posted under its key, and nothing would have errored. The Bunker path
+(rows 1–2) has refused that class since day one, via `EXPECT_PUBKEY` in `relay-send`,
+`publish-dm-relay-list` and the profile publishes. Registration had no equivalent, so the same
+defect moved one layer up from Pair to Bind and found nothing waiting.
+
+Registered is not sole — #380 closed that half. Sole is not yours; #338 closes this one.
 
 ### The failure signature is always the same
 
@@ -242,7 +253,7 @@ properties matter more than the layout:
 
 ## Part IV — Architecture
 
-**"Connect Remote Agent" is one workflow with one job: make the fourteen artifacts, verify each one,
+**"Connect Remote Agent" is one workflow with one job: make the fifteen artifacts, verify each one,
 and refuse to continue when it cannot.**
 
 ### Principles
@@ -256,7 +267,7 @@ and refuse to continue when it cannot.**
    wrong-identity pairing survived precisely because its guard could not execute and the step around
    it looked fine.
 4. **Default closed, and resumable.** The flow is interrupted constantly in practice — a Bunker to
-   click, a name to register. It must be re-enterable and report exactly which of the fourteen are
+   click, a name to register. It must be re-enterable and report exactly which of the fifteen are
    present, which are missing, and which are present but unverified. Three states, never two.
 5. **Nothing the wizard writes is a template string.** Placeholder text must be structurally
    incapable of reaching a signature.

--- a/docs/DESIGN_CONNECT_REMOTE_AGENT.md
+++ b/docs/DESIGN_CONNECT_REMOTE_AGENT.md
@@ -79,6 +79,16 @@ defect moved one layer up from Pair to Bind and found nothing waiting.
 
 Registered is not sole — #380 closed that half. Sole is not yours; #338 closes this one.
 
+It closes it by a weaker proof than the Bunker path's, and the two should not be read as equivalent.
+`publish_relay_list.mjs` compares `EXPECT_PUBKEY` against a key derived from the **live signer,
+in-process, immediately before signing**. `--whoami` compares against a **file**: a capture the
+operator took at some earlier point, with no freshness and no binding to the session under test. It
+passes forever once taken, including after the registration changes underneath it. Row 15 reaching
+PRESENT — "present and observed doing its job" — therefore rests on a `readFileSync`. That is worth
+far more than nothing, and it is not the same guarantee; the freshness gap is #462. The tool must not
+open the channel itself, because the channel server holds its own lock and a second connection
+orphans it.
+
 ### The failure signature is always the same
 
 Every one of the gaps above produces an agent that *looks* configured:

--- a/src/agent_install_state.mjs
+++ b/src/agent_install_state.mjs
@@ -70,6 +70,14 @@ export const ARTIFACTS = [
     why: 'How a new session becomes this agent. Needs the instance root set explicitly; the default path does not exist here.' },
   { key: 'mcp-exclusive', title: 'No other nvoy server registered', blocking: true,
     why: 'Registered is not sole. A generically-named server alongside carries the tools that sign, bound to somebody else.' },
+  // #338. Sole is not YOURS. An agent was handed a session whose attached server answered `whoami`
+  // with a different agent's identity — it would have read that identity's sealed inbox and posted
+  // under its key, and neither would have errored, because a wrong-identity binding signs and seals
+  // perfectly. The Bunker path has refused this since day one via EXPECT_PUBKEY. The MCP path had
+  // no equivalent, so the same class of defect moved one layer up from Pair to Bind and found no
+  // guard there.
+  { key: 'mcp-identity', title: 'The server answers as THIS agent', blocking: true,
+    why: 'Registered is not sole, and sole is not yours. Proven by whoami equalling the minted key — never by the registration existing.' },
   { key: 'channel-answers', title: 'Channel server answers', blocking: true,
     why: 'Registered is not running. Proven by initialize + tools/list, not by the registration existing.' },
 ]
@@ -168,6 +176,82 @@ export function foreignNvoyServers(listOutput, name) {
     if (!found.includes(server)) found.push(server)
   }
   return found
+}
+
+// Does the registered MCP server answer as the agent we just minted? (#338)
+//
+// This is the MCP path's `EXPECT_PUBKEY`. `nvoy_whoami` returns `{ npub, pubkey, relays, metadata }`
+// (nvoy `mcp/src/app.ts`); the operator captures that and hands it here, because this repo's checker
+// opens no sockets and the channel server holds its own lock.
+//
+// Three answers, and the third is the one that matters. `null` — nobody looked, or nobody said what
+// to expect — must NEVER be reachable by the same path as `true`. The failure this exists to catch
+// is a guard that passes because the comparison was never supplied: that is precisely how a session
+// ran for a day answering as somebody else.
+//
+// Pure, and both arguments are untrusted text. Returns the resolved key alongside the verdict so a
+// PASS can print WHO it matched — a guard that passes in silence is indistinguishable from a guard
+// that is not there.
+export function boundIdentity(whoamiOutput, expected) {
+  const unknown = reason => ({ match: null, resolved: null, reason })
+  if (typeof whoamiOutput !== 'string' || whoamiOutput.trim() === '') return unknown('nothing captured from the server — INCONCLUSIVE, not absent')
+
+  const want = normalizeKey(expected)
+  // Deliberately checked BEFORE parsing. With no expectation there is no comparison to make, and
+  // reporting "the server answered" as a pass is the whole defect.
+  if (!want) return unknown('no expected key given, so there is nothing to compare against')
+
+  const resolved = whoamiPubkey(whoamiOutput)
+  if (!resolved) return unknown('no identity found in the captured output — check it is the whole `nvoy_whoami` result')
+
+  return resolved === want
+    ? { match: true, resolved, reason: `answers as ${resolved.slice(0, 12)}…, which is the minted key` }
+    : { match: false, resolved, reason: `answers as ${resolved.slice(0, 12)}…, NOT the minted ${want.slice(0, 12)}… — this session would sign as someone else` }
+}
+
+// npub or 64-hex in, lowercase hex out, or null. Hand-decoded rather than imported so this module
+// stays free of runtime dependencies; bech32's checksum is not verified here because the value is
+// only ever compared against another value normalized the same way — a corrupt npub cannot match a
+// good one, and cannot be mistaken for "nobody looked" either, since it returns null.
+function normalizeKey(value) {
+  const v = String(value ?? '').trim().toLowerCase()
+  if (/^[0-9a-f]{64}$/.test(v)) return v
+  if (!/^npub1[023456789acdefghjklmnpqrstuvwxyz]{58}$/.test(v)) return null
+  const CHARSET = 'qpzry9x8gf2tvdw0s3jn54khce6mua7l'
+  let acc = 0, bits = 0
+  const out = []
+  for (const ch of v.slice(5, -6)) {
+    const d = CHARSET.indexOf(ch)
+    if (d < 0) return null
+    acc = (acc << 5) | d; bits += 5
+    if (bits >= 8) { bits -= 8; out.push((acc >> bits) & 0xff) }
+  }
+  if (out.length !== 32) return null
+  return out.map(b => b.toString(16).padStart(2, '0')).join('')
+}
+
+// The JSON field first, because it is the contract. The loose scan is a fallback for output that
+// has been reformatted by a client on its way to the operator's clipboard — a real path, since a
+// human is carrying this between two tools.
+function whoamiPubkey(text) {
+  try {
+    const found = pickKey(JSON.parse(text))
+    if (found) return found
+  } catch { /* not JSON, or wrapped in a client's own envelope — fall through */ }
+  const m = /"(?:pubkey|npub)"\s*:\s*"([^"]+)"/.exec(text) || /\b(npub1[023456789acdefghjklmnpqrstuvwxyz]{58})\b/.exec(text)
+  return m ? normalizeKey(m[1]) : null
+}
+
+// MCP results arrive wrapped — `{content:[{type:'text',text:'{…}'}]}` — so walk into strings too.
+function pickKey(value, depth = 0) {
+  if (depth > 6) return null
+  if (typeof value === 'string') { try { return pickKey(JSON.parse(value), depth + 1) } catch { return null } }
+  if (!value || typeof value !== 'object') return null
+  if (Array.isArray(value)) { for (const v of value) { const f = pickKey(v, depth + 1); if (f) return f } return null }
+  const direct = normalizeKey(value.pubkey) || normalizeKey(value.npub)
+  if (direct) return direct
+  for (const v of Object.values(value)) { const f = pickKey(v, depth + 1); if (f) return f }
+  return null
 }
 
 // Render for a terminal. Kept here rather than in the CLI so the suite can assert that an

--- a/src/agent_install_state.mjs
+++ b/src/agent_install_state.mjs
@@ -26,7 +26,9 @@
 //
 // This module is pure: it takes observations and returns a report. It reads no files and opens no
 // sockets, so tests/agent_install_state.mjs can drive every state including the ones that are
-// hard to produce on a real machine.
+// hard to produce on a real machine. `nip19.decode` is arithmetic over a string and opens nothing,
+// so importing it does not cost that.
+import { nip19 } from 'nostr-tools'
 
 export const PRESENT = 'present'
 export const UNVERIFIED = 'unverified'
@@ -77,7 +79,7 @@ export const ARTIFACTS = [
   // no equivalent, so the same class of defect moved one layer up from Pair to Bind and found no
   // guard there.
   { key: 'mcp-identity', title: 'The server answers as THIS agent', blocking: true,
-    why: 'Registered is not sole, and sole is not yours. Proven by whoami equalling the minted key — never by the registration existing.' },
+    why: 'Registered is not sole, and sole is not yours. Proven by whoami equalling the minted key — never by the registration existing. That proof is a saved capture, not a live signer: it has no freshness and no binding to the session under test, so it passes forever once taken (#462).' },
   { key: 'channel-answers', title: 'Channel server answers', blocking: true,
     why: 'Registered is not running. Proven by initialize + tools/list, not by the registration existing.' },
 ]
@@ -199,35 +201,54 @@ export function boundIdentity(whoamiOutput, expected) {
   const want = normalizeKey(expected)
   // Deliberately checked BEFORE parsing. With no expectation there is no comparison to make, and
   // reporting "the server answered" as a pass is the whole defect.
-  if (!want) return unknown('no expected key given, so there is nothing to compare against')
+  if (!want) {
+    return unknown(malformedNpub(expected)
+      ? 'the expected key is an npub that does not decode — INCONCLUSIVE, a garbled value rather than a different identity'
+      : 'no expected key given, so there is nothing to compare against')
+  }
 
   const resolved = whoamiPubkey(whoamiOutput)
-  if (!resolved) return unknown('no identity found in the captured output — check it is the whole `nvoy_whoami` result')
+  if (!resolved) {
+    return unknown(malformedNpub(whoamiRawKey(whoamiOutput))
+      ? 'the captured output holds an npub that does not decode — INCONCLUSIVE, a garbled capture rather than a different identity'
+      : 'no identity found in the captured output — check it is the whole `nvoy_whoami` result')
+  }
 
   return resolved === want
     ? { match: true, resolved, reason: `answers as ${resolved.slice(0, 12)}…, which is the minted key` }
     : { match: false, resolved, reason: `answers as ${resolved.slice(0, 12)}…, NOT the minted ${want.slice(0, 12)}… — this session would sign as someone else` }
 }
 
-// npub or 64-hex in, lowercase hex out, or null. Hand-decoded rather than imported so this module
-// stays free of runtime dependencies; bech32's checksum is not verified here because the value is
-// only ever compared against another value normalized the same way — a corrupt npub cannot match a
-// good one, and cannot be mistaken for "nobody looked" either, since it returns null.
+// npub or 64-hex in, lowercase hex out, or null.
+//
+// `nip19.decode`, not a hand-rolled base32 walk. The hand-rolled one read `v.slice(5, -6)` and
+// never looked at the six characters it discarded — so the only part of a bech32 string that can
+// detect corruption was the only part it threw away. Flip one checksum character and a string the
+// standard decoder refuses outright decoded to a clean 32 bytes and was reported as a MATCH, by the
+// guard whose entire job is to refuse what it cannot vouch for (#451 review).
+//
+// The defence for hand-rolling was that this module takes no runtime dependency. It does not hold:
+// `src/nostr_signer.mjs` and `src/buzz_policy_core.mjs` already import nip19, `nostr-tools` is a
+// direct dependency, and `nip19.decode` opens nothing — the module stays pure. The house precedent
+// is `tools/publish-dm-relay-list.mjs`, which normalizes the same value the same way for the same
+// job; the hand-rolled version was strictly weaker than the guard it was modelled on.
 function normalizeKey(value) {
   const v = String(value ?? '').trim().toLowerCase()
   if (/^[0-9a-f]{64}$/.test(v)) return v
-  if (!/^npub1[023456789acdefghjklmnpqrstuvwxyz]{58}$/.test(v)) return null
-  const CHARSET = 'qpzry9x8gf2tvdw0s3jn54khce6mua7l'
-  let acc = 0, bits = 0
-  const out = []
-  for (const ch of v.slice(5, -6)) {
-    const d = CHARSET.indexOf(ch)
-    if (d < 0) return null
-    acc = (acc << 5) | d; bits += 5
-    if (bits >= 8) { bits -= 8; out.push((acc >> bits) & 0xff) }
-  }
-  if (out.length !== 32) return null
-  return out.map(b => b.toString(16).padStart(2, '0')).join('')
+  if (!v.startsWith('npub1')) return null
+  try {
+    const { type, data } = nip19.decode(v)
+    return type === 'npub' && /^[0-9a-f]{64}$/.test(data) ? data : null
+  } catch { return null }   // bad checksum, wrong length, not bech32 at all — all refused
+}
+
+// An npub-shaped string that does not decode is a GARBLED CAPTURE, not somebody else's key, and the
+// two need different words. Corrupting the data part used to produce "answers as …, NOT the minted
+// … — this session would sign as someone else", which sends the operator hunting for an impostor
+// when one character got mangled between two clipboards. Assert the reason, not only the refusal.
+function malformedNpub(value) {
+  const v = String(value ?? '').trim().toLowerCase()
+  return v.startsWith('npub1') && normalizeKey(v) === null
 }
 
 // The JSON field first, because it is the contract. The loose scan is a fallback for output that
@@ -240,6 +261,16 @@ function whoamiPubkey(text) {
   } catch { /* not JSON, or wrapped in a client's own envelope — fall through */ }
   const m = /"(?:pubkey|npub)"\s*:\s*"([^"]+)"/.exec(text) || /\b(npub1[023456789acdefghjklmnpqrstuvwxyz]{58})\b/.exec(text)
   return m ? normalizeKey(m[1]) : null
+}
+
+// The raw token `whoamiPubkey` WOULD have used, before normalization — diagnosis only, never a
+// return value. It is what lets a null answer say WHICH null: nothing key-shaped in the capture at
+// all, or an npub-shaped string that does not decode. The npub pattern here is deliberately looser
+// than the one above, because a truncated or over-long npub is exactly the garbling being reported.
+function whoamiRawKey(text) {
+  if (typeof text !== 'string') return null
+  const m = /"(?:pubkey|npub)"\s*:\s*"([^"]+)"/.exec(text) || /\bnpub1[023456789acdefghjklmnpqrstuvwxyz]{6,}\b/.exec(text)
+  return m ? (m[1] ?? m[0]) : null
 }
 
 // MCP results arrive wrapped — `{content:[{type:'text',text:'{…}'}]}` — so walk into strings too.

--- a/tests/agent_install_state.mjs
+++ b/tests/agent_install_state.mjs
@@ -19,7 +19,8 @@ import { dirname, join, resolve } from 'node:path'
 import { tmpdir } from 'node:os'
 import { execFileSync } from 'node:child_process'
 import { fileURLToPath } from 'node:url'
-import { installState, renderState, foreignNvoyServers, ARTIFACTS, ARTIFACT_KEYS, PRESENT, UNVERIFIED, MISSING, UNKNOWN }
+import { npubEncode } from 'nostr-tools/nip19'
+import { installState, renderState, foreignNvoyServers, boundIdentity, ARTIFACTS, ARTIFACT_KEYS, PRESENT, UNVERIFIED, MISSING, UNKNOWN }
   from '../src/agent_install_state.mjs'
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..')
@@ -317,6 +318,89 @@ check(ARTIFACTS.some(a => a.blocking) && ARTIFACTS.some(a => !a.blocking),
   check(readdirSync(probeRoot).length === 0,
     'NEGATIVE CONTROL — and --check wrote nothing into the probe root, so running the tool is side-effect free')
   rmSync(probeRoot, { recursive: true, force: true })
+}
+
+// ── #338 — sole is not YOURS: the MCP path's EXPECT_PUBKEY ───────────────────────────────────
+//
+// Every assertion here is paired. The reported failure was a session answering as another agent
+// and nothing objecting; the failure this test could introduce is a guard that objects to
+// everything, which looks identical from a green suite and takes the working case down with it.
+{
+  // MC Claude and Oliver, the two identities in the incident, as their real key shapes.
+  const MINE = 'ad05b00e'.padEnd(64, '3')
+  const THEIRS = 'ebc6eec1'.padEnd(64, '7')
+  const whoami = pk => JSON.stringify({ npub: 'npub1…', pubkey: pk, relays: ['wss://relay.example'], metadata: null })
+
+  const right = boundIdentity(whoami(MINE), MINE)
+  check(right.match === true, 'a server answering as the minted key passes')
+  check(right.resolved === MINE && right.reason.includes(MINE.slice(0, 12)),
+    'and the PASS names WHO it matched, because a guard that passes in silence is indistinguishable from one that is not there (#338)')
+
+  const wrong = boundIdentity(whoami(THEIRS), MINE)
+  check(wrong.match === false, 'a server answering as a DIFFERENT agent is refused — the reported failure, caught')
+  check(wrong.resolved === THEIRS && wrong.reason.includes(THEIRS.slice(0, 12)) && wrong.reason.includes(MINE.slice(0, 12)),
+    'and the refusal names both keys, so the operator is not left guessing which session they are in')
+
+  // BOTH DIRECTIONS, at the level that matters: not "it refused" but "it refused THIS and not THAT".
+  check(right.match !== wrong.match, 'NEGATIVE CONTROL — the two verdicts differ, so the guard is discriminating and not merely refusing')
+
+  // The three UNKNOWNs. None may reach `true`, and none may reach `false` either: "nobody looked"
+  // sends an operator to fix a binding that may be correct, which is the same false confidence
+  // pointing the other way.
+  check(boundIdentity(null, MINE).match === null, 'nothing captured is UNKNOWN, not a pass')
+  check(boundIdentity('', MINE).match === null, 'and so is an empty capture — a file that read blank has told you nothing')
+  const unasked = boundIdentity(whoami(THEIRS), '')
+  check(unasked.match === null,
+    'CRITICAL — with no expected key there is no comparison, so the verdict is UNKNOWN even though the server answered')
+  check(unasked.match !== true,
+    'NEGATIVE CONTROL — and specifically not a pass: a guard that goes green because nobody supplied the comparison is the whole defect')
+  check(boundIdentity('{"npub":"npub1…"}', MINE).match === null,
+    'output with no readable identity is UNKNOWN — not silently clean')
+
+  // npub and hex are the same key. Comparing the two alphabets as strings would refuse a correct
+  // binding, and a guard that refuses the working case gets switched off.
+  //
+  // The fixture is encoded by nip19 rather than typed, because the first draft of this test used a
+  // hand-invented npub that fails its own checksum. It passed — both sides normalize identically,
+  // so a nonsense string matches a nonsense string — and proved nothing about real input.
+  const NPUB = npubEncode(MINE)
+  const asHex = boundIdentity(JSON.stringify({ npub: NPUB }), NPUB)
+  check(asHex.match === true && asHex.resolved === MINE,
+    'an npub is decoded to hex, so npub-vs-hex compares as the same key rather than as a mismatch')
+  check(boundIdentity(JSON.stringify({ pubkey: MINE }), NPUB).match === true,
+    'and the comparison holds with the alphabets swapped between the two sides')
+  check(boundIdentity(JSON.stringify({ npub: NPUB }), THEIRS).match === false,
+    'NEGATIVE CONTROL — decoding does not make every npub match; a different key still refuses')
+
+  // The decoder is hand-rolled so the module stays dependency-free, which makes it a place a bug
+  // can live unseen: every assertion above compares two values this same code produced, so a
+  // decoder that is wrong in a consistent way agrees with itself perfectly. Check it against the
+  // library instead, across the whole byte range rather than one lucky key.
+  let disagreed = 0
+  for (let i = 0; i < 128; i++) {
+    const hex = Array.from({ length: 32 }, (_, j) => ((i * 31 + j * 7) % 256).toString(16).padStart(2, '0')).join('')
+    if (boundIdentity(JSON.stringify({ npub: npubEncode(hex) }), hex).match !== true) disagreed++
+  }
+  check(disagreed === 0, `the hand-rolled bech32 agrees with nip19 on 128 keys (${disagreed} disagreed)`)
+
+  // MCP results reach a human wrapped in an envelope. Failing to read through it would report
+  // UNKNOWN for a session that did answer, and UNKNOWN is the state operators learn to skip past.
+  const wrapped = JSON.stringify({ content: [{ type: 'text', text: whoami(THEIRS) }] })
+  check(boundIdentity(wrapped, MINE).match === false && boundIdentity(wrapped, THEIRS).match === true,
+    'a whoami wrapped in an MCP content envelope is still read, in both directions')
+
+  // The artifact, and its exit code. Blocking, because a session bound to someone else must not
+  // read as an agent that merely lacks a name.
+  const bind = ARTIFACTS.find(a => a.key === 'mcp-identity')
+  check(!!bind && bind.blocking === true, 'the checklist carries a blocking mcp-identity artifact')
+  const everythingElse = Object.fromEntries(
+    ARTIFACT_KEYS.filter(k => k !== 'mcp-identity').map(k => [k, { found: true, verified: true }]))
+  check(installState({ ...everythingElse, 'mcp-identity': { found: false } }).exitCode === 1,
+    'an otherwise-perfect agent whose server answers as someone else exits 1 — it cannot be used')
+  check(installState(everythingElse).exitCode === 3,
+    'and one where nobody checked the binding exits 3 — INCONCLUSIVE is not a softer 0')
+  check(installState({ ...everythingElse, 'mcp-identity': { found: true, verified: true } }).outcome === 'complete',
+    'BOTH DIRECTIONS — a correctly bound agent still reads complete, so the guard has not simply closed the door')
 }
 
 console.log(`\n${pass ? 'ALL PASS' : 'FAILURES ABOVE'}`)

--- a/tests/agent_install_state.mjs
+++ b/tests/agent_install_state.mjs
@@ -19,7 +19,7 @@ import { dirname, join, resolve } from 'node:path'
 import { tmpdir } from 'node:os'
 import { execFileSync } from 'node:child_process'
 import { fileURLToPath } from 'node:url'
-import { npubEncode } from 'nostr-tools/nip19'
+import { npubEncode, decode as nip19decode } from 'nostr-tools/nip19'
 import { installState, renderState, foreignNvoyServers, boundIdentity, ARTIFACTS, ARTIFACT_KEYS, PRESENT, UNVERIFIED, MISSING, UNKNOWN }
   from '../src/agent_install_state.mjs'
 
@@ -372,16 +372,67 @@ check(ARTIFACTS.some(a => a.blocking) && ARTIFACTS.some(a => !a.blocking),
   check(boundIdentity(JSON.stringify({ npub: NPUB }), THEIRS).match === false,
     'NEGATIVE CONTROL — decoding does not make every npub match; a different key still refuses')
 
-  // The decoder is hand-rolled so the module stays dependency-free, which makes it a place a bug
-  // can live unseen: every assertion above compares two values this same code produced, so a
-  // decoder that is wrong in a consistent way agrees with itself perfectly. Check it against the
-  // library instead, across the whole byte range rather than one lucky key.
+  // A round trip across the byte range. Every assertion above compares two values this same path
+  // produced, so a normalizer that is wrong in a consistent way agrees with itself perfectly.
   let disagreed = 0
   for (let i = 0; i < 128; i++) {
     const hex = Array.from({ length: 32 }, (_, j) => ((i * 31 + j * 7) % 256).toString(16).padStart(2, '0')).join('')
     if (boundIdentity(JSON.stringify({ npub: npubEncode(hex) }), hex).match !== true) disagreed++
   }
-  check(disagreed === 0, `the hand-rolled bech32 agrees with nip19 on 128 keys (${disagreed} disagreed)`)
+  check(disagreed === 0, `npub↔hex round-trips on 128 keys (${disagreed} disagreed)`)
+
+  // MALFORMED INPUT — the gap the 128 keys above cannot see, because every one of them is
+  // well-formed (#451 review).
+  //
+  // The old decoder read `v.slice(5, -6)` and never looked at the six characters it discarded. Those
+  // six ARE the checksum: the only part of a bech32 string that can detect corruption was the only
+  // part it threw away. Flip one of them, leave the data untouched, and a string `nip19.decode`
+  // refuses outright decoded to the same clean 32 bytes and printed a green tick — on the artifact
+  // whose whole job is to refuse what it cannot vouch for.
+  //
+  // Corrupt the DATA part instead and the refusal was confidently wrong the other way: "answers as
+  // …, NOT the minted … — this session would sign as someone else", said about a capture that got
+  // mangled between two clipboards. Both are asserted, and both assert the REASON: `match === null`
+  // alone cannot tell a correct refusal from a correct refusal that sends the operator hunting for
+  // an impostor who does not exist.
+  const CHARSET = 'qpzry9x8gf2tvdw0s3jn54khce6mua7l'
+  const flip = (s, i) => {
+    const at = i < 0 ? s.length + i : i
+    return s.slice(0, at) + CHARSET[(CHARSET.indexOf(s[at]) + 1) % CHARSET.length] + s.slice(at + 1)
+  }
+  const BAD_SUM = flip(NPUB, -3)    // inside the six checksum characters — data part untouched
+  const BAD_DATA = flip(NPUB, 10)   // inside the data part
+
+  // FIXTURE GUARD. A probe that loses its own input has told you nothing: if these strings were
+  // still valid npubs, every assertion below would pass while exercising nothing.
+  const refused = s => { try { nip19decode(s); return false } catch { return true } }
+  check(refused(BAD_SUM) && refused(BAD_DATA) && !refused(NPUB) && BAD_SUM !== NPUB && BAD_DATA !== NPUB,
+    'FIXTURE — nip19 refuses both corrupted npubs and accepts the clean one, so these cases test what they claim')
+
+  const badSum = boundIdentity(JSON.stringify({ npub: BAD_SUM }), MINE)
+  check(badSum.match === null,
+    'an npub that fails its CHECKSUM is UNKNOWN — the six characters the old decoder discarded were the only ones that could catch it')
+  check(/does not decode/.test(badSum.reason) && !/someone else/.test(badSum.reason),
+    '  ...and the reason says garbled capture, not impostor')
+
+  const badData = boundIdentity(JSON.stringify({ npub: BAD_DATA }), MINE)
+  check(badData.match === null && /does not decode/.test(badData.reason),
+    'an npub whose DATA is corrupt is UNKNOWN too — not a confident "this session would sign as someone else"')
+
+  const badExpected = boundIdentity(JSON.stringify({ pubkey: MINE }), BAD_SUM)
+  check(badExpected.match === null && /expected key/.test(badExpected.reason),
+    'and a corrupt --pubkey is UNKNOWN rather than a match — the EXPECTED side is decoded too, which is how the checksum flip got its green tick')
+
+  check(boundIdentity(JSON.stringify({ npub: NPUB.slice(0, -4) }), MINE).match === null,
+    'a truncated npub is UNKNOWN — nothing about it is readable, so nothing about it is reported')
+
+  // BOTH DIRECTIONS. A normalizer that returned null for every npub would satisfy all four of those
+  // and break every real check, which is the shape that gets a guard switched off.
+  const impostor = boundIdentity(JSON.stringify({ npub: npubEncode(THEIRS) }), MINE)
+  check(impostor.match === false && /sign as someone else/.test(impostor.reason),
+    'NEGATIVE CONTROL — a WELL-FORMED npub for a different key still reads as an impostor, so this refuses the garbled input rather than all input')
+  check(boundIdentity(JSON.stringify({ npub: npubEncode(MINE) }), MINE).match === true,
+    '  ...and the matching one still passes')
 
   // MCP results reach a human wrapped in an envelope. Failing to read through it would report
   // UNKNOWN for a session that did answer, and UNKNOWN is the state operators learn to skip past.

--- a/tools/connect-agent.mjs
+++ b/tools/connect-agent.mjs
@@ -25,6 +25,10 @@
 //   node tools/connect-agent.mjs --name oliver --pubkey <64-hex> --owner <64-hex>
 //   node tools/connect-agent.mjs --name oliver --check      # changes nothing
 //
+// --whoami <path>    the `nvoy_whoami` result captured from the session under test, compared
+//                    against --pubkey. This is the MCP path's EXPECT_PUBKEY (#338): registered is
+//                    not sole, and sole is not YOURS. Without it the binding reads UNCHECKED.
+//
 // --from <instance>  mirror an existing agent's manifest for the fields this repo cannot derive
 //                    (grantors, task carriers, relays). Mirroring is not understanding: the
 //                    copied values are reported, and docs/DESIGN_CONNECT_REMOTE_AGENT.md §II
@@ -34,7 +38,7 @@ import { execFileSync } from 'node:child_process'
 import { existsSync, lstatSync, mkdirSync, readFileSync, statSync, writeFileSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
-import { foreignNvoyServers, installState, renderState } from '../src/agent_install_state.mjs'
+import { boundIdentity, foreignNvoyServers, installState, renderState } from '../src/agent_install_state.mjs'
 
 const flag = n => { const i = process.argv.indexOf(n); return i < 0 ? '' : (process.argv[i + 1] || '') }
 const has = n => process.argv.includes(n)
@@ -189,6 +193,23 @@ see('mcp-exclusive', foreign === null ? null : foreign.length === 0, foreign !==
       ? `nvoy-${name} is the only nvoy server registered`
       : `also registered: ${foreign.join(', ')} — these carry the tools that SIGN, and not as ${name}. Remove with \`claude mcp remove <name>\` before acting.`)
 if (foreign?.length) warn.push(`${foreign.join(', ')} would sign as another identity from this session`)
+
+// Sole is not YOURS (#338). Nothing here can call the server — the channel holds its own lock — so
+// the operator captures `nvoy_whoami` from the session under test and passes the file. Reported
+// UNKNOWN without it, never as a pass: an unsupplied comparison reading green is the defect.
+const whoamiPath = flag('--whoami')
+let captured = null
+if (whoamiPath) {
+  try { captured = readFileSync(whoamiPath, 'utf8') } catch { captured = null }
+  if (captured === null) warn.push(`could not read ${whoamiPath} — the binding is UNCHECKED, not clean`)
+}
+const bind = boundIdentity(captured, pubkey)
+const bindRemedy = !pubkey
+  ? ' — pass --pubkey <64-hex>'
+  : captured === null ? ' — call nvoy_whoami in the session under test, save the result, and pass --whoami <path>' : ''
+see('mcp-identity', bind.match, bind.match === true, bind.match === null ? bind.reason + bindRemedy : bind.reason)
+if (bind.match === false) warn.push(`this session answers as ${bind.resolved.slice(0, 12)}… — do not send, do not read; it is not ${name}`)
+
 see('channel-answers', registered === true ? true : null, false, 'registered is not running — prove with an initialize + tools/list handshake')
 
 // ── Report ──────────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Registered is not sole — #380 closed that. **Sole is not YOURS.**

An agent was handed a session whose attached nvoy server answered `whoami` with a different agent's identity. Had it trusted the briefing it would have read that identity's sealed inbox and posted under its key, and neither would have errored, because a wrong-identity binding signs and seals perfectly. It was found only because the agent treated its own briefing as unverified and ran one read-only call to check.

The Bunker path has refused this class since day one — `relay-send`, `publish-dm-relay-list` and the profile publishes all hard-stop on `EXPECT_PUBKEY` before signing. The MCP registration path had no guard at all, so the same defect moved one layer up from Pair to Bind and found nothing waiting.

## What changed

- **`src/agent_install_state.mjs`** — `boundIdentity(whoamiOutput, expected)`, and `mcp-identity` joins `ARTIFACTS` as **blocking**. A session bound to someone else must not read as an agent that merely lacks a name.
- **`tools/connect-agent.mjs`** — `--whoami <path>`. This repo's checker opens no sockets and the channel server holds its own lock, so the operator captures the `nvoy_whoami` result from the session under test and the tool compares it against `--pubkey`.
- **`docs/DESIGN_CONNECT_REMOTE_AGENT.md`** — inventory row 15.

## Three verdicts, and the third is the point

`null` is never reachable by the same path as `true`. With no expectation supplied there is no comparison, so the answer is UNKNOWN **even though the server answered** — a guard that goes green because nobody gave it anything to check is the whole defect restated. The check is deliberately made before parsing, so no amount of well-formed output can route around it.

A pass prints **who** it matched (`answers as ad05b00e3333…, which is the minted key`); a refusal names both keys. #338 asked for this explicitly: a guard that passes in silence is indistinguishable from a guard that is not there, which is how the original went unnoticed.

## Evidence

Five mutations, each failing by name:

| mutation | first failure |
|---|---|
| pass when nobody supplied the expectation | `CRITICAL — with no expected key there is no comparison…` |
| mismatch reported as UNKNOWN | `a server answering as a DIFFERENT agent is refused` |
| one-bit bech32 decode error | `the hand-rolled bech32 agrees with nip19 on 128 keys (128 disagreed)` |
| artifact downgraded to non-blocking | `the checklist carries a blocking mcp-identity artifact` |
| tool stops reporting it | `every artifact is reported by connect-agent.mjs — unreported: mcp-identity` |

Both directions throughout, per #168: the correct binding passes *and* the cross-binding refuses, and the suite asserts the two verdicts differ rather than only that one of them refused.

The four CLI paths were driven end to end, not only the pure module — matching, cross-bound, no `--pubkey`, unreadable file. That mattered: my first run of that probe showed `--whoami` having no effect, which was zsh not word-splitting an unquoted variable, not a code defect. The unit tests would never have surfaced either way.

`npm test` exit 0, 2540 assertions, no failures. `npx eslint src tools tests` clean.

## Two things a reviewer should push on

**The bech32 decoder is hand-rolled** to keep `agent_install_state.mjs` free of runtime dependencies, and it does **not** verify the checksum. That is defensible — both sides normalize through the same function, so a corrupt npub cannot match a good one and cannot read as "nobody looked" either — but it is a judgement call, and importing `nip19` here is a one-line alternative. The suite cross-checks the decoder against `nip19` on 128 keys precisely because every other assertion compares two values this same code produced.

**`--whoami` puts the operator in the loop.** The alternative is for this tool to call the server itself, which it cannot do without opening a socket and taking the channel lock — but it does mean the guard only fires when someone remembers the flag. Without it the row reads UNKNOWN with the remedy, never clean.

## Stack

Branches off #450 (#337), which touches the same three files. Merge that first.

I wrote this, so it needs a reader who did not.

Drafted with assistance from [Claude Code](https://claude.com/claude-code)
