### PR TITLE
Mint the channel key where the stanza names it, and close the manifest round trip (#474)

### DIFF
--- a/src/agent_install_state.mjs
+++ b/src/agent_install_state.mjs
@@ -68,7 +68,13 @@ export const ARTIFACTS = [
   { key: 'state-dirs', title: 'Runtime directories', blocking: true,
     why: 'Five of them, two with non-default modes. Nothing creates them and nothing lists them.' },
   { key: 'channel-key', title: 'Channel keypair', blocking: true,
-    why: 'The MCP channel transport.' },
+    why: 'The MCP channel transport. Minted at the path the registration names — the two used to disagree, so a fresh agent got a correct stanza pointing at a key nothing had created (#474).' },
+  // Its own row, not folded into the keypair. The private half is mintable here; neither of these
+  // is, and a green key row beside a missing host key is exactly how a fresh agent reads as ready.
+  { key: 'channel-host-key', title: "The broker's host key", blocking: true,
+    why: "StrictHostKeyChecking refuses an unknown host, so without this the channel will not connect. It is the broker's host key and comes from the broker doctor on that box — it cannot be minted here, and this tool will never write one." },
+  { key: 'channel-authorized', title: 'The public half is seated on the broker', blocking: true,
+    why: "The other box's authorized_keys, under its forced command. Nothing on this machine can see it, so it is UNKNOWN until an operator confirms it — never assumed from the key existing here." },
   { key: 'mcp-registration', title: 'Registered as an MCP server', blocking: true,
     why: 'How a new session becomes this agent. Needs the instance root set explicitly; the default path does not exist here.' },
   { key: 'mcp-exclusive', title: 'No other nvoy server registered', blocking: true,

--- a/src/agent_manifest_transfer.mjs
+++ b/src/agent_manifest_transfer.mjs
@@ -58,6 +58,31 @@ export function relayFault(v) {
 }
 
 /**
+ * A task carrier, as production actually spells it.
+ *
+ * `{ pubkey, channels: [...] }`, not a bare key. This was validated as a plain hex list, so
+ * `--export` from a real working agent produced a template that `--from-file` refused: the tool
+ * could not consume its own output, and the whole point of the pair is the round trip.
+ *
+ * Nothing in the suite caught it because every fixture in it was a bare 64-hex string. The
+ * fixtures did not resemble production, which is the same failure that put a name with a space
+ * into a live outage here — the assertions were all true about a manifest shape that does not
+ * exist on any machine.
+ *
+ * The bare-key form is still accepted. It may be what an older manifest holds, and refusing a
+ * carrier that a running agent is using would be this function inventing a policy rather than
+ * validating a value. A carrier with no channels is refused either way: it names a key that
+ * carries nothing, which is indistinguishable at runtime from having no carrier at all.
+ */
+const isCarrier = x => {
+  if (HEX64.test(String(x))) return true
+  if (!x || typeof x !== 'object' || Array.isArray(x)) return false
+  if (!HEX64.test(String(x.pubkey || ''))) return false
+  return Array.isArray(x.channels) && x.channels.length > 0 && x.channels.every(c => typeof c === 'string' && c.trim() !== '')
+}
+const isCarrierList = v => Array.isArray(v) && v.length > 0 && v.every(isCarrier)
+
+/**
  * Reduce a working manifest to what may cross a machine boundary.
  *
  * Returns `{ template, dropped }` — `dropped` names every field left behind, because a transfer
@@ -115,7 +140,7 @@ export function importTemplate(template, host) {
     throw new Error(`template is missing ${missing.join(', ')} — this repo cannot derive ${missing.length === 1 ? 'it' : 'them'}, and an agent seated without ${missing.length === 1 ? 'it' : 'them'} looks configured and is not`)
   }
   if (!isHexList(template.grantors)) throw new Error('template grantors must be a non-empty list of 64-hex keys')
-  if (!isHexList(template.task_carriers)) throw new Error('template task_carriers must be a non-empty list of 64-hex keys')
+  if (!isCarrierList(template.task_carriers)) throw new Error('template task_carriers must be a non-empty list of carriers — each a 64-hex key, or {pubkey, channels:[…]} with at least one channel')
   // The reason, not only the refusal. `must be a non-empty list of wss:// URLs` about a URL that
   // IS a wss:// URL sends the operator hunting for a typo in a string whose fault is the token on
   // the end of it.

--- a/tests/agent_manifest_transfer.mjs
+++ b/tests/agent_manifest_transfer.mjs
@@ -16,11 +16,12 @@
 //      declares a privilege separation the new host may not have, silently.
 import { strict as assert } from 'node:assert'
 import { execFileSync } from 'node:child_process'
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { HOST_ONLY, IDENTITY_ONLY, exportTemplate, importTemplate, relayFault } from '../src/agent_manifest_transfer.mjs'
+import { channelCommand, credentialPaths } from '../src/channel_registration.mjs'
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..')
 let pass = 0, fail = 0
@@ -30,7 +31,14 @@ const threw = fn => { try { fn(); return '' } catch (e) { return e.message } }
 console.log('\nagent_manifest_transfer\n')
 
 const K = n => String(n).repeat(64).slice(0, 64)
-const GRANTOR = K('a'), CARRIER = K('b'), SRC_PUB = K('c'), NEW_PUB = K('d')
+const GRANTOR = K('a'), CARRIER_KEY = K('b'), SRC_PUB = K('c'), NEW_PUB = K('d')
+
+// The shape a real manifest holds: a key AND the channels it carries for. This was a bare 64-hex
+// string, and that one wrong fixture was enough — `--export` from a working agent produced a
+// template that `--from-file` refused as "not a list of 64-hex keys". The tool could not consume
+// its own output, which is the entire point of the pair, and 62 assertions were green over it
+// because every one of them was true about a manifest shape that exists on no machine.
+const CARRIER = { pubkey: CARRIER_KEY, channels: ['a8186b53-537d-46ad-a7e7-b6486c58970e'] }
 
 // A manifest in the shape the real ones are in, uids and all.
 const working = {
@@ -103,7 +111,14 @@ const host = {
   stateDir: '/home/pi/agent/state', runtimeDir: '/home/pi/agent/runtime', spoolDir: '/home/pi/agent/spool',
   uriPath: '/home/pi/agent/credentials/bunker-uri', clientPath: '/home/pi/agent/credentials/bunker-client',
 }
-const { manifest, warnings } = importTemplate(template, host)
+// Guarded, and the guard is load-bearing. With the production-shaped fixture above, a regression in
+// the carrier validator throws HERE — at module scope, killing the suite before any summary prints.
+// A dead suite greps as zero failures and reads like a pass; `npm test` catches it only because the
+// chain stops on a non-zero exit, which is the alarm working by accident rather than by design.
+let imported = null
+try { imported = importTemplate(template, host) } catch (e) { imported = { error: e.message } }
+check(!imported.error, `the exported template imports at all${imported.error ? ` — ${imported.error.slice(0, 70)}` : ''}`)
+const { manifest = {}, warnings = [] } = imported
 check(manifest.id === 'pi-agent' && manifest.pubkey === NEW_PUB,
   'the seated manifest carries the NEW agent identity, not the exporting one')
 check(manifest.pubkey !== SRC_PUB, 'and specifically NOT the source key — this is the impersonation guard')
@@ -128,6 +143,34 @@ check(/must not travel/.test(threw(() => importTemplate({ ...template, pubkey: S
   'a template that carries a pubkey is refused — that is a hand-copied manifest, not an export')
 check(/must not travel/.test(threw(() => importTemplate({ ...template, watcher_uid: 1001 }, host))),
   'and one that carries a uid is refused for the same reason')
+
+// ── 4b. The carrier shape, in both directions ───────────────────────────────────────────────
+// The round trip is the property, not either half. `--export` and `--from-file` agreeing on paper
+// is what was already asserted; that they agree on a REAL manifest is what was not.
+console.log('\n4b. the round trip actually closes on a production-shaped manifest')
+check(threw(() => importTemplate(exportTemplate(working).template, host)) === '',
+  'export → import round-trips a manifest whose carriers are {pubkey, channels} — the case that was broken')
+check(threw(() => importTemplate({ ...template, task_carriers: [CARRIER_KEY] }, host)) === '',
+  'NEGATIVE CONTROL — a bare 64-hex carrier is still accepted, so this widened the shape rather than swapping it')
+// Guarded. An unguarded call here throws at module scope when the round trip is broken, and a
+// suite that dies prints no summary at all — which greps as zero failures and reads exactly like a
+// pass. The mutation run that proved this section works surfaced as a crash, not as a named FAIL.
+let roundTripped = null
+try { roundTripped = importTemplate(exportTemplate(working).template, host).manifest } catch { roundTripped = null }
+check(roundTripped?.task_carriers?.[0]?.pubkey === CARRIER_KEY && roundTripped?.task_carriers?.[0]?.channels?.length === 1,
+  'and the carrier arrives intact — key and channels both, not flattened to a key')
+
+// Widened is not "anything goes". Each of these is a carrier that would look seated and carry
+// nothing, which at runtime is indistinguishable from having no carrier at all.
+const badCarrier = v => threw(() => importTemplate({ ...template, task_carriers: v }, host))
+check(badCarrier([{ pubkey: CARRIER_KEY }]) !== '', 'a carrier with no channels field is refused')
+check(badCarrier([{ pubkey: CARRIER_KEY, channels: [] }]) !== '', 'and one with an empty channel list is refused')
+check(badCarrier([{ pubkey: CARRIER_KEY, channels: [''] }]) !== '', 'and one whose channel is an empty string is refused')
+check(badCarrier([{ channels: ['a8186b53'] }]) !== '', 'and one with channels but no key is refused')
+check(badCarrier([{ pubkey: 'not-hex', channels: ['a8186b53'] }]) !== '', 'and one whose key is not 64-hex is refused')
+check(badCarrier([]) !== '', 'and an empty carrier list is refused — seated with nothing to carry is not seated')
+check(/pubkey/.test(badCarrier([{ pubkey: CARRIER_KEY }])) && /channels/.test(badCarrier([{ pubkey: CARRIER_KEY }])),
+  'and the refusal describes the shape it wants, rather than repeating "64-hex keys" at an object')
 check(/64-hex pubkey/.test(threw(() => importTemplate(template, { ...host, pubkey: 'nope' }))),
   'seating needs a real key for the new agent')
 check(/needs the agent name/.test(threw(() => importTemplate(template, { ...host, name: '' }))), 'and a name')
@@ -232,6 +275,22 @@ if (existsSync(landed)) {
   check(m.state_dir.startsWith(piRoot), 'with paths under THIS root')
 }
 check(/imported relays/.test(String(seated.out) + ''), 'the operator is told what was copied, at the moment it is copied')
+
+// The channel key, at the path the stanza names (#474). This is the end of the Pi path, and it is
+// asserted here rather than in a unit test because the defect was precisely that two correct halves
+// disagreed: the tool minted `mcp-channel/id_ed25519` and the stanza named
+// `credentials/claude-channel-ssh`. Each half passed when tested alone. Only running both catches it.
+const { keyPath: mintedAt } = credentialPaths(join(piRoot, 'pi-agent'))
+check(existsSync(mintedAt), 'the channel key is minted at the path the registration names, not beside it')
+check(existsSync(`${mintedAt}.pub`), 'with its public half — the part that has to reach the broker')
+check(existsSync(mintedAt) && (statSync(mintedAt).mode & 0o777) === 0o600, 'and mode 600')
+check(!existsSync(join(piRoot, 'pi-agent', 'mcp-channel', 'id_ed25519')),
+  'NEGATIVE CONTROL — and nothing is minted at the retired location, so this moved the key rather than adding a second')
+// Asserted as an equality, not as two existsSync calls. Two checks that each pass against a
+// different path is exactly the shape of the original defect.
+const stanzaNames = channelCommand({ instanceRoot: join(piRoot, 'pi-agent'), host: 'nave.pub' }).keyPath
+check(stanzaNames === mintedAt, 'and the stanza names that exact file — the two halves agree, which is the whole of #474')
+
 rmSync(probe, { recursive: true, force: true })
 
 console.log(`\n${pass} passed, ${fail} failed`)

--- a/tools/connect-agent.mjs
+++ b/tools/connect-agent.mjs
@@ -25,7 +25,6 @@
 //   node tools/connect-agent.mjs --name oliver --pubkey <64-hex> --owner <64-hex>
 //   node tools/connect-agent.mjs --name oliver --check      # changes nothing
 //   node tools/connect-agent.mjs --name oliver --check --stanza --channel-host <host>  # register
-
 //   node tools/connect-agent.mjs --name oliver --startup --runtime codex   # write AGENTS.md
 //   node tools/connect-agent.mjs --name oliver --check --startup --print   # show it, write nothing
 //
@@ -45,10 +44,10 @@
 import { execFileSync } from 'node:child_process'
 import { existsSync, lstatSync, mkdirSync, readFileSync, statSync, writeFileSync } from 'node:fs'
 import { homedir } from 'node:os'
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
 import { boundIdentity, installState, renderState } from '../src/agent_install_state.mjs'
 import { exportTemplate, importTemplate } from '../src/agent_manifest_transfer.mjs'
-import { channelCommand, credentialReport, registeredForm, sameVector } from '../src/channel_registration.mjs'
+import { channelCommand, credentialPaths, credentialReport, registeredForm, sameVector } from '../src/channel_registration.mjs'
 import { RUNTIMES, channelStanza, cliRuntimes, exclusivityVerdict, foreignServers, isMine, registrationHelp, runtime } from '../src/mcp_runtimes.mjs'
 import { startupDoc } from '../src/agent_startup.mjs'
 
@@ -250,14 +249,37 @@ see('state-dirs', dirsNow.length === DIRS.length, dirsNow.length === DIRS.length
   dirsNow.length === DIRS.length ? (modesRight ? `${DIRS.length} directories, modes as expected` : 'all present, but a mode differs') : `${DIRS.length - dirsNow.length} missing`)
 
 // ── Channel keypair ─────────────────────────────────────────────────────────────────────────
-const keyPath = join(HERE, 'mcp-channel', 'id_ed25519')
+// Minted where the stanza names it (#474). It used to be minted at `mcp-channel/id_ed25519`, which
+// nothing consumed, while the registration named `credentials/claude-channel-ssh`, which nothing
+// minted — so a fresh agent finished with a correct stanza pointing at a private key that had never
+// been created, and the one working agent worked only because its pair was made by hand.
+const { keyPath, knownHostsPath } = credentialPaths(HERE)
 if (!existsSync(keyPath) && !CHECK && !STARTUP_ONLY) {
-  mkdirSync(join(HERE, 'mcp-channel'), { recursive: true, mode: 0o700 })
+  mkdirSync(dirname(keyPath), { recursive: true, mode: 0o700 })
   execFileSync('ssh-keygen', ['-t', 'ed25519', '-N', '', '-C', `nvoy-mcp-channel ${name}`, '-f', keyPath], { stdio: 'ignore' })
   did.push(`generated ${keyPath}`)
 }
 const keyOk = existsSync(keyPath) && mode(keyPath) === 0o600 && existsSync(`${keyPath}.pub`)
 see('channel-key', existsSync(keyPath), keyOk, existsSync(keyPath) ? (keyOk ? 'mode 600, with its public half' : `mode ${mode(keyPath)?.toString(8)}`) : 'absent')
+
+// The old location is left exactly where it is. It is key material, and this tool does not delete
+// key material — but an agent carrying both should be told which one its channel actually uses,
+// because the answer is not guessable from the filenames.
+const retiredKey = join(HERE, 'mcp-channel', 'id_ed25519')
+if (existsSync(retiredKey) && existsSync(keyPath)) {
+  warn.push(`${retiredKey} is a keypair from the pre-#474 location — nothing reads it. Left in place; remove it yourself once you are satisfied the channel works.`)
+}
+
+// The two halves that are somebody else's step, on the other box. Their own rows, because a green
+// keypair beside a missing host key is exactly how a fresh agent reads as ready and is not.
+see('channel-host-key', existsSync(knownHostsPath), false,
+  existsSync(knownHostsPath)
+    ? 'present — but whether it is the RIGHT host key is not checked here; StrictHostKeyChecking proves that on first connect'
+    : `absent — run the broker doctor on the broker and write its host key to ${knownHostsPath}. This tool will never mint one`)
+// UNKNOWN and not MISSING: nothing on this machine can see the broker's authorized_keys, and
+// "cannot check" must not read as "not there" any more than it may read as "fine".
+see('channel-authorized', null, false,
+  `unverifiable from here — confirm ${keyPath}.pub is seated in the broker's authorized_keys under its forced command`)
 
 // ── MCP registration. Reported, never written: it edits the operator's own config, and this tool
 // prints the exact command rather than reaching into it.


### PR DESCRIPTION
Closes #474. Stacked on #473.

Both defects here were found by **running the Pi path end to end**, not by reading it. Neither was visible to a suite that merely ran — the suites were green through both.

## 1. The tool minted one key and named another

`connect-agent` minted `<agent>/mcp-channel/id_ed25519`. Its stanza named `<agent>/credentials/claude-channel-ssh`. Nothing consumed the first, nothing minted the second.

A fresh agent therefore finished with a **correct registration pointing at a private key that had never been created**. `mc-claude` works only because its pair was made by hand when its channel was set up.

The key is now minted where the stanza names it. The old file is left exactly where it is — this tool does not delete key material — and reported as unread so an operator knows which of the two their channel uses.

## 2. The manifest export/import pair could not round-trip

`--export` emits `task_carriers` as `{pubkey, channels:[…]}`. `--from-file` validated them as bare 64-hex strings. So `--export` from a real working agent produced a template that `--from-file` refused.

The round trip is the entire point of the pair, and it had never once been run.

62 assertions were green over it because **every fixture in that suite was a bare hex string**. The fixtures did not resemble production — the same failure that put a name with a space into a live outage here. The fixture is now the production shape, and with it the *pre-existing* import section catches this on its own.

The bare-key form is still accepted; a carrier with no channels is refused either way, because it names a key that carries nothing.

## 3. Two rows split out of `channel-key`

Neither is mintable on this machine, and a green keypair beside a missing host key is exactly how a fresh agent reads as ready:

- **The broker's host key** — MISSING when absent, naming the file. `StrictHostKeyChecking` means the channel will not connect without it.
- **The public half seated in the broker's `authorized_keys`** — UNKNOWN. Nothing here can see the other box, and "cannot check" must not read as "not there" any more than as "fine".

## Evidence

A fresh agent seated from an exported template — the actual Pi path, real tool, temp root:

```
credentials/claude-channel-ssh       mode 600
credentials/claude-channel-ssh.pub   present
mcp-channel/                         does not exist
[ok ] Channel keypair                        — mode 600, with its public half
[ x ] The broker's host key           MISSING — absent — run the broker doctor …
[ -  ] The public half is seated       UNKNOWN — unverifiable from here …
```

Both directions: adding a host key flips that row off MISSING; it does not go green, because whether it is the *right* host key is not checkable here.

**No regression:** `mc-claude`'s stanza still matches its live registration byte for byte, and its rows are unchanged.

**Mutations, each with an anchor guard:**
- mint back at the retired location → 4 named failures, including the negative control
- revert the carrier validator → the import fails naming its own reason

One extra fix worth flagging: two module-scope `importTemplate` calls were unguarded, so a regression killed the suite before it printed a summary. **A dead suite greps as zero failures and reads exactly like a pass** — it was caught only because the `&&` chain stops on a non-zero exit, which is the alarm working by accident. Both are guarded now and report named assertions.

95 suites green, lint 0 errors.

---

@My Dude — this one touches key material paths, so it needs a reader. The judgement call I'd most like checked: I widened the carrier validator to accept both shapes rather than swapping it, on the grounds that refusing a shape a running agent is currently using would be the validator inventing policy. If you think it should only accept the object form, say so — it is a one-line change and I would rather be wrong here than lenient by default.

Drafted with assistance from [Claude Code](https://claude.com/claude-code)