### PR TITLE
Let the operator paste a bunker:// URI instead of seating two files (#480)

### DIFF
--- a/src/bunker_paste.mjs
+++ b/src/bunker_paste.mjs
@@ -1,0 +1,131 @@
+// bunker_paste.mjs — accept a bunker:// URI the operator pastes, without letting it reach a place
+// that keeps it (#480).
+//
+// The operator holds the only key with `owner`/`admin` in `relay_members`, so they are the only
+// one who can mint an invite — and their signer hands them a `bunker://` string to PASTE, not a
+// pairing to seat in two files. Requiring the files put a key on disk to avoid putting a key on
+// disk, which is the wrong trade and it stalled the one step everything else waits behind.
+//
+// A `bunker://` URI carries a `secret` parameter. That makes it credential material, so:
+//
+//   - it is read from `/dev/tty` with echo off, never from argv (`ps`) and never from an
+//     environment variable (the shell history of whoever typed it, and `/proc` on Linux);
+//   - `findBunkerUriExposure` refuses the run when one shows up in either place anyway. Without
+//     that refusal the prompt is decoration, because the first person in a hurry routes around it
+//     and nothing says otherwise;
+//   - the URI is never written down. What persists is the CLIENT key, which is a different thing:
+//     a NIP-46 bunker authorizes a specific client keypair, so a fresh one each run is an app the
+//     signer has never seen and the connect is refused as "Unknown client"
+//     (`tools/grant.mjs:56-66`, same reasoning, same 0600 file). Persisting it is what makes the
+//     second run cost no approval; persisting the URI would keep the connect secret for no gain.
+//
+// Pure: strings in, verdicts out. No TTY, no filesystem, no socket — those live in the tool. This
+// module also may not import the signer backend (egress ban), which is why the caller builds the
+// signer from what these functions return.
+
+const BUNKER_URI = /^bunker:\/\/([0-9a-f]{64})(\?|$)/i
+
+/**
+ * Is this pasted text a bunker URI that can actually be connected with?
+ *
+ * Every refusal names the part that is wrong. A paste is a manual act — a truncated copy, a
+ * trailing quote from a chat client, or a signer that emitted `nostrconnect://` instead all land
+ * here, and "invalid bunker URI" sends the operator back to re-copy the same string.
+ *
+ * @returns {{uri: string, pubkey: string, relays: string[], hasSecret: boolean}|{error: string}}
+ */
+export function checkPastedBunkerUri(text) {
+  // Signers wrap the string in quotes, and a paste through a terminal can carry stray whitespace.
+  const raw = String(text ?? '').trim().replace(/^["'<]+|["'>]+$/g, '').trim()
+  if (!raw) return { error: 'nothing was pasted' }
+
+  if (/^nostrconnect:\/\//i.test(raw)) {
+    return { error: 'that is a nostrconnect:// URI, which is the OTHER direction — the client ' +
+      'publishes it and the signer connects back.\n' +
+      '  This tool needs the bunker:// string from your signer\'s "connect an app" flow.' }
+  }
+  if (!/^bunker:\/\//i.test(raw)) {
+    const scheme = raw.includes('://') ? raw.split('://')[0] : '(no scheme)'
+    return { error: `expected a bunker:// URI, got ${scheme}://…` }
+  }
+  const match = BUNKER_URI.exec(raw)
+  if (!match) {
+    // The commonest paste failure by far, and it does not look like a failure: the string is
+    // plausible and merely short, so a length-blind check would hand it to the signer and report
+    // the bunker's refusal instead of the truncation.
+    const after = raw.slice('bunker://'.length).split('?')[0]
+    return { error: `the pubkey in the URI is ${after.length} characters, not 64 — the paste looks ` +
+      'truncated. Copy the whole string.' }
+  }
+
+  let url
+  try { url = new URL(raw) } catch { return { error: 'the URI is not parseable — copy the whole string' } }
+  const relays = [...new Set(url.searchParams.getAll('relay').filter(v => /^wss:\/\//i.test(v)))]
+  if (!relays.length) {
+    const any = url.searchParams.getAll('relay')
+    return { error: any.length
+      ? `the URI's relay(s) are not wss:// — NIP-46 traffic is not sent over ${any[0].split('://')[0]}://`
+      : 'the URI names no relay, so there is no transport to reach the signer over. Copy the whole string.' }
+  }
+  return {
+    uri: raw,
+    pubkey: match[1].toLowerCase(),
+    relays,
+    // Not an error. A secret is single-use on first pairing, and a URI re-copied after the client
+    // key is already authorized legitimately has none. Refusing here would break the second run.
+    hasSecret: !!url.searchParams.get('secret'),
+  }
+}
+
+/**
+ * Did a bunker URI arrive by a route that records it?
+ *
+ * Checked BEFORE the prompt, so the answer is a refusal rather than a prompt the operator fills in
+ * while the same secret already sits in their history.
+ *
+ * @returns {{error: string}|{}}
+ */
+export function findBunkerUriExposure(argv = [], env = {}) {
+  const inArgv = (argv || []).some(a => /bunker:\/\//i.test(String(a)))
+  if (inArgv) {
+    return { error: 'a bunker:// URI was passed on the command line, and this tool will not take ' +
+      'one that way.\n' +
+      '  Argv is visible in `ps` to every user on this host and is kept in your shell history, and\n' +
+      '  the URI carries a connect secret. Re-run with --bunker and paste it at the prompt — it is\n' +
+      '  not echoed and it is not written down.\n' +
+      '  Your shell history now holds that secret. Rotate the pairing in your signer.' }
+  }
+  const named = Object.keys(env || {}).filter(k => /bunker/i.test(k) && /uri/i.test(k) && !/_FILE$/i.test(k))
+    .filter(k => /bunker:\/\//i.test(String(env[k] || '')))
+  if (named.length) {
+    return { error: `${named[0]} holds a bunker:// URI, and this tool will not take one from the ` +
+      'environment.\n' +
+      '  It is readable from /proc on Linux and it is in the history of whoever exported it.\n' +
+      '  Use --bunker and paste at the prompt, or WAGGLE_BUNKER_URI_FILE with a mode-0600 file.' }
+  }
+  return {}
+}
+
+/**
+ * The client key for this pairing — reuse what is there, or say a new one is needed.
+ *
+ * `existing` is the file's text, or null when there is no file. Reuse is the point: the bunker
+ * authorized THIS keypair, so generating a fresh one turns every run into a new approval and some
+ * signers refuse it outright as an unknown client.
+ *
+ * @returns {{hex: string, created: false}|{create: true}|{error: string}}
+ */
+export function planClientKey(existing) {
+  if (existing === null || existing === undefined) return { create: true }
+  const raw = String(existing).trim()
+  if (!raw) return { create: true }
+  if (!/^[0-9a-f]{64}$/i.test(raw)) {
+    // Never silently replace it. A corrupt file that regenerates looks identical to a working one
+    // for exactly as long as it takes the signer to ask for approval again, and the operator is
+    // left approving a second app without being told the first was discarded.
+    return { error: 'the saved client key is not 64-character hex. Delete the file to pair again — ' +
+      'this tool will not overwrite it, because a silent replacement is a second app in your signer ' +
+      'that you were never told about.' }
+  }
+  return { hex: raw.toLowerCase(), created: false }
+}

--- a/src/bunker_paste.mjs
+++ b/src/bunker_paste.mjs
@@ -50,12 +50,19 @@ export function checkPastedBunkerUri(text) {
   }
   const match = BUNKER_URI.exec(raw)
   if (!match) {
-    // The commonest paste failure by far, and it does not look like a failure: the string is
-    // plausible and merely short, so a length-blind check would hand it to the signer and report
-    // the bunker's refusal instead of the truncation.
+    // Two different faults reach here and they need two different sentences. A short pubkey is a
+    // truncated paste; a full-length one with a stray character in it is not, and telling that
+    // operator "it is 64 characters, not 64" sends them to re-copy a string that is already
+    // complete. Branch on length first, then on charset.
     const after = raw.slice('bunker://'.length).split('?')[0]
-    return { error: `the pubkey in the URI is ${after.length} characters, not 64 — the paste looks ` +
-      'truncated. Copy the whole string.' }
+    if (after.length !== 64) {
+      return { error: `the pubkey in the URI is ${after.length} characters, not 64 — the paste looks ` +
+        `${after.length < 64 ? 'truncated' : 'to have picked up extra characters'}. Copy the whole string.` }
+    }
+    const bad = [...after].filter(c => !/[0-9a-f]/i.test(c))
+    return { error: 'the pubkey in the URI is the right length but is not hex — it contains ' +
+      `${JSON.stringify(bad[0])}. A pubkey is 64 characters of 0-9 and a-f; check for a character ` +
+      'your terminal or chat client substituted while copying.' }
   }
 
   let url
@@ -95,13 +102,24 @@ export function findBunkerUriExposure(argv = [], env = {}) {
       '  not echoed and it is not written down.\n' +
       '  Your shell history now holds that secret. Rotate the pairing in your signer.' }
   }
-  const named = Object.keys(env || {}).filter(k => /bunker/i.test(k) && /uri/i.test(k) && !/_FILE$/i.test(k))
-    .filter(k => /bunker:\/\//i.test(String(env[k] || '')))
+  // Scanned by VALUE, not by name. This previously required the variable to be named something
+  // matching /bunker/ AND /uri/, which is a guess about what the operator called it — and the
+  // guess is wrong for every one of `SIGNER=bunker://…`, `NOSTR_CONNECT=…`, `BUNKER=…` and
+  // `NIP46_URI=…`. A check that only catches the exposure when it is helpfully labelled is not a
+  // check; the secret is in the value either way, and the value is what /proc and the shell
+  // history hold.
+  //
+  // The `_FILE` convention needs no exemption once the value is what is read: those variables hold
+  // a path, and a path does not contain `bunker://`. Exempting them by NAME would reopen the same
+  // hole one rename along — `WAGGLE_BUNKER_URI_FILE` set to the URI itself rather than to a path
+  // is precisely the mistake this refusal exists to catch.
+  const named = Object.keys(env || {}).filter(k => /bunker:\/\//i.test(String(env[k] ?? '')))
   if (named.length) {
     return { error: `${named[0]} holds a bunker:// URI, and this tool will not take one from the ` +
       'environment.\n' +
       '  It is readable from /proc on Linux and it is in the history of whoever exported it.\n' +
-      '  Use --bunker and paste at the prompt, or WAGGLE_BUNKER_URI_FILE with a mode-0600 file.' }
+      '  Use --bunker and paste at the prompt, or WAGGLE_BUNKER_URI_FILE with a mode-0600 file.\n' +
+      '  That variable now holds a connect secret. Rotate the pairing in your signer.' }
   }
   return {}
 }

--- a/src/relay_invite.mjs
+++ b/src/relay_invite.mjs
@@ -88,14 +88,30 @@ export function exitFor(status) {
  * Pure: it takes strings and returns a verdict, so both directions can be asserted without a key
  * file, a bunker or a socket. It does not import the signer backend — `src/` may not (egress ban).
  *
- * @returns {{kind: 'bunker'|'local'}|{error: string}}
+ * @returns {{kind: 'bunker'|'local'|'paste'}|{error: string}}
  */
-export function chooseSigningSource({ keyArg = null, uriFile = '', clientFile = '' } = {}) {
+export function chooseSigningSource({ keyArg = null, uriFile = '', clientFile = '', paste = false } = {}) {
   const key = String(keyArg || '').trim()
   const uri = String(uriFile || '').trim()
   const client = String(clientFile || '').trim()
   const pairing = !!uri || !!client
+  const pasted = !!paste
 
+  // Every ambiguous PAIR is named, rather than one check for "more than one source". The operator
+  // is told which two things are fighting and how to drop one, and a third source is the point at
+  // which a generic message stops being actionable (#480).
+  if (pasted && key) {
+    return { error: '--bunker and --key are BOTH given, and this tool will not pick one.\n' +
+      '  Drop one. A claim writes a relay_members row that cannot be removed without whichever\n' +
+      '  key signs (#366), so the wrong choice here is permanent.' }
+  }
+  if (pasted && pairing) {
+    return { error: '--bunker was given AND a pairing is already configured in the environment.\n' +
+      '  Pasting would sign as the pasted signer while the seated pairing sits unused, and this\n' +
+      '  tool will not choose between two bunkers. Unset WAGGLE_BUNKER_URI_FILE and\n' +
+      '  WAGGLE_NIP46_CLIENT_NSEC_FILE to paste, or drop --bunker to use the seated pairing.' }
+  }
+  if (pasted) return { kind: 'paste' }
   if (key && pairing) {
     return { error: '--key and a bunker pairing are BOTH configured, and this tool will not pick one.\n' +
       '  A claim writes a relay_members row that cannot be removed without that key (#366), so\n' +
@@ -111,8 +127,9 @@ export function chooseSigningSource({ keyArg = null, uriFile = '', clientFile = 
     return { kind: 'bunker' }
   }
   if (key) return { kind: 'local' }
-  return { error: 'no signing key. Either pass --key <path>, or set WAGGLE_BUNKER_URI_FILE and\n' +
-    '  WAGGLE_NIP46_CLIENT_NSEC_FILE to sign through a bunker pairing (#477).' }
+  return { error: 'no signing key. Pass --bunker to paste a bunker:// URI at a prompt (#480), or\n' +
+    '  --key <path> for a local key file, or set WAGGLE_BUNKER_URI_FILE and\n' +
+    '  WAGGLE_NIP46_CLIENT_NSEC_FILE to use a seated pairing (#477).' }
 }
 
 /** Local check of the relay's mint bounds. Returns null when fine, else the operator's message. */

--- a/src/relay_invite_signer.mjs
+++ b/src/relay_invite_signer.mjs
@@ -22,6 +22,9 @@ import { chooseSigningSource } from './relay_invite.mjs'
 /** Exit codes, matching the tool's contract. 2 is "the signer failed", 1 is "you meant another key". */
 const INPUT = 1, SIGNER = 2
 
+/** What to call the thing EXPECT_PUBKEY disagreed with, in the operator's terms. */
+const SOURCE = { bunker: 'pairing', local: 'key file', paste: 'bunker you pasted' }
+
 /**
  * Resolve one signer for a run, or explain why not.
  *
@@ -31,9 +34,9 @@ const INPUT = 1, SIGNER = 2
  * @returns `{signer, identity, kind, remote}` on success. On failure `{error, code, signer?}` —
  *          `signer` is present when one was built, so the caller can close it before exiting.
  */
-export async function resolveSigner({ keyArg, uriFile, clientFile, expect = '', what = 'this run' } = {}, deps = {}) {
-  const { loadBunker, loadLocal, pin } = deps
-  const choice = chooseSigningSource({ keyArg, uriFile, clientFile })
+export async function resolveSigner({ keyArg, uriFile, clientFile, paste = false, expect = '', what = 'this run' } = {}, deps = {}) {
+  const { loadBunker, loadLocal, loadPaste, pin } = deps
+  const choice = chooseSigningSource({ keyArg, uriFile, clientFile, paste })
   if (choice.error) return { error: choice.error, code: INPUT, usage: true }
 
   // Shape-checked BEFORE anything is built or asked. On a bunker, resolving the identity means a
@@ -45,8 +48,15 @@ export async function resolveSigner({ keyArg, uriFile, clientFile, expect = '', 
     return { error: 'EXPECT_PUBKEY must be a 64-character hex pubkey', code: INPUT }
   }
 
+  const load = {
+    bunker: () => loadBunker(uriFile, clientFile),
+    local: () => loadLocal(keyArg),
+    paste: () => loadPaste(),
+  }[choice.kind]
+  if (!load) return { error: `no loader for a ${choice.kind} signer`, code: INPUT }
+
   let base
-  try { base = choice.kind === 'bunker' ? await loadBunker(uriFile, clientFile) : await loadLocal(keyArg) }
+  try { base = await load() }
   catch (e) { return { error: `could not load the signing key: ${e.message}`, code: INPUT } }
 
   // ASK which identity it holds — never read it off the pairing. `bunker://<hex>` names the remote
@@ -65,7 +75,7 @@ export async function resolveSigner({ keyArg, uriFile, clientFile, expect = '', 
     // Refused before anything is signed. A claim inserts a relay_members row that cannot be removed
     // without that key's cooperation (#366), so the wrong identity here is permanent.
     return {
-      error: `EXPECT_PUBKEY does not match the ${choice.kind === 'bunker' ? 'pairing' : 'key file'}:\n` +
+      error: `EXPECT_PUBKEY does not match the ${SOURCE[choice.kind]}:\n` +
         `  expected ${want}\n  signer is ${identity}\n` +
         `  Refusing before signing — ${what} writes state under whichever key signs.`,
       code: INPUT, signer: base,
@@ -85,6 +95,10 @@ export async function resolveSigner({ keyArg, uriFile, clientFile, expect = '', 
  * Takes the resolved identity, never the signer — passing the signer is what let a banner print the
  * pairing's transport address, which is a key that signs nothing.
  */
-export function signerBanner(verb, { identity, remote } = {}) {
-  return `relay-invite: ${verb} as ${nip19.npubEncode(identity)} (${remote ? 'bunker pairing' : 'local key file'})`
+export function signerBanner(verb, { identity, remote, kind } = {}) {
+  // A pasted bunker and a seated one are both remote, and the operator needs to tell them apart:
+  // the pasted one is whatever they just put in, the seated one is whatever an administrator left
+  // in the environment. Reading `remote` alone would print the same line for both.
+  const source = kind === 'paste' ? 'pasted bunker' : remote ? 'bunker pairing' : 'local key file'
+  return `relay-invite: ${verb} as ${nip19.npubEncode(identity)} (${source})`
 }

--- a/tests/relay_invite_signer.mjs
+++ b/tests/relay_invite_signer.mjs
@@ -284,11 +284,30 @@ try {
       /Rotate the pairing/.test(String(inArgv.error)))
     ok('a bunker URI in an env var is refused',
       /will not take one from the\s+environment/.test(String(findBunkerUriExposure([], { MY_BUNKER_URI: `bunker://${uriHex}?relay=wss://r.example` }).error)))
+    // The env scan reads VALUES, not names (#481 review). Matching the name meant the refusal only
+    // fired when the operator had helpfully called the variable something with "bunker" and "uri"
+    // in it; every realistic name a signer's own docs suggest went straight through with the
+    // secret in it. Each of these was accepted before the fix.
+    for (const name of ['SIGNER', 'NOSTR_CONNECT', 'BUNKER', 'NIP46_URI', 'X']) {
+      ok(`a bunker URI in ${name} is refused — the name is not what makes it a secret`,
+        /will not take one from the\s+environment/.test(
+          String(findBunkerUriExposure([], { [name]: `bunker://${uriHex}?relay=wss://r.example` }).error)))
+    }
+    ok('…and names the variable, so the operator knows which one to rotate',
+      /^SIGNER holds a bunker:\/\/ URI/.test(String(findBunkerUriExposure([], { SIGNER: `bunker://${uriHex}` }).error)))
+    ok('…and says to rotate, as the argv branch already did',
+      /Rotate the pairing/.test(String(findBunkerUriExposure([], { SIGNER: `bunker://${uriHex}` }).error)))
+    ok('a URI in a _FILE-named variable is refused too — the convention is a path, not a hiding place',
+      /will not take one from the\s+environment/.test(
+        String(findBunkerUriExposure([], { WAGGLE_BUNKER_URI_FILE: `bunker://${uriHex}` }).error)))
+
     // BOTH DIRECTIONS. A guard that refuses everything is indistinguishable from one that works.
     ok('NEGATIVE CONTROL — an ordinary command line is not refused',
       !findBunkerUriExposure(['mint', '--bunker', '--ttl', '3600'], {}).error)
     ok('NEGATIVE CONTROL — WAGGLE_BUNKER_URI_FILE naming a PATH is not refused, only a URI is',
       !findBunkerUriExposure([], { WAGGLE_BUNKER_URI_FILE: '/home/op/.nvoy/bunker-uri' }).error)
+    ok('NEGATIVE CONTROL — an ordinary environment is not refused',
+      !findBunkerUriExposure([], { HOME: '/home/op', PATH: '/usr/bin', LANG: 'en_GB.UTF-8' }).error)
 
     // checkPastedBunkerUri — what a paste is allowed to be. Every refusal names the wrong part,
     // because the operator's next act is to re-copy the string and a generic message re-copies
@@ -300,6 +319,19 @@ try {
       checkPastedBunkerUri(`bunker://${uriHex}?relay=wss://relay.example`).hasSecret === false)
     ok('a truncated paste is named as truncated, with the length it actually had',
       /is 40 characters, not 64/.test(String(checkPastedBunkerUri(`bunker://${uriHex.slice(0, 40)}?relay=wss://r.example`).error)))
+    // ASSERT THE REASON, NOT ONLY THE REFUSAL (#481 review). A full-length pubkey with one wrong
+    // character used to be refused with "is 64 characters, not 64", which reads as a tool fault and
+    // sends the operator to re-copy a string that was never short.
+    {
+      const substituted = `${uriHex.slice(0, 63)}g`
+      const e = String(checkPastedBunkerUri(`bunker://${substituted}?relay=wss://r.example`).error)
+      ok('a full-length non-hex pubkey is refused for its CHARSET, not for a length it has',
+        /right length but is not hex/.test(e) && !/not 64/.test(e))
+      ok('…and names the offending character, so the operator can find it',
+        /contains "g"/.test(e))
+      ok('an over-long paste says so rather than calling itself truncated',
+        /extra characters/.test(String(checkPastedBunkerUri(`bunker://${uriHex}ff?relay=wss://r.example`).error)))
+    }
     ok('a nostrconnect:// URI is named as the other direction, not as invalid',
       /OTHER direction/.test(String(checkPastedBunkerUri('nostrconnect://abc?relay=wss://r.example').error)))
     ok('a URI with no relay is refused for having no transport',

--- a/tests/relay_invite_signer.mjs
+++ b/tests/relay_invite_signer.mjs
@@ -25,6 +25,7 @@ import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { finalizeEvent, generateSecretKey, getPublicKey } from 'nostr-tools/pure'
 import * as nip19 from 'nostr-tools/nip19'
+import { checkPastedBunkerUri, findBunkerUriExposure, planClientKey } from '../src/bunker_paste.mjs'
 import { withPinnedCustody } from '../src/nostr_signer.mjs'
 import { resolveSigner, signerBanner } from '../src/relay_invite_signer.mjs'
 
@@ -231,6 +232,89 @@ try {
     ok('…and names the thing that could not be established', /which identity the signer holds/.test(broken.error))
     const junkId = await resolve({ userPubkey: async () => 'not-a-pubkey' })
     ok('a malformed identity is refused rather than pinned to', /nothing can be pinned/.test(String(junkId.error)))
+  }
+
+  // --- --bunker: pasting a URI (#480) ------------------------------------------------------------
+  // The prompt itself is a TTY read and is not driven here — what IS driven is every decision
+  // around it: the ambiguity guard with a third source, the refusal of a URI that arrived by a
+  // route that records it, what a paste is allowed to be, and the client key's reuse rule.
+  {
+    const uriHex = getPublicKey(generateSecretKey())   // what the pasted bunker:// names
+    const userPk = getPublicKey(generateSecretKey())   // who it actually signs as — deliberately not the same
+
+    // A signing source is only a source if it can be CHOSEN. Asserted through resolveSigner rather
+    // than the chooser alone, because a `kind` the loader map has no entry for resolves to
+    // "no loader for a paste signer" — which is a green chooser test and a broken tool.
+    let built = 0
+    const pasteSigner = { pubkey: uriHex, remote: true, userPubkey: async () => userPk, close() {} }
+    const viaPaste = await resolveSigner({ paste: true }, {
+      loadPaste: async () => { built++; return pasteSigner },
+      loadLocal: async () => { throw new Error('not this path') },
+      loadBunker: async () => { throw new Error('not this path') },
+      pin: withPinnedCustody,
+    })
+    ok('--bunker resolves through the paste loader', !viaPaste.error && built === 1 && viaPaste.kind === 'paste')
+    // The whole point of the split-signer fixture: a pasted bunker is remote, so pinning to
+    // `.pubkey` would pin to the transport address here and every signature would be a mismatch.
+    ok('…and pins to the identity the signer reports, not the pasted URI\'s address',
+      viaPaste.signer.pinned === userPk && viaPaste.signer.pinned !== uriHex)
+    ok('…and the banner names a PASTED bunker, distinct from a seated pairing',
+      signerBanner('minting', viaPaste) === `relay-invite: minting as ${nip19.npubEncode(userPk)} (pasted bunker)`)
+    ok('NEGATIVE CONTROL — a seated pairing still reads as a pairing, not as a paste',
+      /\(bunker pairing\)$/.test(signerBanner('minting', { identity: userPk, remote: true, kind: 'bunker' })))
+
+    // Ambiguity, per PAIR. Each of these would otherwise resolve by silent precedence, and a claim
+    // writes a relay_members row that cannot be removed without whichever key signed (#366).
+    const noLoad = { loadPaste: async () => { throw new Error('must not load') },
+      loadLocal: async () => { throw new Error('must not load') },
+      loadBunker: async () => { throw new Error('must not load') }, pin: withPinnedCustody }
+    const bothCli = await resolveSigner({ paste: true, keyArg: '/k' }, noLoad)
+    ok('--bunker with --key is refused, and nothing is loaded',
+      /--bunker and --key are BOTH given/.test(String(bothCli.error)) && bothCli.code === 1)
+    const bothBunkers = await resolveSigner({ paste: true, uriFile: '/u', clientFile: '/c' }, noLoad)
+    ok('--bunker with a seated pairing is refused rather than choosing one bunker over the other',
+      /will not choose between two bunkers/.test(String(bothBunkers.error)))
+    const nothing = await resolveSigner({}, noLoad)
+    ok('with no source at all, the error offers --bunker first', /Pass --bunker to paste/.test(String(nothing.error)))
+
+    // findBunkerUriExposure — the refusal that makes the prompt more than decoration.
+    const inArgv = findBunkerUriExposure([`bunker://${uriHex}?relay=wss://r.example`], {})
+    ok('a bunker URI in argv is refused', /will not take\s+one that way/.test(String(inArgv.error)))
+    ok('…and says the secret is already in the shell history, so it must be rotated',
+      /Rotate the pairing/.test(String(inArgv.error)))
+    ok('a bunker URI in an env var is refused',
+      /will not take one from the\s+environment/.test(String(findBunkerUriExposure([], { MY_BUNKER_URI: `bunker://${uriHex}?relay=wss://r.example` }).error)))
+    // BOTH DIRECTIONS. A guard that refuses everything is indistinguishable from one that works.
+    ok('NEGATIVE CONTROL — an ordinary command line is not refused',
+      !findBunkerUriExposure(['mint', '--bunker', '--ttl', '3600'], {}).error)
+    ok('NEGATIVE CONTROL — WAGGLE_BUNKER_URI_FILE naming a PATH is not refused, only a URI is',
+      !findBunkerUriExposure([], { WAGGLE_BUNKER_URI_FILE: '/home/op/.nvoy/bunker-uri' }).error)
+
+    // checkPastedBunkerUri — what a paste is allowed to be. Every refusal names the wrong part,
+    // because the operator's next act is to re-copy the string and a generic message re-copies
+    // the same one.
+    const good = checkPastedBunkerUri(`  "bunker://${uriHex}?relay=wss://relay.example&secret=abc"  `)
+    ok('a whole URI is accepted, quotes and whitespace stripped',
+      good.pubkey === uriHex && good.relays.length === 1 && good.hasSecret === true)
+    ok('a URI with no secret is ACCEPTED, not refused — a re-run after pairing has none',
+      checkPastedBunkerUri(`bunker://${uriHex}?relay=wss://relay.example`).hasSecret === false)
+    ok('a truncated paste is named as truncated, with the length it actually had',
+      /is 40 characters, not 64/.test(String(checkPastedBunkerUri(`bunker://${uriHex.slice(0, 40)}?relay=wss://r.example`).error)))
+    ok('a nostrconnect:// URI is named as the other direction, not as invalid',
+      /OTHER direction/.test(String(checkPastedBunkerUri('nostrconnect://abc?relay=wss://r.example').error)))
+    ok('a URI with no relay is refused for having no transport',
+      /names no relay/.test(String(checkPastedBunkerUri(`bunker://${uriHex}`).error)))
+    ok('a ws:// relay is refused, and says which scheme it got',
+      /not wss:\/\/ — NIP-46 traffic is not sent over ws:\/\//.test(String(checkPastedBunkerUri(`bunker://${uriHex}?relay=ws://r.example`).error)))
+    ok('an empty paste says so plainly', /nothing was pasted/.test(String(checkPastedBunkerUri('   ').error)))
+
+    // planClientKey — reuse is the behaviour, and a corrupt file must NOT quietly regenerate.
+    ok('no file yet means create one', planClientKey(null).create === true)
+    ok('an empty file means create one', planClientKey('\n').create === true)
+    ok('an existing key is REUSED, not replaced — a fresh one is a new app to the signer',
+      planClientKey(`${uriHex.toUpperCase()}\n`).hex === uriHex && planClientKey(uriHex).created === false)
+    ok('a corrupt client key is refused rather than silently regenerated',
+      /will not overwrite it/.test(String(planClientKey('garbage').error)))
   }
 } finally { rmSync(dir, { recursive: true, force: true }) }
 

--- a/tools/relay-invite.mjs
+++ b/tools/relay-invite.mjs
@@ -65,12 +65,15 @@
 // Exit: 0 ok · 1 bad input · 2 relay/network · 3 INCONCLUSIVE (it ran, and could not tell you)
 //       4 the relay answered, and its answer is a refusal — that IS the result, not a failure.
 
+import { createInterface } from 'node:readline'
 import { readFileSync, writeFileSync, existsSync, mkdirSync, statSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { homedir } from 'node:os'
+import { generateSecretKey } from 'nostr-tools/pure'
 import { nip19 } from 'nostr-tools'
+import { checkPastedBunkerUri, findBunkerUriExposure, planClientKey } from '../src/bunker_paste.mjs'
 import { nip98Template, nip98Header, expectedUrl } from '../src/nip98.mjs'
-import { loadBunkerSignerFiles, makeLocalSigner, withPinnedCustody } from '../src/nostr_signer.mjs'
+import { loadBunkerSignerFiles, makeBunkerSigner, makeLocalSigner, withPinnedCustody } from '../src/nostr_signer.mjs'
 import { refusal, checkMintBounds,
   SIGN_TIMEOUT_MS, MAX_SIGN_SKEW_SECS, NIP98_WINDOW_SECS } from '../src/relay_invite.mjs'
 import { resolveSigner, signerBanner } from '../src/relay_invite_signer.mjs'
@@ -90,17 +93,24 @@ const die = (msg, code = 1) => { console.error(`relay-invite: ${msg}`); process.
 const expand = (p) => (String(p).startsWith('~/') ? resolve(homedir(), String(p).slice(2)) : resolve(String(p)))
 
 const USAGE = `usage:
-  BUZZ_RELAY_URL=… node tools/relay-invite.mjs mint  --key <path> [--ttl 3600] [--uses 1] [--out <path>]
-  BUZZ_RELAY_URL=… node tools/relay-invite.mjs claim --key <path> --code-file <path>
+  BUZZ_RELAY_URL=… node tools/relay-invite.mjs mint  --bunker [--ttl 3600] [--uses 1] [--out <path>]
+  BUZZ_RELAY_URL=… node tools/relay-invite.mjs claim --bunker --code-file <path>
                                                      [--accept-terms] [--confirm-age]
 
   --accept-terms   accept this deployment's join policy (required where one is configured)
   --confirm-age    attest, as a person, that the age requirement is met. Never inferred.
 
-  Instead of --key, sign through a NIP-46 pairing — the only way a bunker-held identity can
-  claim, and the shape #367 requires (#477). Set BOTH, and do not also pass --key:
+  ONE signing source, named explicitly — never two. A claim writes a relay_members row that
+  cannot be removed without whichever key signs (#366), so an ambiguous run is refused.
+
+    --bunker              paste a bunker:// URI at a hidden prompt (#480). Not echoed, not saved;
+                          only the NIP-46 client key persists, so later runs need no re-approval.
+                          A URI in argv or an env var is REFUSED — both are recorded.
+    --key <path>          a mode-0600 file holding an nsec or 64-hex key.
     WAGGLE_BUNKER_URI_FILE=<path>  WAGGLE_NIP46_CLIENT_NSEC_FILE=<path>
-    EXPECT_PUBKEY=<64-hex>         optional; pins which identity may sign.`
+                          a pairing an administrator seated for an agent runtime (#477/#367).
+
+    EXPECT_PUBKEY=<64-hex>  optional with any source; pins which identity may sign.`
 
 if (!cmd || !['mint', 'claim'].includes(cmd)) die(USAGE)
 
@@ -126,8 +136,99 @@ function readKeyText(pathArg) {
   die(`${p} holds neither an nsec nor a 64-character hex key`)
 }
 
+// --- pasting a bunker URI (#480) ----------------------------------------------------------------
+// The prompt REQUIRES an interactive terminal, and reads from `process.stdin` rather than opening
+// /dev/tty. Both halves of that are load-bearing:
+//
+//   - A pipe or a heredoc is refused rather than accepted, because both are routes by which the
+//     connect secret ends up in a file or a history. Falling back to stdin when there is no
+//     terminal would quietly defeat the reason this prompt exists.
+//   - Echo suppression only works on a stream readline can put in raw mode. A stream opened from
+//     /dev/tty has no `setRawMode`, so readline cannot take over the echoing, the terminal driver
+//     keeps doing it, and the pasted URI appears on screen — while the prompt says it will not.
+//     `process.stdin` on a TTY has it. Found by running this through a pty; it is invisible to
+//     every check that does not.
+function promptHidden(question) {
+  return new Promise((ok, no) => {
+    const input = process.stdin, output = process.stdout
+    if (!input.isTTY || typeof input.setRawMode !== 'function') {
+      return no(new Error('--bunker needs an interactive terminal. stdin here is not one, and this ' +
+        'tool will not read a bunker URI from a pipe or a heredoc:\n' +
+        '  the URI carries a connect secret, and both of those put it in a file.\n' +
+        '  Run it from a shell, or use --key / WAGGLE_BUNKER_URI_FILE instead.'))
+    }
+    const rl = createInterface({ input, output, terminal: true })
+    let muted = false, settled = false
+    // Nothing is echoed — not even asterisks, which leak the length. Announced, because a prompt
+    // that swallows keystrokes with no warning reads as a hung tool.
+    rl._writeToOutput = (s) => { if (!muted) output.write(s) }
+    const finish = (fn, arg) => {
+      if (settled) return
+      settled = true
+      muted = false
+      output.write('\n')
+      rl.close()
+      fn(arg)
+    }
+    // A closed input has to REJECT. Without this the promise never settles, and Ctrl-D or Ctrl-C
+    // at the prompt exits 13 on an unsettled top-level await rather than saying anything.
+    rl.on('close', () => finish(no, new Error('the prompt was closed before a URI was entered — nothing was signed')))
+    rl.on('SIGINT', () => finish(no, new Error('cancelled at the prompt — nothing was signed')))
+    output.write(`${question}\n(nothing will appear as you paste)\n> `)
+    muted = true
+    rl.question('', (answer) => finish(ok, answer))
+  })
+}
+
+// The CLIENT key, persisted; the URI never is. A NIP-46 bunker authorizes a specific client
+// keypair, so a fresh one each run is an app the signer has never seen — some refuse it outright
+// as "Unknown client", and the rest ask for approval again. Same reasoning and same 0600 file as
+// tools/grant.mjs:56-66.
+function clientKeyHex() {
+  const dir = process.env.WAGGLE_HOME ? expand(process.env.WAGGLE_HOME) : resolve(homedir(), '.waggle')
+  const path = resolve(dir, 'relay-invite-client.key')
+  let existing = null
+  if (existsSync(path)) {
+    const mode = statSync(path).mode & 0o777
+    if (mode & 0o077) die(`${path} is mode ${mode.toString(8)} — the NIP-46 client key must be 0600.`, 1)
+    existing = readFileSync(path, 'utf8')
+  }
+  const plan = planClientKey(existing)
+  if (plan.error) die(`${path}: ${plan.error}`, 1)
+  if (!plan.create) return plan.hex
+
+  const hex = Buffer.from(generateSecretKey()).toString('hex')
+  mkdirSync(dir, { recursive: true, mode: 0o700 })
+  writeFileSync(path, `${hex}\n`, { mode: 0o600 })
+  console.error(`relay-invite: new NIP-46 client key saved to ${path}`)
+  console.error('  Approve this app in your signer once — later runs reuse it and will not ask again.')
+  return hex
+}
+
+async function loadPastedBunker() {
+  const answer = await promptHidden('Paste the bunker:// URI from your signer\'s "connect an app" flow.')
+  const parsed = checkPastedBunkerUri(answer)
+  if (parsed.error) die(parsed.error, 1)
+  if (!parsed.hasSecret) {
+    // Not fatal: a URI re-copied after this client key was already authorized has no secret left,
+    // and that run is legitimate. Said out loud because if the pairing ISN'T established the
+    // bunker answers "Unknown client", which reads as a broken tool rather than a missing secret.
+    console.error('relay-invite: the URI carries no secret. That is expected on a re-run with an ' +
+      'already-approved client key,\n  and is the cause of "Unknown client" if this is the first pairing.')
+  }
+  // The client key is resolved BEFORE the connecting message, so "a new key was saved, approve it
+  // once" is read before "approve the prompt" rather than after it.
+  const client = clientKeyHex()
+  console.error(`relay-invite: connecting to the signer over ${parsed.relays.length} relay(s) — approve the prompt.`)
+  return makeBunkerSigner(parsed.uri, nip19.nsecEncode(Uint8Array.from(Buffer.from(client, 'hex'))), {
+    uriLabel: 'the pasted bunker URI',
+    clientLabel: 'the saved NIP-46 client key',
+  })
+}
+
 /**
- * The one signer for this run — local file or bunker pairing, chosen explicitly, custody pinned.
+ * The one signer for this run — pasted bunker, local file, or seated pairing; chosen explicitly,
+ * custody pinned.
  *
  * The decisions live in ../src/relay_invite_signer.mjs so they can be driven with a signer whose
  * identity differs from its pairing address. What stays here is the environment, the file checks,
@@ -135,15 +236,22 @@ function readKeyText(pathArg) {
  */
 async function buildSigner(what) {
   const keyArg = arg('key')
+  // Before the prompt, not after: a URI already in argv or the environment is a secret already
+  // recorded, and prompting for a second one would leave the operator believing it was not.
+  const exposed = findBunkerUriExposure(argv, process.env)
+  if (exposed.error) die(exposed.error, 1)
+
   const result = await resolveSigner({
     keyArg,
     uriFile: String(process.env.WAGGLE_BUNKER_URI_FILE || '').trim(),
     clientFile: String(process.env.WAGGLE_NIP46_CLIENT_NSEC_FILE || '').trim(),
+    paste: flag('bunker'),
     expect: process.env.EXPECT_PUBKEY,
     what,
   }, {
     loadBunker: (uriFile, clientFile) => loadBunkerSignerFiles(uriFile, clientFile),
     loadLocal: (path) => makeLocalSigner(readKeyText(path), expand(path)),
+    loadPaste: () => loadPastedBunker(),
     pin: withPinnedCustody,
   })
 


### PR DESCRIPTION
Closes #480. **Stacked on #478** (`fix/477-relay-invite-nip46`) — merge that first; this branch
contains its three commits.

## Why

The operator holds the only key with `owner`/`admin` in `relay_members`, so they are the only one
who can `mint`. Their signer hands them a `bunker://` string to paste. `relay-invite` could only
take a pairing already sitting in two mode-0600 files, which meant creating a client nsec by hand
to avoid putting a key on disk. That is the wrong trade and it stalled the one step the rest of the
chain waits behind.

`--bunker` prompts on the terminal with echo off, for `mint` and `claim` alike. The URI is never
written down. Only the NIP-46 client key persists, so a second run costs no second approval — same
reasoning and same 0600 file as `tools/grant.mjs:56-66`, where a fresh client key each run is an app
the signer has never seen ("Unknown client").

A URI in argv or an environment variable is **refused**, and the message says to rotate the pairing,
because by then the secret is already in `ps` and in shell history. Without that refusal the prompt
is decoration that the first person in a hurry routes around.

`chooseSigningSource` gains the third source. Each ambiguous **pair** is refused by name rather than
resolved by precedence — a claim writes a `relay_members` row that cannot be removed without
whichever key signed (#366).

## Two defects the tests could not see

Both found by running the prompt through a pty, and both invisible to `node --check`, to lint, and
to the whole suite:

**The promise never settled on a closed input.** Ctrl-D or Ctrl-C at the prompt exited 13 on an
unsettled top-level await instead of saying anything. Now it rejects with "the prompt was closed
before a URI was entered — nothing was signed", exit 1.

**The paste was echoed.** A stream opened from `/dev/tty` has no `setRawMode`, so readline could not
take over the echoing and the terminal driver kept doing it — while the prompt printed "nothing will
appear as you paste". A security promise the code did not keep. Fixed by reading `process.stdin` and
requiring a TTY, which also refuses a pipe or a heredoc.

## Evidence

92 suites, `ALL PASS`, exit 0. Lint 0 errors, 1 known warning (#438). 64 assertions in the
signer-selection suite.

The paste path is driven **in-process** through a signer whose `userPubkey()` differs from its
`pubkey` — the arrangement where pinning to the wrong one is visible, and the gap that let three
mutations survive in #478's first attempt.

Five mutations, all detected:

| mutation | result |
|---|---|
| banner drops the `paste` branch | 1 FAIL |
| argv exposure check disabled | 2 FAIL |
| corrupt client key regenerates silently | 1 FAIL |
| `--bunker` + `--key` ambiguity removed | 1 FAIL |
| paste loader wired to `loadLocal` | 1 FAIL |

Plus a negative control — a comment-only mutation — reported SURVIVED, so the harness can say it.
The first attempt at that control did not apply (perl failed to compile on `//` in the pattern);
`ANCHOR MISS` fired and the result was discarded rather than counted.

**The echo suppression has no automated regression test.** Node has no built-in pty and the suite is
node-only, so proving it needs a driver the suite cannot run. It is proven manually, and the
reproduction is:

```
python3 ptydrive.py node tools/relay-invite.mjs mint --bunker    # TYPE_THIS=bunker://…secret=MARKER
```

reading the pty master and grepping for the marker: **0 occurrences**. Two positive controls, because
a probe that has only ever come back clean proves nothing — the same driver against `cat` sees the
marker (2), and against this same prompt with the mute removed sees it (1). Driver in the PR
discussion below rather than in the tree, since an uncommitted-to-CI python file is a maintenance
surface with no runner.

Also confirmed by hand on the valid path: client key written 0600, reused byte-identical on a second
run with no "new key" message, and `grep -rl 'bunker://'` under `WAGGLE_HOME` finds nothing.

## Review

Worth a reader on the prompt itself (`promptHidden` in `tools/relay-invite.mjs`). It is the part with
no CI behind it, and the echo bug is the kind that returns quietly the next time someone touches the
stream handling.

Drafted with assistance from [Claude Code](https://claude.com/claude-code)
