### PR TITLE
Attempt the community leg without an auth tag, and report what the relay says (#482)

### DIFF
--- a/tests/publish_profile.mjs
+++ b/tests/publish_profile.mjs
@@ -82,13 +82,64 @@ const run = (env, argv) => {
   ok('  ...and nothing was published on the refusal', /Nothing published/.test(r.stderr))
 }
 
-// 4. The community leg is skipped, loudly, when its env pair is absent — never silently.
+// 4. The community leg is skipped, loudly, when there is no relay URL — never silently.
 {
   const r = run({ BUZZ_PRIVATE_KEY: hex }, ['--dry-run', '--content-file', contentFile])
   ok('skipping the community leg is stated, not silent',
-    r.status === 0 && /BUZZ_RELAY_URL \/ BUZZ_AUTH_TAG unset/.test(r.stderr))
+    r.status === 0 && /BUZZ_RELAY_URL unset/.test(r.stderr))
   ok('  ...and the signature count drops to 1 with it, rather than staying wrong',
     /this run makes 1 signature\b/.test(r.stderr))
+}
+
+// 4b. A RELAY URL AND NO AUTH TAG (#482). This combination used to skip the community leg — the
+//     one that writes the `users` row an at-word resolves against — so a run with everything else
+//     right reported success and moved nothing. Since #357/#477 a claimed key is in relay_members
+//     and passes the gate on its own, so the tool must ATTEMPT it and report what the relay says.
+{
+  const r = run({ BUZZ_PRIVATE_KEY: hex, EXPECT_PUBKEY: pk, BUZZ_RELAY_URL: 'wss://relay.invalid' },
+    ['--dry-run', '--content-file', contentFile])
+  const e = r.stderr
+  ok('a relay URL with no auth tag ATTEMPTS the community leg rather than skipping it',
+    r.status === 0 && !/skipped/.test(e), `exit ${r.status}`)
+  ok('  ...and the two copies are ONE event with one id, because there is no tag to differ by', (() => {
+    const t = e.match(/trio copy\s+([0-9a-f]{64})/), c = e.match(/community copy\s+([0-9a-f]{64})/)
+    return t && c && t[1] === c[1]
+  })())
+  ok('  ...and that inversion is said out loud, not left for the reader to notice two equal ids',
+    /the SAME id: with no auth tag the two copies are one event/.test(e))
+  ok('  ...and the signature count is 1, not 2 — a bunker operator is not told to wait for a prompt that never comes',
+    /this run makes 1 signature\b/.test(e))
+
+  // BOTH DIRECTIONS. With a tag it must still build two distinct events — otherwise this change
+  // reads as "works" while having quietly dropped the auth-tag path.
+  const withTag = run({ BUZZ_PRIVATE_KEY: hex, EXPECT_PUBKEY: pk,
+    BUZZ_RELAY_URL: 'wss://relay.invalid', BUZZ_AUTH_TAG: '["auth","probe"]' },
+    ['--dry-run', '--content-file', contentFile])
+  ok('  NEGATIVE CONTROL — WITH a tag the copies are still two events with different ids', (() => {
+    const t = withTag.stderr.match(/trio copy\s+([0-9a-f]{64})/)
+    const c = withTag.stderr.match(/community copy\s+([0-9a-f]{64})/)
+    return t && c && t[1] !== c[1] && /this run makes 2 signatures/.test(withTag.stderr)
+  })())
+  // A tag that is present but malformed must still be refused. Making the tag optional is exactly
+  // the change that turns "invalid" into "absent" if the emptiness test is written carelessly.
+  const badTag = run({ BUZZ_PRIVATE_KEY: hex, BUZZ_RELAY_URL: 'wss://relay.invalid', BUZZ_AUTH_TAG: 'not json' },
+    ['--dry-run', '--content-file', contentFile])
+  ok('  a malformed auth tag is still REFUSED, not treated as absent',
+    badTag.status === 1 && /must be a JSON array/.test(badTag.stderr), `exit ${badTag.status}`)
+  const whitespaceTag = run({ BUZZ_PRIVATE_KEY: hex, BUZZ_RELAY_URL: 'wss://relay.invalid', BUZZ_AUTH_TAG: '   ' },
+    ['--dry-run', '--content-file', contentFile])
+  ok('  a whitespace-only tag counts as absent, not as malformed',
+    whitespaceTag.status === 0 && /one event/.test(whitespaceTag.stderr), `exit ${whitespaceTag.status}`)
+
+  // NOT ASSERTED HERE, deliberately. The tool compares its announced signature count against the
+  // count actually taken, and that guard cannot fire on any input this suite can construct — the
+  // counts only disagree when the code is wrong. An assertion that the message is absent would
+  // pass whether or not the guard exists, which is worse than no assertion.
+  //
+  // What proves it is a mutation: replacing `communityEvent = trioEvent` with a second, identical
+  // `sign(...)` makes the counts disagree, the guard fires, and three assertions above go red.
+  // Without the guard that mutation SURVIVES a green suite — the two events have the same id, so
+  // nothing in the output differs. Re-run it before trusting this block.
 }
 
 // 5. A malformed content file is refused before anything is signed.

--- a/tools/publish_profile.mjs
+++ b/tools/publish_profile.mjs
@@ -122,6 +122,9 @@ const httpBase = () => process.env.BUZZ_RELAY_URL.replace(/^wss:/, 'https:').rep
 // The community-relay leg. NIP-98 over HTTP with the owner-minted auth tag, exactly as
 // publish_relay_list.mjs does it — the only difference here is that the NIP-98 event is signed by
 // the signer rather than by a secret key this process holds.
+const authHeader = () => (String(process.env.BUZZ_AUTH_TAG || '').trim()
+  ? { 'x-auth-tag': process.env.BUZZ_AUTH_TAG } : {})
+
 async function pushCommunity(signer, ev) {
   const url = httpBase() + '/events'
   const body = JSON.stringify(ev)
@@ -134,7 +137,10 @@ async function pushCommunity(signer, ev) {
     headers: {
       'content-type': 'application/json',
       authorization: 'Nostr ' + Buffer.from(JSON.stringify(nip98)).toString('base64'),
-      'x-auth-tag': process.env.BUZZ_AUTH_TAG,
+      // Omitted entirely when unset. Sending `x-auth-tag: undefined` puts the literal string
+      // "undefined" on the wire, which the relay reads as a malformed tag rather than as no tag —
+      // so the run would answer a question nobody asked.
+      ...authHeader(),
     },
     body,
   })
@@ -163,7 +169,10 @@ async function readBackCommunity(signer, pubkey) {
     r = await fetch(url, {
       headers: {
         authorization: 'Nostr ' + Buffer.from(JSON.stringify(nip98)).toString('base64'),
-        'x-auth-tag': process.env.BUZZ_AUTH_TAG,
+        // Omitted entirely when unset. Sending `x-auth-tag: undefined` puts the literal string
+      // "undefined" on the wire, which the relay reads as a malformed tag rather than as no tag —
+      // so the run would answer a question nobody asked.
+      ...authHeader(),
       },
     })
   } catch (e) { return { reachable: false, why: `read failed: ${e.message}` } }
@@ -184,7 +193,18 @@ async function readBackCommunity(signer, pubkey) {
 
 const dryRun = has('--dry-run')
 const contentFile = flag('--content-file')
-const community = !!(process.env.BUZZ_RELAY_URL && process.env.BUZZ_AUTH_TAG)
+// The community leg needs a relay URL. It used to need BUZZ_AUTH_TAG as well, and that made the
+// tool untestable against the thing it exists to do: with the tag unset it did not attempt the
+// community push, it SKIPPED it — so a run that had everything else right reported success while
+// leaving the `users` row, the only thing an at-word resolves against, unwritten (#482).
+//
+// The tag stopped being the only way in when #357/#477 landed: a claimed key is in `relay_members`
+// and passes `enforce_relay_membership` at NIP-98 time on its own. Whether the tag is still
+// required on top of that is a live question, and the tool's job is to be able to ASK it — try,
+// and report the relay's answer as the answer. Refusing to try is not the safe option; it is the
+// one that cannot learn anything.
+const authTagRaw = String(process.env.BUZZ_AUTH_TAG || '').trim()
+const community = !!String(process.env.BUZZ_RELAY_URL || '').trim()
 
 let loaded
 try { loaded = loadNostrSigner(process.env) } catch (e) { die(e.message) }
@@ -215,9 +235,14 @@ if (signer.remote && !expect)
 // property of the run, not of the backend, so a test can hold it in place either way. On a bunker
 // each of these is a SEPARATE approval prompt with a 60s timeout, and an operator who thinks it is
 // one tap walks away and the run dies on a signature nobody was there to give.
-const signatureCount = dryRun ? (community ? 2 : 1) : (community ? 4 : 1)
+// Counted, not guessed. With no auth tag the community copy IS the trio event, so the second
+// kind:0 signature does not happen — announcing 4 there would have a bunker operator waiting at a
+// prompt that never comes, which reads as a hang.
+const kind0Signatures = community && authTagRaw ? 2 : 1
+const signatureCount = dryRun ? kind0Signatures : kind0Signatures + (community ? 2 : 0)
 say(`  this run makes ${signatureCount} signature${signatureCount === 1 ? '' : 's'}${
   signatureCount === 4 ? ' — trio kind:0, community kind:0, then the NIP-98 headers for the push and the read-back' : ''}${
+  signatureCount === 3 ? ' — one kind:0 for both sides, then the NIP-98 headers for the push and the read-back' : ''}${
   signer.remote ? ', and each one is a separate bunker approval. Stay at the prompt.' : '.'}`)
 
 // Adopt the existing profile unless one was handed in. Reading first also means a run that cannot
@@ -253,17 +278,39 @@ say('    It covers every signature this run makes, not the first — each one is
 // After this point the PROVEN key is the one to read against, not the claimed one.
 const proven = trioEvent.pubkey
 
-let communityEvent = null
+let communityEvent = null, oneEvent = false
 if (community) {
-  const authTag = (() => { try { return JSON.parse(process.env.BUZZ_AUTH_TAG) } catch { return die('BUZZ_AUTH_TAG must be a JSON array, e.g. \'["auth","…"]\'') } })()
-  if (!Array.isArray(authTag)) die('BUZZ_AUTH_TAG must be a JSON array')
-  communityEvent = await sign({ kind: 0, created_at, tags: [authTag], content })
+  if (authTagRaw) {
+    const authTag = (() => { try { return JSON.parse(authTagRaw) } catch { return die('BUZZ_AUTH_TAG must be a JSON array, e.g. \'["auth","…"]\'') } })()
+    if (!Array.isArray(authTag)) die('BUZZ_AUTH_TAG must be a JSON array')
+    communityEvent = await sign({ kind: 0, created_at, tags: [authTag], content })
+  } else {
+    // No tag means no tags[] to add, which means the community copy would be byte-identical to the
+    // trio copy — same pubkey, same created_at, same content, so the same id. Signing it a second
+    // time would produce the same event, cost a second bunker approval, and let the tool print two
+    // ids that are one id. So it is the SAME EVENT on both sides, and that is said out loud:
+    // "one profile, not one event" is this tool's central honesty claim, and here it inverts.
+    communityEvent = trioEvent
+    oneEvent = true
+  }
 }
 
 say('')
 say(`  trio copy       ${trioEvent.id}`)
-say(`  community copy  ${communityEvent ? communityEvent.id : '(skipped — BUZZ_RELAY_URL / BUZZ_AUTH_TAG unset)'}`)
-say(`  same content    sha256 ${hash(content).slice(0, 16)}… — different ids, because the community copy carries the auth tag`)
+say(`  community copy  ${communityEvent ? communityEvent.id : '(skipped — BUZZ_RELAY_URL unset)'}`)
+say(oneEvent
+  ? `  same content    sha256 ${hash(content).slice(0, 16)}… — and the SAME id: with no auth tag the two copies are one event`
+  : `  same content    sha256 ${hash(content).slice(0, 16)}… — different ids, because the community copy carries the auth tag`)
+
+// The ANNOUNCED count against the count actually taken. A bunker operator is told how many
+// approvals to expect, and an announcement nothing checks is a number that drifts — signing a
+// second, byte-identical kind:0 instead of reusing the trio event costs a real approval and is
+// invisible in the output, because the two events have the same id.
+// Compared against the kind:0 half, not the announced total: the two NIP-98 signatures happen
+// after this point, so checking the total here would fire on every real run.
+if (signer.signatures !== kind0Signatures)
+  die(`announced ${kind0Signatures} kind:0 signature(s) and took ${signer.signatures}. ` +
+    'Refusing: the count is what a bunker operator waits on, so a wrong one is a hang they cannot read.', 2)
 
 if (dryRun) { say('publish_profile: --dry-run — nothing published'); process.exit(0) }
 


### PR DESCRIPTION
Closes #482. Branches from `main` — independent of #478 and #481.

## Why

`publish_profile.mjs` gated the community push on `BUZZ_AUTH_TAG` as well as the relay URL. Unset,
it **skipped** the leg and exited 0. That leg is the only one that writes the `users` row an at-word
resolves against, so a run with everything else right reported success and moved the name not at all.

The gate made sense when an owner-minted NIP-OA auth tag was the only way past
`enforce_relay_membership`. Since #357/#477 a claimed key is in `relay_members`, which is what the
AUTH gate reads — live-proven tonight: `200 — joined` for `ad05b00e`. Whether the tag is still
needed *on top of* membership is now an answerable question, and the tool could not ask it.
Refusing to attempt is not the cautious option; it is the one that cannot learn anything.

## Two consequences, handled

**With no tag the two copies are one event.** No tag means no `tags[]`, so the community copy is
byte-identical to the trio copy — same id. It is reused rather than signed again, which would cost a
second bunker approval and print two ids that are one id. This tool's standing claim is "one profile,
not one event"; here it inverts, and it says so.

**`x-auth-tag: undefined` is not "no tag".** A `fetch` header from an unset env var puts the literal
string `undefined` on the wire, which the relay reads as malformed. Omitted entirely now.

## Evidence

92 suites `ALL PASS`, exit 0. Lint 0 errors, 1 known warning (#438).

| mutation | result |
|---|---|
| re-gate the leg on the tag | 3 FAIL |
| sign a second identical kind:0 instead of reusing | 3 FAIL |
| treat a malformed tag as absent | 5 FAIL |
| revert the signature-count formula | 1 FAIL |

Both directions: with a tag the copies are still two events with different ids, and a malformed tag
is still refused rather than read as absent.

**One thing is not asserted, and the test says so.** Removing the announced-vs-actual signature
count guard alone survives a green suite — no input this suite can construct makes the counts
disagree. What proves the guard is the second-identical-kind:0 mutation, which without it survives
silently because the two events share an id. An assertion that the guard's message is absent would
pass whether or not the guard existed, which is worse than none.

Live dry run against the real Bunker pairing: custody proven for `ad05b00e`, one event built for
both sides, nothing published.

## Review

The interesting question is whether reusing the trio event for the community leg is right, or
whether the community copy should carry something that distinguishes it even without a tag.

Drafted with assistance from [Claude Code](https://claude.com/claude-code)