### PR TITLE
`--check` could never report complete, and nothing said so (#492)

### DIFF
--- a/src/agent_install_state.mjs
+++ b/src/agent_install_state.mjs
@@ -93,6 +93,56 @@ export const ARTIFACTS = [
 
 export const ARTIFACT_KEYS = ARTIFACTS.map(a => a.key)
 
+// ── The ceiling. ─────────────────────────────────────────────────────────────────────────────
+//
+// `connect-agent --check` cannot report `complete` on any machine, however perfectly the agent is
+// installed. It opens no sockets and cannot see the other box, so eleven of the nineteen rows above
+// are hardcoded at their call sites: five report `found: null` and six report `verified: false`, and
+// no branch can move them. `complete` requires zero unknown and zero unverified, so exit 0 is
+// unreachable by construction (#492).
+//
+// Each of those was a reasonable local decision — "not checked here" is honest — and the aggregate
+// consequence lived in a different file from every one of them. An operator running `--check` to
+// completion was chasing an exit code the tool cannot emit, and the natural reading of a permanent
+// exit 3 is "something on my box is still wrong". These two lists are where the aggregate lives, so
+// a reader meets it: adding a key here is visibly a decision to keep exit 0 unreachable.
+//
+// Every reason names what WOULD settle the row and where, because in each case the remedy is off
+// this machine rather than on it.
+
+/// Rows nothing on this machine looks at. Permanently UNKNOWN — never MISSING, because "cannot
+/// check" must not read as "not there" any more than it may read as "fine".
+export const NEVER_CHECKED = Object.freeze({
+  'nip05': 'no sockets here — settled by resolving <name>@<host>/.well-known/nostr.json',
+  'profile': 'no sockets here — settled by fetching the kind 0 back BY ID from a fresh connection',
+  'admit-grant': 'no sockets here — settled by cold-reading the 440 per relay, EOSE/ERROR/TIMEOUT reported separately',
+  'dm-relays': 'no sockets here — settled by tools/publish-dm-relay-list.mjs, which cold-reads it back by id',
+  'channel-authorized': "on the broker's disk — settled by an operator confirming the public half is seated under the forced command",
+})
+
+/// Rows this build can see but never observe DOING their job. Permanently UNVERIFIED once present —
+/// which is the honest answer, and is also why it is not exit 0.
+export const NEVER_VERIFIED = Object.freeze({
+  'identity': 'the key is in the Bunker — settled by EXPECT_PUBKEY on a real send, not by a file being here',
+  'bunker-uri': 'present is not paired — settled by asking the Bunker for the public key',
+  'signer-identity': 'this tool opens no Bunker session — settled by the first send under EXPECT_PUBKEY',
+  'signer-methods': 'permissions are per-method and denials are silent — settled by a decrypt round trip',
+  'channel-host-key': 'present is not RIGHT — settled by StrictHostKeyChecking on first connect',
+  'channel-answers': 'registered is not running — settled by an initialize + tools/list handshake',
+})
+
+/// Is this report already the best one this build can produce? True only when every row still
+/// standing between it and `complete` is one of the two lists above.
+///
+/// Deliberately NOT a property of the outcome. `inconclusive` stays inconclusive; this says whether
+/// the operator can do anything about it from here, which is the question a permanent exit 3 leaves
+/// them guessing at.
+export function ceilingReached({ unverified = [], unknown = [], missing = [] } = {}) {
+  if (missing.length) return false
+  if (!unverified.length && !unknown.length) return false
+  return unknown.every(k => k in NEVER_CHECKED) && unverified.every(k => k in NEVER_VERIFIED)
+}
+
 /**
  * Build the report.
  *
@@ -124,6 +174,9 @@ export function installState(observations = {}) {
   const unverified = by(UNVERIFIED)
   const unknown = by(UNKNOWN)
   const blockingMissing = missing.filter(r => r.blocking)
+  const atCeiling = ceilingReached({
+    unverified: unverified.map(r => r.key), unknown: unknown.map(r => r.key), missing: missing.map(r => r.key),
+  })
 
   // Three outcomes, mapped onto this project's exit convention. INCONCLUSIVE is not a softer
   // failure — it is the honest answer when the tool could not see enough, and it must not be
@@ -138,6 +191,9 @@ export function installState(observations = {}) {
     if (unverified.length) parts.push(`${unverified.length} present but unchecked`)
     if (unknown.length) parts.push(`${unknown.length} not looked at`)
     headline = `${parts.join(', ')} — being unable to check is not the same as being fine.`
+    // Name the ceiling, or the sentence above reads as a local failure. It is the true sentence and
+    // it is exactly the one that sends an operator hunting on a box where there is nothing to find.
+    if (atCeiling) headline += ' Every remaining row is one this build never checks — exit 3 is the best result available here, and the remedy for each is off this machine.'
   } else if (missing.length) {
     outcome = 'runs-unfinished'; exitCode = 3
     headline = `Runs, but ${missing.length} non-blocking piece${missing.length === 1 ? ' is' : 's are'} absent — it works and has no name.`
@@ -147,7 +203,7 @@ export function installState(observations = {}) {
   }
 
   return {
-    outcome, exitCode, headline, rows,
+    outcome, exitCode, headline, rows, atCeiling,
     counts: { present: by(PRESENT).length, unverified: unverified.length, missing: missing.length, unknown: unknown.length },
     missing: missing.map(r => r.key),
     unverified: unverified.map(r => r.key),

--- a/tests/agent_install_state.mjs
+++ b/tests/agent_install_state.mjs
@@ -20,7 +20,7 @@ import { tmpdir } from 'node:os'
 import { execFileSync } from 'node:child_process'
 import { fileURLToPath } from 'node:url'
 import { npubEncode, decode as nip19decode } from 'nostr-tools/nip19'
-import { installState, renderState, foreignNvoyServers, boundIdentity, ARTIFACTS, ARTIFACT_KEYS, PRESENT, UNVERIFIED, MISSING, UNKNOWN }
+import { installState, renderState, foreignNvoyServers, boundIdentity, ARTIFACTS, ARTIFACT_KEYS, NEVER_CHECKED, NEVER_VERIFIED, PRESENT, UNVERIFIED, MISSING, UNKNOWN }
   from '../src/agent_install_state.mjs'
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..')
@@ -314,6 +314,12 @@ check(ARTIFACTS.some(a => a.blocking) && ARTIFACTS.some(a => !a.blocking),
     `${noteless.length ? ` — silent: ${noteless.join(', ')}` : ''}`)
   check(!rendered.includes('No such artifact, invented for this check'),
     'NEGATIVE CONTROL — the run does not render a title the tool never had')
+  // The ceiling clause is EARNED, not printed always. A fresh root is missing blocking pieces, so
+  // there is plenty to do here and the tool must not say this is the best it can report (#492).
+  check(/\nexit 1 \(incomplete\)/.test(rendered),
+    'a fresh root exits 1 with a bare outcome — nothing on the exit line claims a ceiling')
+  check(!rendered.includes('best result this build can report'),
+    'NEGATIVE CONTROL — the ceiling clause does NOT appear on a run with real work outstanding')
   // `--check` is what makes running it safe in a suite. Prove that rather than trusting the flag.
   check(readdirSync(probeRoot).length === 0,
     'NEGATIVE CONTROL — and --check wrote nothing into the probe root, so running the tool is side-effect free')
@@ -452,6 +458,118 @@ check(ARTIFACTS.some(a => a.blocking) && ARTIFACTS.some(a => !a.blocking),
     'and one where nobody checked the binding exits 3 — INCONCLUSIVE is not a softer 0')
   check(installState({ ...everythingElse, 'mcp-identity': { found: true, verified: true } }).outcome === 'complete',
     'BOTH DIRECTIONS — a correctly bound agent still reads complete, so the guard has not simply closed the door')
+}
+
+
+// ── The ceiling: exit 0 is unreachable, and that must cost something (#492) ──────────────────
+//
+// `--check` has four outcomes and one of them cannot happen — not "does not happen on a
+// half-finished box", cannot happen, on any machine. Eleven rows are hardcoded at their call sites
+// in tools/connect-agent.mjs: five pass a bare `null` for `found`, six pass a bare `false` for
+// `verified`. `complete` requires zero unknown and zero unverified, so it is unreachable by
+// construction. Each of those was a reasonable local decision; the aggregate lived in a different
+// file from every one of them.
+//
+// Two properties. The report NAMES the ceiling, so a permanent exit 3 does not read as a local
+// failure — and a new bare null or false cannot be added without landing in the allowlist, where a
+// reader meets it.
+{
+  // Split a call's arguments on TOP-LEVEL commas only. `see('bunker-client', nonEmptyFile(p),
+  // nonEmptyFile(p) && mode(p) === 0o600, …)` has commas inside parens and a naive split reads its
+  // second argument as `nonEmptyFile(p)` — which is not a literal, so the row would go unchecked
+  // and the scan would report a clean sweep of a file it had misread.
+  const splitArgs = (src, from) => {
+    const out = []
+    let depth = 0, quote = null, start = from, i = from
+    for (; i < src.length; i++) {
+      const c = src[i], prev = src[i - 1]
+      if (quote) { if (c === quote && prev !== '\\') quote = null; continue }
+      if (c === "'" || c === '"' || c === '`') { quote = c; continue }
+      if ('([{'.includes(c)) { depth++; continue }
+      if (')]}'.includes(c)) { if (depth === 0) { out.push(src.slice(start, i).trim()); return out } depth--; continue }
+      if (c === ',' && depth === 0) { out.push(src.slice(start, i).trim()); start = i + 1 }
+    }
+    return out
+  }
+  const seeCalls = src => {
+    const calls = []
+    const re = /\bsee\(\s*'([^']+)'\s*,/g
+    let m
+    while ((m = re.exec(src))) calls.push({ key: m[1], args: splitArgs(src, m.index + m[0].length) })
+    return calls
+  }
+
+  // POSITIVE CONTROL on the scanner itself, before it is believed about anything. A scanner that
+  // silently found nothing would report every allowlist as complete.
+  const fixture = "see('a', null, false, 'x')\nsee('b', f(p), f(p) && mode(p) === 0o600, `n`)\nsee('c', x === true ? true : null, false, 'y')"
+  const fx = seeCalls(fixture)
+  check(fx.length === 3 && fx.map(c => c.key).join(',') === 'a,b,c', 'the see() scanner finds every call in a fixture')
+  check(fx[0].args[0] === 'null' && fx[0].args[1] === 'false', '  …and reads a bare null and a bare false as literals')
+  check(fx[1].args[1] === 'f(p) && mode(p) === 0o600',
+    '  …and does NOT split an argument on a comma inside parens — a naive split misreads this file and reports it clean')
+  check(fx[2].args[0] === 'x === true ? true : null' && fx[2].args[1] === 'false',
+    '  …and a ternary ending in null is not a bare null: the row can still be observed')
+
+  const toolSrc = readFileSync(join(ROOT, 'tools', 'connect-agent.mjs'), 'utf8')
+  const calls = seeCalls(toolSrc)
+  check(calls.length >= 15, `the scan reads ${calls.length} see() calls out of connect-agent.mjs — a scan that found none would pass silently`)
+
+  const bareNull = calls.filter(c => c.args[0] === 'null').map(c => c.key)
+  const bareFalse = calls.filter(c => c.args[1] === 'false' && c.args[0] !== 'null').map(c => c.key)
+
+  const unlisted = [
+    ...bareNull.filter(k => !(k in NEVER_CHECKED)).map(k => `${k} (found: null)`),
+    ...bareFalse.filter(k => !(k in NEVER_VERIFIED)).map(k => `${k} (verified: false)`),
+  ]
+  check(unlisted.length === 0,
+    `every hardcoded null/false is declared in the allowlist${unlisted.length ? ` — UNDECLARED: ${unlisted.join(', ')}` : ''}`)
+  // Both directions: a stale allowlist entry is its own defect. A key listed here that the tool no
+  // longer hardcodes states that exit 0 is unreachable for a reason that has been fixed.
+  const stale = [
+    ...Object.keys(NEVER_CHECKED).filter(k => !bareNull.includes(k)),
+    ...Object.keys(NEVER_VERIFIED).filter(k => !bareFalse.includes(k)),
+  ]
+  check(stale.length === 0, `and no allowlist entry outlives the call site it describes${stale.length ? ` — STALE: ${stale.join(', ')}` : ''}`)
+  check(Object.keys(NEVER_CHECKED).every(k => ARTIFACT_KEYS.includes(k)) && Object.keys(NEVER_VERIFIED).every(k => ARTIFACT_KEYS.includes(k)),
+    'and every allowlisted key is a real artifact — a typo would allow a row nothing checks')
+  check(Object.values({ ...NEVER_CHECKED, ...NEVER_VERIFIED }).every(r => /settled by/.test(r)),
+    'and every reason names what WOULD settle the row, because the remedy is off this machine')
+
+  // NEGATIVE CONTROL — made to fire. A new bare null on a key nobody allowlisted must be caught.
+  const mutated = toolSrc + "\nsee('mcp-registration', null, false, 'nobody looked')\n"
+  const mutatedBad = seeCalls(mutated).filter(c => c.args[0] === 'null' && !(c.key in NEVER_CHECKED))
+  check(mutatedBad.length === 1 && mutatedBad[0].key === 'mcp-registration',
+    'NEGATIVE CONTROL — a new bare null on an unlisted key is caught, so this check can fail')
+
+  // The allowlist asserted against the `complete` branch: this is the claim that adding a key here
+  // is a decision to keep exit 0 unreachable.
+  const asTheToolSets = { ...complete }
+  for (const k of Object.keys(NEVER_CHECKED)) asTheToolSets[k] = { found: null, verified: false }
+  for (const k of Object.keys(NEVER_VERIFIED)) asTheToolSets[k] = { found: true, verified: false }
+  const best = installState(asTheToolSets)
+  check(best.outcome === 'inconclusive' && best.exitCode === 3,
+    'a PERFECTLY installed agent still exits 3 — exit 0 is unreachable while the allowlist is non-empty')
+  check(best.atCeiling === true && /best result available here/.test(best.headline),
+    '  …and the report says so, instead of leaving a permanent 3 to read as a local failure')
+  check(/remedy for each is off this machine/.test(best.headline),
+    '  …and points off the box, which is where every remaining row is settled')
+  check(renderState(best).includes('best result available here'),
+    '  …and the operator reads it, not just the caller')
+  // The exit line, which is the line an operator reads for the verdict. Asserted at the call site
+  // because producing a live at-the-ceiling run needs a fully installed agent on this machine.
+  check(/exit \$\{report\.exitCode\} \(\$\{report\.outcome\}\$\{report\.atCeiling \?/.test(toolSrc),
+    'and the tool puts it on the exit line too, not only in the headline forty lines up')
+
+  // BOTH DIRECTIONS — the sentence must not appear when there IS something to do here. Otherwise
+  // it is an alarm that always fires, which fails identically to one that never does.
+  const oneRealGap = { ...asTheToolSets, 'manifest': { found: true, verified: false } }
+  const real = installState(oneRealGap)
+  check(real.atCeiling === false && !/best result available/.test(real.headline),
+    'BOTH DIRECTIONS — one row that IS checkable and unverified drops the ceiling sentence entirely')
+  check(installState({ ...asTheToolSets, 'manifest': { found: false } }).atCeiling === false,
+    'and a missing row is never at the ceiling — something is absent and can be created')
+  check(installState(complete).atCeiling === false,
+    'and a report with nothing outstanding is not "the best available" — it is complete')
 }
 
 console.log(`\n${pass ? 'ALL PASS' : 'FAILURES ABOVE'}`)

--- a/tools/connect-agent.mjs
+++ b/tools/connect-agent.mjs
@@ -538,5 +538,7 @@ if (has('--startup')) {
   console.log(`  point ${rt.label} at ${HERE} so it reads this at session start — registering the MCP`)
   console.log(`  server does not make a runtime read a file next to it.`)
 }
-console.log(`\nexit ${report.exitCode} (${report.outcome})`)
+// The ceiling on the exit line too, not only in the headline forty lines up. An operator reading
+// the last line for the verdict is the reason this tool prints one (#492).
+console.log(`\nexit ${report.exitCode} (${report.outcome}${report.atCeiling ? ' — the best result this build can report; every remaining row is settled off this machine' : ''})`)
 process.exit(report.exitCode)


### PR DESCRIPTION
`connect-agent --check` has four outcomes and one of them cannot happen. Not "does not happen on a half-finished box" — cannot happen, on any machine, however perfectly the agent is installed. Eleven of the nineteen rows are hardcoded at their call sites: five pass a bare `null` for `found`, six pass a bare `false` for `verified`. `complete` requires zero unknown and zero unverified, so exit 0 is unreachable by construction.

The report's own headline — *being unable to check is not the same as being fine* — is true, and is exactly the sentence that makes a permanent exit 3 read as a local failure.

## What is here

Part 1 — **name the ceiling**. `ceilingReached()` decides whether the report in hand is already the best this build can produce. When it is, both the headline and the exit line say so and point off the machine:

```
exit 3 (inconclusive — the best result this build can report; every remaining row is settled off this machine)
```

When one checkable row is still outstanding, the clause disappears. An alarm that always fires and one that never fires fail identically, so that direction is asserted too — including against the live `--check` run the suite already does, which exits 1 on a fresh root and must not claim a ceiling.

Part 2 — **make a bare `null` cost something**. `NEVER_CHECKED` and `NEVER_VERIFIED` in `src/agent_install_state.mjs` name every hardcoded row and what would settle it. The suite scans `tools/connect-agent.mjs` for every `see()` whose second argument is the literal `null` or whose third is the literal `false`, and fails on any key not in the allowlist. Both directions: an allowlist entry that outlives its call site fails too, because a stale entry states that exit 0 is unreachable for a reason that has been fixed.

Each of these was a reasonable local decision — "not checked here" is honest — and the aggregate consequence lived in a different file from every one of them. The allowlist is where a reader meets the aggregate, and adding a key to it is visibly a decision to keep exit 0 unreachable.

## One correction to the issue

The issue counted five hardcoded rows and four permanent UNKNOWNs. The scan found eleven: `channel-authorized` is a sixth bare `null`, and `identity`, `bunker-uri`, `signer-identity`, `signer-methods`, `channel-host-key` and `channel-answers` all pass a literal `false` for `verified`, so they can never be PRESENT either. That is the argument for the mechanism over the list — the list was written by hand and was short.

## Evidence

- The argument splitter tracks paren depth. A naive comma split reads `see('bunker-client', nonEmptyFile(p), nonEmptyFile(p) && mode(p) === 0o600, …)` as a two-argument call, misreads the file, and reports a clean sweep. That is a positive control in the suite, not a claim — as is "the scan read 18 `see()` calls", because a scanner that found none would pass silently.
- 9 mutation controls, **9 caught, 0 survived, 0 anchor misses**: a hardcoded null on an unlisted key; a hardcoded `verified: false` on an unlisted key; an allowlist entry outliving its call site; the ceiling claimed when a checkable row is unverified; the ceiling sentence dropped from the headline; the ceiling claimed over a MISSING row; the ceiling claimed on a complete report; an allowlist reason naming no remedy; the splitter losing paren depth.
- Full `npm test` exit 0, `npm run lint` clean (one pre-existing warning in `tests/console_agent_empty_state.mjs`, untouched).

No new suite, so the suite count is unchanged.

Reviewer: **@My Dude** — you raised this out of the #475 review. The part worth pressing: whether `NEVER_VERIFIED` should carry those six rows at all, or whether one or two of them ought to become checkable here rather than allowlisted.

Closes #492.

Drafted with assistance from [Claude Code](https://claude.com/claude-code)
