### PR TITLE
A correctly-onboarded agent was told it could not run (#513)

### DIFF
--- a/console/VERSION.json
+++ b/console/VERSION.json
@@ -1,3 +1,3 @@
 {
-  "build": "9dfedec4a8a22e5fdccf5a7cbb038c40"
+  "build": "dd13e8336b81871b9ec9fce92b365187"
 }

--- a/console/VERSION.json
+++ b/console/VERSION.json
@@ -1,3 +1,3 @@
 {
-  "build": "dd13e8336b81871b9ec9fce92b365187"
+  "build": "c478d5ef6ff8287cba196c78088e7342"
 }

--- a/console/agent-startup.mjs
+++ b/console/agent-startup.mjs
@@ -255,7 +255,7 @@ export function startupDoc({ agent, pubkey, channel, bridge, runtimeLabel, brief
     out.push(`- **${neverChecked.length} further artifact${neverChecked.length === 1 ? ' was' : 's were'} never checked` +
       ` — do not assume either way:** ${titles}.`)
     out.push(`  Whatever wrote this could not observe ${neverChecked.length === 1 ? 'it' : 'them'};` +
-      ` run \`connect-agent --check\` on the agent's own machine to settle ${neverChecked.length === 1 ? 'it' : 'them'}.`)
+      ` run \`connect-agent --check --lane sealed\` on the agent's own machine to settle ${neverChecked.length === 1 ? 'it' : 'them'}.`)
   }
   out.push('')
   if (open.length) {

--- a/console/agent-startup.mjs
+++ b/console/agent-startup.mjs
@@ -36,6 +36,12 @@ const LANE_TITLES = {
   'signer-identity': 'Signer resolves to the right key',
 }
 
+// The lane names, inlined for the same reason and exported so `tests/console_first_prompt.mjs` can
+// pin them against `LANES` in `src/agent_install_state.mjs`. A stale list here does not render a
+// wrong sentence — it renders a `--lane` flag the node side would reject, which is a command an
+// agent is told to run and cannot.
+export const LANES = Object.freeze({ sealed: true, broker: true })
+
 // Anything that looks like a credential. Checked against the rendered text, not against the inputs,
 // because the failure that matters is what reaches the file.
 const HEX64 = /^[0-9a-f]{64}$/
@@ -98,6 +104,16 @@ export function startupDoc({ agent, pubkey, channel, bridge, runtimeLabel, brief
   // true of the system whatever this install looks like, and mixing the two is how a document tells
   // an agent it holds a pairing it does not have. Absent row reads as never-checked, never as fine.
   const stateOf = key => { const r = row(key); return r ? (SAYS[r.state] || r.state) : SAYS[UNKNOWN] }
+
+  // The check command this agent should actually run, rendered from the lane it was checked under.
+  // `--lane` is not cosmetic: declaring `sealed` scopes six broker rows out (#513), so a document
+  // that hardcodes one lane tells an agent on the other one to scope out the rows it depends on —
+  // `applies` refusing to assume the cheaper lane, arriving through the document instead of the
+  // flag. Undeclared renders no flag at all, for the same reason `installState` treats undeclared
+  // as "every row applies": absent is not sealed. An unknown name is dropped rather than echoed,
+  // because a command printed with a lane `installState` would reject is a command that fails.
+  const lane = Object.prototype.hasOwnProperty.call(LANES, String(report?.lane)) ? String(report.lane) : null
+  const checkCmd = `connect-agent --check${lane ? ` --lane ${lane}` : ''}`
 
   // Only the rows an agent's own behaviour depends on. A wall of install state is a wall nobody
   // reads, and this file competes for the top of a context window.
@@ -242,7 +258,7 @@ export function startupDoc({ agent, pubkey, channel, bridge, runtimeLabel, brief
       : `${laneTitle(k)} is not in place`
     out.push('')
     out.push(`⚠ **Neither command works yet.** ${laneOpen.map(laneSays).join('; ')}.`)
-    out.push(`Settle that first with \`connect-agent --check\`; running either tool before then fails in a`)
+    out.push(`Settle that first with \`${checkCmd}\`; running either tool before then fails in a`)
     out.push(`way that looks like the lane being down.`)
   }
   out.push('')
@@ -255,7 +271,7 @@ export function startupDoc({ agent, pubkey, channel, bridge, runtimeLabel, brief
     out.push(`- **${neverChecked.length} further artifact${neverChecked.length === 1 ? ' was' : 's were'} never checked` +
       ` — do not assume either way:** ${titles}.`)
     out.push(`  Whatever wrote this could not observe ${neverChecked.length === 1 ? 'it' : 'them'};` +
-      ` run \`connect-agent --check --lane sealed\` on the agent's own machine to settle ${neverChecked.length === 1 ? 'it' : 'them'}.`)
+      ` run \`${checkCmd}\` on the agent's own machine to settle ${neverChecked.length === 1 ? 'it' : 'them'}.`)
   }
   out.push('')
   if (open.length) {

--- a/console/build-id.mjs
+++ b/console/build-id.mjs
@@ -2,4 +2,4 @@
 //
 // The id of the console build this module graph belongs to. A page compares it against
 // console/VERSION.json, fetched with no-store, to detect a stale cached graph (#418).
-export const CONSOLE_BUILD_ID = 'dd13e8336b81871b9ec9fce92b365187'
+export const CONSOLE_BUILD_ID = 'c478d5ef6ff8287cba196c78088e7342'

--- a/console/build-id.mjs
+++ b/console/build-id.mjs
@@ -2,4 +2,4 @@
 //
 // The id of the console build this module graph belongs to. A page compares it against
 // console/VERSION.json, fetched with no-store, to detect a stale cached graph (#418).
-export const CONSOLE_BUILD_ID = '9dfedec4a8a22e5fdccf5a7cbb038c40'
+export const CONSOLE_BUILD_ID = 'dd13e8336b81871b9ec9fce92b365187'

--- a/src/agent_install_state.mjs
+++ b/src/agent_install_state.mjs
@@ -19,7 +19,7 @@
 //   not-applicable — this agent's declared lane never needed it. NOT the same as satisfied.
 //
 // The lane (#513) exists because there are two ways to participate and this model could describe
-// only one of them. Seven of the rows below reach an ssh channel on the broker box; an agent on
+// only one of them. Six of the rows below reach an ssh channel on the broker box; an agent on
 // the sealed lane authenticates to the bridge by signature and needs none of them. Until it could
 // say so, `--check` told a correctly-onboarded agent it could not run — a wrong answer given
 // confidently, which is the failure this file was written to prevent.
@@ -101,7 +101,16 @@ export const ARTIFACTS = [
     why: 'Six tools read it and none write it. Every field is validated; one bad field refuses the whole runtime.' },
   { key: 'state-dirs', title: 'Runtime directories', blocking: true,
     why: 'Five of them, two with non-default modes. Nothing creates them and nothing lists them.' },
-  // ── Broker-lane only, all seven. Every one of them exists to reach an ssh channel on another
+  // NOT broker-lane, though it sat inside that block for one commit and was scoped out by list
+  // position rather than by what it reads. `foreignNvoyServers` reads THIS machine's MCP runtime
+  // configs; no ssh, no other box. #338's hazard belongs to the session, not to the transport.
+  // It is worst on the sealed lane specifically: `foreignServers(names, name)` excludes
+  // `nvoy-<name>`, and a sealed-lane agent has no such server — so every nvoy server in that
+  // session counts as foreign. The one lane with nothing of its own to compare against was the
+  // lane the row was scoped out of.
+  { key: 'mcp-exclusive', title: 'No other nvoy server registered', blocking: true,
+    why: 'Registered is not sole. A generically-named server alongside carries the tools that sign, bound to somebody else.' },
+  // ── Broker-lane only, all six. Every one of them exists to reach an ssh channel on another
   // box, and a sealed-lane agent reaches the bridge by signature instead. Two of these were the
   // rows telling a correctly-onboarded agent it could not run (#513).
   { key: 'channel-key', title: 'Channel keypair', blocking: true, lanes: ['broker'],
@@ -114,8 +123,6 @@ export const ARTIFACTS = [
     why: "The other box's authorized_keys, under its forced command. Nothing on this machine can see it, so it is UNKNOWN until an operator confirms it — never assumed from the key existing here." },
   { key: 'mcp-registration', title: 'Registered as an MCP server', blocking: true, lanes: ['broker'],
     why: 'How a new session becomes this agent. Needs the instance root set explicitly; the default path does not exist here.' },
-  { key: 'mcp-exclusive', title: 'No other nvoy server registered', blocking: true, lanes: ['broker'],
-    why: 'Registered is not sole. A generically-named server alongside carries the tools that sign, bound to somebody else.' },
   // #338. Sole is not YOURS. An agent was handed a session whose attached server answered `whoami`
   // with a different agent's identity — it would have read that identity's sealed inbox and posted
   // under its key, and neither would have errored, because a wrong-identity binding signs and seals
@@ -202,7 +209,7 @@ export function installState(observations = {}, { lane = null } = {}) {
   // applies", which is the demanding answer. `--lane brokr` must not quietly become `--lane sealed`.
   //
   // `typeof === 'string'` is not belt-and-braces. `String(['sealed'])` is `'sealed'`, so without it
-  // a single-element array declares a lane and scopes seven rows out — measured, not reasoned
+  // a single-element array declares a lane and scopes six rows out — measured, not reasoned
   // about. `hasOwnProperty` rather than `in` for the same reason one layer down: `'toString'` is a
   // property of every object and would otherwise name a lane.
   const declared = typeof lane === 'string' && Object.prototype.hasOwnProperty.call(LANES, lane) ? lane : null
@@ -265,7 +272,7 @@ export function installState(observations = {}, { lane = null } = {}) {
     headline = 'Every piece present and observed doing its job.'
   }
   // Say out loud how many rows were scoped out, and by which lane. A report that quietly stops
-  // asking about seven artifacts is the same shape as a report that quietly passes them — the
+  // asking about six artifacts is the same shape as a report that quietly passes them — the
   // reader cannot tell the two apart unless the count is on the page.
   if (notApplicable.length) {
     headline += ` ${notApplicable.length} row${notApplicable.length === 1 ? '' : 's'} did not apply to the ${declared} lane and ${notApplicable.length === 1 ? 'was' : 'were'} not checked — that is not the same as satisfied.`

--- a/src/agent_install_state.mjs
+++ b/src/agent_install_state.mjs
@@ -14,6 +14,16 @@
 //   missing     — something looked, and it is not there
 //   unknown     — nothing looked. NOT the same as missing.
 //
+// And one more that is not an observation at all:
+//
+//   not-applicable — this agent's declared lane never needed it. NOT the same as satisfied.
+//
+// The lane (#513) exists because there are two ways to participate and this model could describe
+// only one of them. Seven of the rows below reach an ssh channel on the broker box; an agent on
+// the sealed lane authenticates to the bridge by signature and needs none of them. Until it could
+// say so, `--check` told a correctly-onboarded agent it could not run — a wrong answer given
+// confidently, which is the failure this file was written to prevent.
+//
 // The fourth state was added after the first version reported two artifacts as `missing` that it
 // had never examined. That is the same false confidence pointing the other way, and it is worse
 // than it sounds: "missing" sends an operator to create a thing that may already exist, and for a
@@ -35,11 +45,35 @@ export const PRESENT = 'present'
 export const UNVERIFIED = 'unverified'
 export const MISSING = 'missing'
 export const UNKNOWN = 'unknown'
+// A fifth state, and the only one that is not an observation (#513). The four above answer "what
+// did we see?"; this one answers "was this ever this agent's step?" — and it must never be spelled
+// `present`, because "satisfied" and "did not apply" are different reasons for a row not being a
+// problem, and only one of them means the artifact exists. Collapsing them is how a genuinely
+// missing credential reads as a green row.
+export const NOT_APPLICABLE = 'not-applicable'
+
+// How this agent participates. A DECLARATION, not an observation — and until #513 there was no way
+// to make it, so the model could only describe the broker lane. An agent onboarded exactly as the
+// design describes was told, with confidence, that it could not run.
+export const LANES = Object.freeze({
+  sealed: 'seal to the bridge, and the bridge seals back — authenticated by signature, on no other box',
+  broker: 'an MCP server reached over ssh, on the broker box',
+})
 
 // The artifacts, in the order they must be satisfied. `blocking` marks the ones without which the
 // agent cannot function at all — as opposed to the ones without which it merely has no name.
 // Both matter; conflating them is how "it works" and "it is finished" became the same claim.
+//
+// `lanes` scopes a row to the lanes that need it. A row WITHOUT `lanes` is needed by every lane:
+// the default is the demanding one on purpose, so adding a lane later cannot quietly excuse an
+// artifact that nobody remembered to scope.
 export const ARTIFACTS = [
+  // First, because it governs every row beneath it. Non-blocking on purpose: an agent that has not
+  // said how it participates is not broken, it is unexamined, and the honest report for unexamined
+  // is INCONCLUSIVE rather than "cannot run". What it must not do is assume the lane with fewer
+  // requirements and pass.
+  { key: 'lane', title: 'Declared participation lane', blocking: false,
+    why: 'Which lane this agent speaks over, and therefore which artifacts it needs at all. Undeclared is not sealed: the broker rows stay required, because assuming the lane with fewer requirements is how a missing credential reads as satisfied.' },
   { key: 'identity', title: 'Identity key', blocking: true,
     why: 'The key it signs as. Held in the Bunker; this machine never sees it.' },
   { key: 'bunker-uri', title: 'Bunker pairing', blocking: true,
@@ -67,17 +101,20 @@ export const ARTIFACTS = [
     why: 'Six tools read it and none write it. Every field is validated; one bad field refuses the whole runtime.' },
   { key: 'state-dirs', title: 'Runtime directories', blocking: true,
     why: 'Five of them, two with non-default modes. Nothing creates them and nothing lists them.' },
-  { key: 'channel-key', title: 'Channel keypair', blocking: true,
+  // ── Broker-lane only, all seven. Every one of them exists to reach an ssh channel on another
+  // box, and a sealed-lane agent reaches the bridge by signature instead. Two of these were the
+  // rows telling a correctly-onboarded agent it could not run (#513).
+  { key: 'channel-key', title: 'Channel keypair', blocking: true, lanes: ['broker'],
     why: 'The MCP channel transport. Minted at the path the registration names — the two used to disagree, so a fresh agent got a correct stanza pointing at a key nothing had created (#474).' },
   // Its own row, not folded into the keypair. The private half is mintable here; neither of these
   // is, and a green key row beside a missing host key is exactly how a fresh agent reads as ready.
-  { key: 'channel-host-key', title: "The broker's host key", blocking: true,
+  { key: 'channel-host-key', title: "The broker's host key", blocking: true, lanes: ['broker'],
     why: "StrictHostKeyChecking refuses an unknown host, so without this the channel will not connect. It is the broker's host key and comes from the broker doctor on that box — it cannot be minted here, and this tool will never write one." },
-  { key: 'channel-authorized', title: 'The public half is seated on the broker', blocking: true,
+  { key: 'channel-authorized', title: 'The public half is seated on the broker', blocking: true, lanes: ['broker'],
     why: "The other box's authorized_keys, under its forced command. Nothing on this machine can see it, so it is UNKNOWN until an operator confirms it — never assumed from the key existing here." },
-  { key: 'mcp-registration', title: 'Registered as an MCP server', blocking: true,
+  { key: 'mcp-registration', title: 'Registered as an MCP server', blocking: true, lanes: ['broker'],
     why: 'How a new session becomes this agent. Needs the instance root set explicitly; the default path does not exist here.' },
-  { key: 'mcp-exclusive', title: 'No other nvoy server registered', blocking: true,
+  { key: 'mcp-exclusive', title: 'No other nvoy server registered', blocking: true, lanes: ['broker'],
     why: 'Registered is not sole. A generically-named server alongside carries the tools that sign, bound to somebody else.' },
   // #338. Sole is not YOURS. An agent was handed a session whose attached server answered `whoami`
   // with a different agent's identity — it would have read that identity's sealed inbox and posted
@@ -85,9 +122,9 @@ export const ARTIFACTS = [
   // perfectly. The Bunker path has refused this since day one via EXPECT_PUBKEY. The MCP path had
   // no equivalent, so the same class of defect moved one layer up from Pair to Bind and found no
   // guard there.
-  { key: 'mcp-identity', title: 'The server answers as THIS agent', blocking: true,
+  { key: 'mcp-identity', title: 'The server answers as THIS agent', blocking: true, lanes: ['broker'],
     why: 'Registered is not sole, and sole is not yours. Proven by whoami equalling the minted key — never by the registration existing. That proof is a saved capture, not a live signer: it has no freshness and no binding to the session under test, so it passes forever once taken (#462).' },
-  { key: 'channel-answers', title: 'Channel server answers', blocking: true,
+  { key: 'channel-answers', title: 'Channel server answers', blocking: true, lanes: ['broker'],
     why: 'Registered is not running. Proven by initialize + tools/list, not by the registration existing.' },
 ]
 
@@ -100,6 +137,12 @@ export const ARTIFACT_KEYS = ARTIFACTS.map(a => a.key)
 // are hardcoded at their call sites: five report `found: null` and six report `verified: false`, and
 // no branch can move them. `complete` requires zero unknown and zero unverified, so exit 0 is
 // unreachable by construction (#492).
+//
+// The lane does not change that. Declaring `sealed` scopes three of the eleven out — they are the
+// broker's rows — and the remaining eight are still enough to keep exit 0 unreachable. What the
+// lane changes is exit **1**: a sealed-lane agent reaches the ceiling at exit 3 instead of being
+// told it cannot run. That is the whole of #513, and it is worth being exact about, because "the
+// check now passes" is the summary a reader will reach for and it is not what happens.
 //
 // Each of those was a reasonable local decision — "not checked here" is honest — and the aggregate
 // consequence lived in a different file from every one of them. An operator running `--check` to
@@ -153,9 +196,28 @@ export function ceilingReached({ unverified = [], unknown = [], missing = [] } =
  * it work" is the one people skip. Defaulting the skipped case to `present` is how a report
  * becomes a green light for an agent nobody checked.
  */
-export function installState(observations = {}) {
+export function installState(observations = {}, { lane = null } = {}) {
+  // A lane counts as declared only if it is a string naming one we know. An unrecognised name is a
+  // typo or a future lane, and neither may excuse a row: `applies` falls back to "every row
+  // applies", which is the demanding answer. `--lane brokr` must not quietly become `--lane sealed`.
+  //
+  // `typeof === 'string'` is not belt-and-braces. `String(['sealed'])` is `'sealed'`, so without it
+  // a single-element array declares a lane and scopes seven rows out — measured, not reasoned
+  // about. `hasOwnProperty` rather than `in` for the same reason one layer down: `'toString'` is a
+  // property of every object and would otherwise name a lane.
+  const declared = typeof lane === 'string' && Object.prototype.hasOwnProperty.call(LANES, lane) ? lane : null
+  // No `lanes` on a row → every lane needs it. No declared lane → every row applies, because the
+  // permissive reading of silence is the one this whole module exists to refuse.
+  const applies = artifact => !declared || !artifact.lanes || artifact.lanes.includes(declared)
+
   const rows = ARTIFACTS.map(artifact => {
     const seen = observations[artifact.key]
+    // Scoped out before the observation is consulted, and deliberately so: a broker key that
+    // happens to exist on a sealed-lane box has still not been asked for, and reporting it
+    // `present` would put "we have it" and "we never needed it" back in the same cell.
+    if (!applies(artifact)) {
+      return { ...artifact, state: NOT_APPLICABLE, note: `not part of the ${declared} lane` }
+    }
     // An absent observation and an explicit `found: null` both mean nobody looked. Only an
     // explicit `found: false` — someone looked and it was not there — is MISSING.
     let state
@@ -173,6 +235,7 @@ export function installState(observations = {}) {
   const missing = by(MISSING)
   const unverified = by(UNVERIFIED)
   const unknown = by(UNKNOWN)
+  const notApplicable = by(NOT_APPLICABLE)
   const blockingMissing = missing.filter(r => r.blocking)
   const atCeiling = ceilingReached({
     unverified: unverified.map(r => r.key), unknown: unknown.map(r => r.key), missing: missing.map(r => r.key),
@@ -201,13 +264,23 @@ export function installState(observations = {}) {
     outcome = 'complete'; exitCode = 0
     headline = 'Every piece present and observed doing its job.'
   }
+  // Say out loud how many rows were scoped out, and by which lane. A report that quietly stops
+  // asking about seven artifacts is the same shape as a report that quietly passes them — the
+  // reader cannot tell the two apart unless the count is on the page.
+  if (notApplicable.length) {
+    headline += ` ${notApplicable.length} row${notApplicable.length === 1 ? '' : 's'} did not apply to the ${declared} lane and ${notApplicable.length === 1 ? 'was' : 'were'} not checked — that is not the same as satisfied.`
+  }
 
   return {
-    outcome, exitCode, headline, rows, atCeiling,
-    counts: { present: by(PRESENT).length, unverified: unverified.length, missing: missing.length, unknown: unknown.length },
+    outcome, exitCode, headline, rows, atCeiling, lane: declared,
+    counts: {
+      present: by(PRESENT).length, unverified: unverified.length,
+      missing: missing.length, unknown: unknown.length, notApplicable: notApplicable.length,
+    },
     missing: missing.map(r => r.key),
     unverified: unverified.map(r => r.key),
     unknown: unknown.map(r => r.key),
+    notApplicable: notApplicable.map(r => r.key),
   }
 }
 
@@ -346,8 +419,10 @@ function pickKey(value, depth = 0) {
 // unverified row never prints as a tick — the single most likely way this report lies.
 export function renderState(report, { width = 34 } = {}) {
   // UNKNOWN gets its own glyph. Sharing one with MISSING would put "nobody looked" and "it is not
-  // there" back into the same cell, which is the distinction this report exists to keep.
-  const mark = { [PRESENT]: 'ok ', [UNVERIFIED]: ' ? ', [MISSING]: ' x ', [UNKNOWN]: ' - ' }
+  // there" back into the same cell, which is the distinction this report exists to keep. Same
+  // reasoning for NOT_APPLICABLE: it is emphatically not `ok`, and a reader scanning the left
+  // column for ticks must not find one on a row nobody asked about.
+  const mark = { [PRESENT]: 'ok ', [UNVERIFIED]: ' ? ', [MISSING]: ' x ', [UNKNOWN]: ' - ', [NOT_APPLICABLE]: 'n/a' }
   const lines = report.rows.map(r =>
     `[${mark[r.state]}] ${r.title.padEnd(width)} ${r.state === PRESENT ? '' : r.state.toUpperCase()}${r.note ? `  — ${r.note}` : ''}`.trimEnd())
   return [...lines, '', report.headline].join('\n')

--- a/src/agent_startup.mjs
+++ b/src/agent_startup.mjs
@@ -248,7 +248,7 @@ export function startupDoc({ agent, pubkey, channel, bridge, runtimeLabel, brief
     out.push(`- **${neverChecked.length} further artifact${neverChecked.length === 1 ? ' was' : 's were'} never checked` +
       ` — do not assume either way:** ${titles}.`)
     out.push(`  Whatever wrote this could not observe ${neverChecked.length === 1 ? 'it' : 'them'};` +
-      ` run \`connect-agent --check\` on the agent's own machine to settle ${neverChecked.length === 1 ? 'it' : 'them'}.`)
+      ` run \`connect-agent --check --lane sealed\` on the agent's own machine to settle ${neverChecked.length === 1 ? 'it' : 'them'}.`)
   }
   out.push('')
   if (open.length) {

--- a/src/agent_startup.mjs
+++ b/src/agent_startup.mjs
@@ -27,7 +27,7 @@
 //      whose kind:10050 was never checked is told it was never checked — not that it is reachable.
 //      An agent that believes it is reachable and is not will report the wall as broken, and that
 //      exact confusion has cost this project a day more than once.
-import { ARTIFACTS, MISSING, PRESENT, UNKNOWN, UNVERIFIED } from './agent_install_state.mjs'
+import { ARTIFACTS, LANES, MISSING, PRESENT, UNKNOWN, UNVERIFIED } from './agent_install_state.mjs'
 
 // Anything that looks like a credential. Checked against the rendered text, not against the inputs,
 // because the failure that matters is what reaches the file.
@@ -91,6 +91,16 @@ export function startupDoc({ agent, pubkey, channel, bridge, runtimeLabel, brief
   // true of the system whatever this install looks like, and mixing the two is how a document tells
   // an agent it holds a pairing it does not have. Absent row reads as never-checked, never as fine.
   const stateOf = key => { const r = row(key); return r ? (SAYS[r.state] || r.state) : SAYS[UNKNOWN] }
+
+  // The check command this agent should actually run, rendered from the lane it was checked under.
+  // `--lane` is not cosmetic: declaring `sealed` scopes six broker rows out (#513), so a document
+  // that hardcodes one lane tells an agent on the other one to scope out the rows it depends on —
+  // `applies` refusing to assume the cheaper lane, arriving through the document instead of the
+  // flag. Undeclared renders no flag at all, for the same reason `installState` treats undeclared
+  // as "every row applies": absent is not sealed. An unknown name is dropped rather than echoed,
+  // because a command printed with a lane `installState` would reject is a command that fails.
+  const lane = Object.prototype.hasOwnProperty.call(LANES, String(report?.lane)) ? String(report.lane) : null
+  const checkCmd = `connect-agent --check${lane ? ` --lane ${lane}` : ''}`
 
   // Only the rows an agent's own behaviour depends on. A wall of install state is a wall nobody
   // reads, and this file competes for the top of a context window.
@@ -235,7 +245,7 @@ export function startupDoc({ agent, pubkey, channel, bridge, runtimeLabel, brief
       : `${laneTitle(k)} is not in place`
     out.push('')
     out.push(`⚠ **Neither command works yet.** ${laneOpen.map(laneSays).join('; ')}.`)
-    out.push(`Settle that first with \`connect-agent --check\`; running either tool before then fails in a`)
+    out.push(`Settle that first with \`${checkCmd}\`; running either tool before then fails in a`)
     out.push(`way that looks like the lane being down.`)
   }
   out.push('')
@@ -248,7 +258,7 @@ export function startupDoc({ agent, pubkey, channel, bridge, runtimeLabel, brief
     out.push(`- **${neverChecked.length} further artifact${neverChecked.length === 1 ? ' was' : 's were'} never checked` +
       ` — do not assume either way:** ${titles}.`)
     out.push(`  Whatever wrote this could not observe ${neverChecked.length === 1 ? 'it' : 'them'};` +
-      ` run \`connect-agent --check --lane sealed\` on the agent's own machine to settle ${neverChecked.length === 1 ? 'it' : 'them'}.`)
+      ` run \`${checkCmd}\` on the agent's own machine to settle ${neverChecked.length === 1 ? 'it' : 'them'}.`)
   }
   out.push('')
   if (open.length) {

--- a/tests/agent_install_state.mjs
+++ b/tests/agent_install_state.mjs
@@ -583,10 +583,19 @@ check(ARTIFACTS.some(a => a.blocking) && ARTIFACTS.some(a => !a.blocking),
 // a scope that excuses every row, and both look like a suite that went green.
 {
   const brokerKeys = ARTIFACTS.filter(a => a.lanes?.length === 1 && a.lanes[0] === 'broker').map(a => a.key)
-  check(brokerKeys.length === 7, `seven rows are scoped to the broker lane (found ${brokerKeys.length})`)
+  check(brokerKeys.length === 6, `six rows are scoped to the broker lane (found ${brokerKeys.length})`)
   check(ARTIFACTS.filter(a => !a.lanes).length > 0,
     'and most rows are scoped to no lane at all, which means every lane needs them')
   check(Object.keys(LANES).sort().join(',') === 'broker,sealed', 'two lanes, named')
+
+  // `mcp-exclusive` is NOT one of them, and the distinction is what the row reads, not where it sits
+  // in the list. It went out with the broker block for one commit because it was adjacent to it:
+  // `foreignNvoyServers` reads THIS machine's MCP runtime configs, so it needs no ssh and no other
+  // box. It is worst on the sealed lane — `foreignServers(names, name)` excludes `nvoy-<name>`, and
+  // a sealed-lane agent has no such server, so every nvoy server in that session counts as foreign.
+  // The lane it was scoped out of is the one where it has nothing of its own to compare against.
+  check(!ARTIFACTS.find(a => a.key === 'mcp-exclusive').lanes,
+    'mcp-exclusive is scoped to no lane — it reads this machine, not the broker')
 
   // The tool's own observations: everything found and verified, so nothing here is MISSING for a
   // reason other than the lane. That isolates the property — any refusal below is the scope.
@@ -596,22 +605,27 @@ check(ARTIFACTS.some(a => a.blocking) && ARTIFACTS.some(a => !a.blocking),
   //    and "never asked for" are different reasons for a row not to be a problem, and a model that
   //    spells them the same way is how a genuinely missing credential reads green.
   check(brokerKeys.every(k => sealed.rows.find(r => r.key === k).state === NOT_APPLICABLE),
-    'a sealed-lane agent reports all seven broker rows NOT-APPLICABLE')
+    'a sealed-lane agent reports all six broker rows NOT-APPLICABLE')
   check(brokerKeys.every(k => sealed.rows.find(r => r.key === k).state !== PRESENT),
     '  …and not one of them as PRESENT — "did not apply" is never "satisfied"')
+  check(sealed.rows.find(r => r.key === 'mcp-exclusive').state === PRESENT,
+    '  …and mcp-exclusive is still CHECKED on the sealed lane, not scoped out beside them')
+  check(installState({ ...complete, 'mcp-exclusive': { found: false } }, { lane: 'sealed' })
+    .missing.includes('mcp-exclusive'),
+    '  …BOTH DIRECTIONS — and a foreign nvoy server still fails a sealed-lane agent')
   check(!sealed.notApplicable.some(k => sealed.missing.includes(k) || sealed.unverified.includes(k) || sealed.unknown.includes(k)),
     '  …and a scoped-out row appears in exactly one bucket, so no count double-reports it')
   check(sealed.counts.present === Object.keys(complete).length - brokerKeys.length,
-    '  …and the present count drops by exactly seven — the rows left the tally, they were not renamed into it')
+    '  …and the present count drops by exactly six — the rows left the tally, they were not renamed into it')
 
-  // 2. The row still exists and still says so. Dropping the seven rows from the render would be the
+  // 2. The row still exists and still says so. Dropping the six rows from the render would be the
   //    same defect one layer out: the reader cannot audit a scope they cannot see.
   const shown = renderState(sealed)
   check(brokerKeys.every(k => shown.includes(ARTIFACTS.find(a => a.key === k).title)),
-    'the seven are still printed, so the scope is auditable rather than invisible')
+    'the six are still printed, so the scope is auditable rather than invisible')
   check(!/\[ok \] The broker's host key/.test(shown) && /\[n\/a\] The broker's host key/.test(shown),
     '  …with their own glyph, never a tick')
-  check(/7 rows did not apply to the sealed lane/.test(sealed.headline) && /not the same as satisfied/.test(sealed.headline),
+  check(/6 rows did not apply to the sealed lane/.test(sealed.headline) && /not the same as satisfied/.test(sealed.headline),
     '  …and the headline says how many were skipped, and that skipped is not satisfied')
 
   // 3. The point of the change: this agent is no longer told it cannot run.
@@ -627,7 +641,7 @@ check(ARTIFACTS.some(a => a.blocking) && ARTIFACTS.some(a => !a.blocking),
   check(asBroker.exitCode === 1 && asBroker.outcome === 'incomplete',
     'BOTH DIRECTIONS — a BROKER-lane agent with no broker artifacts still cannot run')
   check(asBroker.missing.length === brokerKeys.length && brokerKeys.every(k => asBroker.missing.includes(k)),
-    '  …and it names all seven, rather than refusing for some other reason')
+    '  …and it names all six, rather than refusing for some other reason')
   check(installState(withoutBroker, { lane: 'sealed' }).exitCode !== 1,
     '  …and the SAME observations pass on the sealed lane — the lane is what differs, not the box')
 
@@ -718,8 +732,8 @@ check(ARTIFACTS.some(a => a.blocking) && ARTIFACTS.some(a => !a.blocking),
   }
   check(/\[ok \] Declared participation lane/.test(live.out) && /sealed —/.test(live.out),
     'a live --lane sealed run reports the declaration as its own row')
-  check((live.out.match(/\[n\/a\]/g) || []).length === 7,
-    '  …and renders exactly seven n/a rows')
+  check((live.out.match(/\[n\/a\]/g) || []).length === 6,
+    '  …and renders exactly six n/a rows')
   const undeclaredRun = run(base)
   if (undeclaredRun === null || !undeclaredRun.out || undeclaredRun.out.length < 500) {
     console.error('agent_install_state: INCONCLUSIVE — the undeclared control never produced a report')

--- a/tests/agent_install_state.mjs
+++ b/tests/agent_install_state.mjs
@@ -20,7 +20,7 @@ import { tmpdir } from 'node:os'
 import { execFileSync } from 'node:child_process'
 import { fileURLToPath } from 'node:url'
 import { npubEncode, decode as nip19decode } from 'nostr-tools/nip19'
-import { installState, renderState, foreignNvoyServers, boundIdentity, ARTIFACTS, ARTIFACT_KEYS, NEVER_CHECKED, NEVER_VERIFIED, PRESENT, UNVERIFIED, MISSING, UNKNOWN }
+import { installState, renderState, foreignNvoyServers, boundIdentity, ARTIFACTS, ARTIFACT_KEYS, LANES, NEVER_CHECKED, NEVER_VERIFIED, NOT_APPLICABLE, PRESENT, UNVERIFIED, MISSING, UNKNOWN }
   from '../src/agent_install_state.mjs'
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..')
@@ -570,6 +570,164 @@ check(ARTIFACTS.some(a => a.blocking) && ARTIFACTS.some(a => !a.blocking),
     'and a missing row is never at the ceiling — something is absent and can be created')
   check(installState(complete).atCeiling === false,
     'and a report with nothing outstanding is not "the best available" — it is complete')
+}
+
+// ── The participation lane (#513) ────────────────────────────────────────────────────────────
+//
+// Two ways to participate, and until this the model could describe only one. Seven rows reach an
+// ssh channel on the broker box; a sealed-lane agent authenticates to the bridge by signature and
+// needs none of them — so `--check` told an agent onboarded exactly as the design describes that
+// it could not run, and exited 1 saying so.
+//
+// The whole risk of the fix is in the other direction. A scope that excuses a row is one line from
+// a scope that excuses every row, and both look like a suite that went green.
+{
+  const brokerKeys = ARTIFACTS.filter(a => a.lanes?.length === 1 && a.lanes[0] === 'broker').map(a => a.key)
+  check(brokerKeys.length === 7, `seven rows are scoped to the broker lane (found ${brokerKeys.length})`)
+  check(ARTIFACTS.filter(a => !a.lanes).length > 0,
+    'and most rows are scoped to no lane at all, which means every lane needs them')
+  check(Object.keys(LANES).sort().join(',') === 'broker,sealed', 'two lanes, named')
+
+  // The tool's own observations: everything found and verified, so nothing here is MISSING for a
+  // reason other than the lane. That isolates the property — any refusal below is the scope.
+  const sealed = installState(complete, { lane: 'sealed' })
+
+  // 1. Scoped out, and NOT to `present`. This is the whole bullet the issue leads with: "satisfied"
+  //    and "never asked for" are different reasons for a row not to be a problem, and a model that
+  //    spells them the same way is how a genuinely missing credential reads green.
+  check(brokerKeys.every(k => sealed.rows.find(r => r.key === k).state === NOT_APPLICABLE),
+    'a sealed-lane agent reports all seven broker rows NOT-APPLICABLE')
+  check(brokerKeys.every(k => sealed.rows.find(r => r.key === k).state !== PRESENT),
+    '  …and not one of them as PRESENT — "did not apply" is never "satisfied"')
+  check(!sealed.notApplicable.some(k => sealed.missing.includes(k) || sealed.unverified.includes(k) || sealed.unknown.includes(k)),
+    '  …and a scoped-out row appears in exactly one bucket, so no count double-reports it')
+  check(sealed.counts.present === Object.keys(complete).length - brokerKeys.length,
+    '  …and the present count drops by exactly seven — the rows left the tally, they were not renamed into it')
+
+  // 2. The row still exists and still says so. Dropping the seven rows from the render would be the
+  //    same defect one layer out: the reader cannot audit a scope they cannot see.
+  const shown = renderState(sealed)
+  check(brokerKeys.every(k => shown.includes(ARTIFACTS.find(a => a.key === k).title)),
+    'the seven are still printed, so the scope is auditable rather than invisible')
+  check(!/\[ok \] The broker's host key/.test(shown) && /\[n\/a\] The broker's host key/.test(shown),
+    '  …with their own glyph, never a tick')
+  check(/7 rows did not apply to the sealed lane/.test(sealed.headline) && /not the same as satisfied/.test(sealed.headline),
+    '  …and the headline says how many were skipped, and that skipped is not satisfied')
+
+  // 3. The point of the change: this agent is no longer told it cannot run.
+  check(sealed.exitCode !== 1 && sealed.outcome !== 'incomplete',
+    'a sealed-lane agent with its own artifacts in place is NOT told "this agent cannot run"')
+
+  // 4. BOTH DIRECTIONS. The same fully-installed observations, minus the broker artifacts, must
+  //    still refuse on the broker lane. A gate that passes everything and one that passes the right
+  //    things fail identically, and this is the assertion that tells them apart.
+  const withoutBroker = { ...complete }
+  for (const k of brokerKeys) withoutBroker[k] = { found: false }
+  const asBroker = installState(withoutBroker, { lane: 'broker' })
+  check(asBroker.exitCode === 1 && asBroker.outcome === 'incomplete',
+    'BOTH DIRECTIONS — a BROKER-lane agent with no broker artifacts still cannot run')
+  check(asBroker.missing.length === brokerKeys.length && brokerKeys.every(k => asBroker.missing.includes(k)),
+    '  …and it names all seven, rather than refusing for some other reason')
+  check(installState(withoutBroker, { lane: 'sealed' }).exitCode !== 1,
+    '  …and the SAME observations pass on the sealed lane — the lane is what differs, not the box')
+
+  // 5. Undeclared is not sealed. The second bullet of the issue, and the one that could silently
+  //    turn this whole file permissive: a default of "assume the lane with fewer requirements" is
+  //    reached by deleting one `||` and looks exactly like this test passing.
+  const undeclared = installState(withoutBroker)
+  check(undeclared.exitCode === 1 && brokerKeys.every(k => undeclared.missing.includes(k)),
+    'an UNDECLARED lane keeps every broker row required — silence is not a declaration')
+  check(undeclared.notApplicable.length === 0,
+    '  …and scopes nothing out at all')
+  // The tool sets this row from the flag, so no flag means no observation. Asserted with the
+  // observation removed rather than on `withoutBroker`, which declares every key satisfied.
+  const { lane: _dropped, ...noLaneObserved } = withoutBroker
+  check(installState(noLaneObserved).rows.find(r => r.key === 'lane').state === UNKNOWN,
+    '  …and the lane row itself reads UNKNOWN, so the reader can see the declaration is absent')
+  check(installState(complete).atCeiling === false,
+    '  …and an undeclared agent is never "at the ceiling" — declaring the lane is a thing to do here')
+
+  // 6. A lane name this build does not know is not a declaration either. Same failure mode as 5,
+  //    reached by a typo rather than by omission.
+  const typo = installState(withoutBroker, { lane: 'sealled' })
+  check(typo.exitCode === 1 && typo.notApplicable.length === 0 && typo.lane === null,
+    'an unrecognised lane name excuses nothing — `sealled` is not `sealed`')
+  for (const bad of [null, undefined, '', 'toString', '__proto__', 'constructor', true, 0, {}, ['sealed']]) {
+    if (installState(withoutBroker, { lane: bad }).notApplicable.length !== 0) {
+      check(false, `  …and neither does ${JSON.stringify(bad) ?? String(bad)} — inherited Object keys are not lanes`)
+    }
+  }
+  check(true, '  …and neither do null, empty, a boolean, an array, or an inherited Object property name')
+
+  // 7. The ceiling still means what it meant. A sealed-lane agent whose only outstanding rows are
+  //    ones this build never checks has reached the best answer available here — which is exit 3,
+  //    not exit 0. Exit 0 stays unreachable (#492) and this change does not alter that.
+  const atCeiling = installState(
+    Object.fromEntries(ARTIFACT_KEYS.map(k => [k,
+      k in NEVER_CHECKED ? { found: null } : k in NEVER_VERIFIED ? { found: true } : { found: true, verified: true }])),
+    { lane: 'sealed' })
+  check(atCeiling.exitCode === 3 && atCeiling.atCeiling === true,
+    'a fully-installed sealed-lane agent reaches exit 3 AT THE CEILING — the best this build can report')
+  check(atCeiling.outcome !== 'complete',
+    '  …and never exit 0, which is still unreachable by construction (#492)')
+}
+
+// ── …and the tool declares it, refuses a bad one, and mints no broker key without it ──────────
+{
+  const src = readFileSync(join(ROOT, 'tools', 'connect-agent.mjs'), 'utf8')
+  if (src.length < 2000) {
+    console.error(`agent_install_state: INCONCLUSIVE — connect-agent.mjs read back only ${src.length} bytes`)
+    process.exit(3)
+  }
+  check(/installState\(obs,\s*\{\s*lane\s*\}\)/.test(src),
+    'the tool passes the declared lane to installState — a flag it parses and drops changes nothing')
+  // Key material created "just in case" is key material nobody is tracking, and a sealed-lane agent
+  // has no broker to present an ssh key to.
+  check(/!CHECK && !STARTUP_ONLY && !SEALED/.test(src),
+    'and it mints no channel keypair on the sealed lane')
+
+  const probeRoot = mkdtempSync(join(tmpdir(), 'wb-lane-probe-'))
+  const run = args => {
+    try {
+      return { out: execFileSync(process.execPath, [join(ROOT, 'tools', 'connect-agent.mjs'), ...args],
+        { encoding: 'utf8', timeout: 60000, stdio: ['ignore', 'pipe', 'pipe'] }), code: 0 }
+    } catch (e) {
+      if (e?.signal || e?.code === 'ETIMEDOUT') return null
+      return { out: `${typeof e?.stdout === 'string' ? e.stdout : ''}${typeof e?.stderr === 'string' ? e.stderr : ''}`, code: e?.status ?? null }
+    }
+  }
+  const base = ['--name', 'probe', '--check', '--root', probeRoot]
+
+  // Assert the REASON, not only the refusal. `!ok` cannot tell a correct refusal from a correct
+  // refusal that sends the operator somewhere useless, and the remedy here is the list of lanes.
+  const bad = run([...base, '--lane', 'sealled'])
+  if (bad === null || !bad.out) {
+    console.error('agent_install_state: INCONCLUSIVE — connect-agent.mjs never ran for the --lane refusal')
+    rmSync(probeRoot, { recursive: true, force: true }); process.exit(3)
+  }
+  check(bad.code === 1 && /--lane must be one of: sealed, broker/.test(bad.out),
+    'the tool refuses an unknown --lane and names the ones it takes')
+  check(!/Declared participation lane/.test(bad.out),
+    '  …and refuses before rendering a report, so a typo cannot look like a run')
+
+  const live = run([...base, '--lane', 'sealed'])
+  if (live === null || !live.out || live.out.length < 500) {
+    console.error(`agent_install_state: INCONCLUSIVE — --lane sealed produced ${live?.out?.length ?? 0} bytes`)
+    console.error('  This is NOT an all-clear: the tool was never observed reporting anything.')
+    rmSync(probeRoot, { recursive: true, force: true }); process.exit(3)
+  }
+  check(/\[ok \] Declared participation lane/.test(live.out) && /sealed —/.test(live.out),
+    'a live --lane sealed run reports the declaration as its own row')
+  check((live.out.match(/\[n\/a\]/g) || []).length === 7,
+    '  …and renders exactly seven n/a rows')
+  const undeclaredRun = run(base)
+  if (undeclaredRun === null || !undeclaredRun.out || undeclaredRun.out.length < 500) {
+    console.error('agent_install_state: INCONCLUSIVE — the undeclared control never produced a report')
+    rmSync(probeRoot, { recursive: true, force: true }); process.exit(3)
+  }
+  check(!/\[n\/a\]/.test(undeclaredRun.out) && /no --lane given/.test(undeclaredRun.out),
+    'BOTH DIRECTIONS — the same run with no --lane scopes nothing out, and says why')
+  rmSync(probeRoot, { recursive: true, force: true })
 }
 
 console.log(`\n${pass ? 'ALL PASS' : 'FAILURES ABOVE'}`)

--- a/tests/agent_startup.mjs
+++ b/tests/agent_startup.mjs
@@ -270,6 +270,34 @@ check(/Bunker pairing is not in place/.test(mixedLine), 'a MISSING piece beside 
 check(/Client transport key was never checked/.test(mixedLine),
   '  …and the unchecked one KEEPS its own state — all-or-nothing silenced this the moment the states mixed')
 
+// ── 5d. the check command names the lane it was checked under ───────────────────────────────
+console.log('\n5d. the remedy command carries the right lane')
+// The document tells the reader to settle its state with `connect-agent --check`. That command was
+// written with `--lane sealed` baked into the string, so a BROKER-lane agent following its own
+// onboarding document scoped out the rows it depends on — `applies` refusing to assume the cheaper
+// lane, arriving through the document instead of the flag.
+const remedies = doc => doc.split('\n').filter(l => l.includes('connect-agent --check'))
+const laneDoc = lane => startupDoc({ agent: 'oliver', pubkey: PUB,
+  report: { lane, rows: [{ key: 'bunker-uri', title: 'Bunker pairing', state: MISSING },
+    { key: 'profile', title: 'Published profile', state: UNKNOWN }] } })
+
+const broker = remedies(laneDoc('broker'))
+check(broker.length >= 2, 'the document prints the remedy command more than once, so one right and one wrong is possible')
+check(broker.every(l => /connect-agent --check --lane broker/.test(l)),
+  'a BROKER-lane report renders --lane broker in EVERY remedy line')
+check(!broker.some(l => /--lane sealed/.test(l)),
+  '  …and never the other lane — this rendered `--lane sealed` for a broker agent')
+const sealedDoc = remedies(laneDoc('sealed'))
+check(sealedDoc.every(l => /connect-agent --check --lane sealed/.test(l)),
+  'BOTH DIRECTIONS — a SEALED-lane report still renders --lane sealed, so the fix is not "drop the flag"')
+// Undeclared is not sealed — `installState` treats silence as "every row applies", and a document
+// that supplied the flag anyway would talk an undeclared agent into the permissive reading.
+const noLane = remedies(laneDoc(null))
+check(noLane.length >= 2 && noLane.every(l => !/--lane/.test(l)),
+  'an UNDECLARED lane prints no --lane at all — silence is not a declaration here either')
+check(remedies(laneDoc('brokr')).every(l => !/--lane/.test(l)),
+  'an unrecognised lane is DROPPED, not echoed — `installState` would refuse it, so printing it hands over a command that fails')
+
 // ── 6. The tool, not the function ───────────────────────────────────────────────────────────
 console.log('\n6. what connect-agent actually writes')
 // Everything above tests `startupDoc`, which is handed a pubkey. The tool is not, and that gap

--- a/tests/console_first_prompt.mjs
+++ b/tests/console_first_prompt.mjs
@@ -107,6 +107,14 @@ const MATRIX = [
   // class rather than those two instances. `writtenBy` is the third defect of this shape.
   ['every non-default parameter supplied at once', { briefPath: 'docs/OTHER_BRIEF.md',
     writtenBy: 'a fixture, deliberately,', report: { rows: rows({ 'admit-grant': PRESENT }) } }],
+  // `report.lane` renders the `--lane` flag on the remedy command (#515). It is a field on `report`
+  // rather than a parameter, so nothing above walks it, and the two copies inline their own lane
+  // list — the exact shape that drifts. All three branches, because a twin can agree on one.
+  ['a BROKER-lane report — the remedy names the other lane', { report: { lane: 'broker',
+    rows: rows({ 'bunker-uri': MISSING, profile: UNKNOWN }) } }],
+  ['a SEALED-lane report', { report: { lane: 'sealed', rows: rows({ 'bunker-uri': MISSING, profile: UNKNOWN }) } }],
+  ['an unrecognised lane — dropped, not echoed', { report: { lane: 'brokr',
+    rows: rows({ 'bunker-uri': MISSING, profile: UNKNOWN }) } }],
 ]
 
 for (const [what, extra] of MATRIX) {
@@ -122,6 +130,26 @@ for (const [what, extra] of MATRIX) {
 // Byte-identity is blind to a parameter BOTH copies ignore — two twins that dropped `briefPath`
 // agree perfectly. So each non-default parameter is also asserted to reach the output, in both
 // directions: the value appears, and the default it replaced does not.
+// The lane is the same blindness one layer in: two copies that both ignored `report.lane` agree
+// byte for byte. Each is asserted to render it, and to render the other branches differently — a
+// copy that hardcoded one lane passes the identity check and fails here.
+for (const [label, copy] of [['node', node], ['browser', web]]) {
+  const remedy = lane => (copy.startupDoc({ agent: 'Pi Agent', pubkey: PUB,
+    report: { lane, rows: rows({ 'bunker-uri': MISSING, profile: UNKNOWN }) } })
+    .split('\n').filter(l => l.includes('connect-agent --check')))
+  const broker = remedy('broker')
+  check(broker.length >= 2 && broker.every(l => l.includes('--lane broker')),
+    `${label}: a broker-lane report renders --lane broker in every remedy line`)
+  check(remedy('sealed').every(l => l.includes('--lane sealed')),
+    `${label}:   …and BOTH DIRECTIONS, a sealed-lane report renders --lane sealed`)
+  check(remedy(null).every(l => !l.includes('--lane')) && remedy('brokr').every(l => !l.includes('--lane')),
+    `${label}:   …and neither an undeclared nor an unrecognised lane prints a flag`)
+}
+// The lane names themselves, pinned. A stale list in the browser copy does not render a wrong
+// sentence — it drops a valid `--lane` flag, or prints one `installState` would refuse.
+check(Object.keys(web.LANES).sort().join(',') === Object.keys(nodeState.LANES).sort().join(','),
+  'the browser copy knows exactly the lanes `src/agent_install_state.mjs` does')
+
 for (const copy of [['node', node], ['browser', web]]) {
   const [label, mod] = copy
   const doc = mod.startupDoc({ agent: 'Pi Agent', briefPath: 'docs/OTHER_BRIEF.md', report: { rows: [] } })

--- a/tools/connect-agent.mjs
+++ b/tools/connect-agent.mjs
@@ -32,6 +32,12 @@
 // --channel-user <u> it (default `root`): the host is deployment state, and a stanza pointing
 //                    nowhere registers cleanly, lists as ✔ Connected, and reaches nobody (#472).
 //
+// --lane <l>         how this agent participates: `sealed` (seal to the bridge, authenticated by
+//                    signature, nothing on another box) or `broker` (an MCP server over ssh). The
+//                    two need different artifacts. UNDECLARED IS NOT SEALED — with no --lane every
+//                    row stays required, because the lane with fewer requirements is not the safe
+//                    default to assume (#513).
+//
 // --whoami <path>    the `nvoy_whoami` result captured from the session under test, compared
 //                    against --pubkey. This is the MCP path's EXPECT_PUBKEY (#338): registered is
 //                    not sole, and sole is not YOURS. Without it the binding reads UNCHECKED.
@@ -45,7 +51,7 @@ import { execFileSync } from 'node:child_process'
 import { existsSync, lstatSync, mkdirSync, readFileSync, statSync, writeFileSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { dirname, join } from 'node:path'
-import { boundIdentity, installState, renderState } from '../src/agent_install_state.mjs'
+import { LANES, boundIdentity, installState, renderState } from '../src/agent_install_state.mjs'
 import { exportTemplate, importTemplate } from '../src/agent_manifest_transfer.mjs'
 import { channelCommand, credentialPaths, credentialReport, registeredForm, sameVector } from '../src/channel_registration.mjs'
 import { RUNTIMES, channelStanza, cliRuntimes, exclusivityVerdict, foreignServers, isMine, registrationHelp, runtime } from '../src/mcp_runtimes.mjs'
@@ -71,6 +77,15 @@ const fromFile = flag('--from-file')
 // forced-command entry is seated under, and is a default because it is not deployment state.
 const channelHost = flag('--channel-host')
 const channelUser = flag('--channel-user') || 'root'
+// Allowlisted at the boundary like --pubkey and --channel. A typo must refuse here rather than
+// fall through to "unrecognised, so treat every row as required" — that behaviour is the correct
+// backstop inside installState, but silently demanding broker artifacts from someone who typed
+// `--lane sealled` is a confusing way to be right.
+const lane = flag('--lane').toLowerCase()
+if (has('--lane') && !Object.prototype.hasOwnProperty.call(LANES, lane)) {
+  die(`--lane must be one of: ${Object.keys(LANES).join(', ')}`)
+}
+const SEALED = lane === 'sealed'
 
 // Shape-check the two operator-pasted values HERE, at the boundary, before anything renders them
 // (#466 review §3). Both have a known shape, so an allowlist is available and an allowlist is
@@ -88,6 +103,14 @@ const obs = {}
 const see = (key, found, verified, note) => { obs[key] = { found, verified, note } }
 const did = []
 const warn = []
+
+// The declaration itself is a row, so an agent that never made one is visibly UNKNOWN rather than
+// silently defaulted. Verified: the flag was supplied and is a lane this build knows about, which
+// is the whole of what this row claims.
+see('lane', has('--lane') ? true : null, has('--lane'),
+  has('--lane')
+    ? `${lane} — ${LANES[lane]}`
+    : 'no --lane given, so every row stays required — an undeclared lane is not a sealed one')
 
 // ── Credentials. Observed, never created: the identity lives in a Bunker and the pairing is
 // copied from its UI by a human. This tool refuses to be the thing that invents either. ────────
@@ -254,7 +277,9 @@ see('state-dirs', dirsNow.length === DIRS.length, dirsNow.length === DIRS.length
 // minted — so a fresh agent finished with a correct stanza pointing at a private key that had never
 // been created, and the one working agent worked only because its pair was made by hand.
 const { keyPath, knownHostsPath } = credentialPaths(HERE)
-if (!existsSync(keyPath) && !CHECK && !STARTUP_ONLY) {
+// Not minted for a sealed-lane agent: it has no broker to present it to, and key material created
+// "just in case" is key material nobody is tracking.
+if (!existsSync(keyPath) && !CHECK && !STARTUP_ONLY && !SEALED) {
   mkdirSync(dirname(keyPath), { recursive: true, mode: 0o700 })
   execFileSync('ssh-keygen', ['-t', 'ed25519', '-N', '', '-C', `nvoy-mcp-channel ${name}`, '-f', keyPath], { stdio: 'ignore' })
   did.push(`generated ${keyPath}`)
@@ -465,7 +490,7 @@ if (bind.match === false) warn.push(`this session answers as ${bind.resolved.sli
 see('channel-answers', registered === true ? true : null, false, 'registered is not running — prove with an initialize + tools/list handshake')
 
 // ── Report ──────────────────────────────────────────────────────────────────────────────────
-const report = installState(obs)
+const report = installState(obs, { lane })
 if (did.length) { console.log(`\nchanged:`); for (const d of did) console.log(`  + ${d}`) }
 if (CHECK) console.log(`\n(--check: nothing was changed)`)
 console.log(`\n${name} — ${HERE}\n`)


### PR DESCRIPTION
Closes #513. **Fourth in the stack** — #506 → #509 → #514 → this. Review those first.

This is the one that was blocking the Pi walk.

## The failure

`connect-agent --check` on a fresh sealed-lane agent:

```
10 required pieces missing — this agent cannot run.
exit 1 (incomplete)
```

Two of the ten were the broker's — its host key, and the MCP registration that ssh's to it. But the first-principles review settled that the broker is an **alternative** transport, not a requirement: waggle already runs the sealed lane in both directions, and an agent on it authenticates by signature. The install-state model and the architecture disagreed, and the model was the one giving a wrong answer with confidence.

The startup document in #514 says, three sections up, that neither lane "needs an ssh account, a broker, or a key held on this machine". Then the checker it points the agent at demanded all three.

## What changed

A declared participation lane. Seven rows scope to `broker`; a `sealed` agent reports them `not-applicable`.

```
[ok ] Declared participation lane          — sealed — seal to the bridge, and the bridge seals back
[ ? ] Bunker pairing                     UNVERIFIED  — …
[n/a] The broker's host key              NOT-APPLICABLE  — not part of the sealed lane
[n/a] Registered as an MCP server        NOT-APPLICABLE  — not part of the sealed lane
…
4 present but unchecked, 4 not looked at — being unable to check is not the same as being fine.
Every remaining row is one this build never checks. 7 rows did not apply to the sealed lane and
were not checked — that is not the same as satisfied.

exit 3 (inconclusive — the best result this build can report)
```

**Exit 0 is still unreachable by construction (#492), and this does not change that.** It changes exit **1**. "The check now passes" is the summary a reader reaches for and it is not what happens — a sealed-lane agent reaches the ceiling, which is the honest answer.

## The two things the issue said not to get wrong

**`not-applicable` is never `present`.** Its own state, its own glyph, and the seven rows are still rendered rather than dropped — a scope the reader cannot see is a scope nobody can audit. The headline says how many were skipped and that skipped is not satisfied.

**Undeclared is not sealed.** With no `--lane`, every row stays required and the lane row itself reads UNKNOWN, so the report is inconclusive rather than permissive. An unrecognised name is not a declaration either — the tool refuses it and names the lanes it takes, before rendering anything.

Also: the sealed lane no longer mints a broker ssh key. Key material created just in case is key material nobody is tracking.

And the startup document's remedy line now reads `--check --lane sealed`, in both the runtime copy and the console twin, or it hands the agent the command that produced the wrong answer.

## Found while measuring

`String(['sealed'])` is `'sealed'`. Without an explicit `typeof === 'string'`, a single-element array declared a lane and scoped seven rows out. That was a test assertion failing, not reasoning — the same sweep is why the lookup is `hasOwnProperty` and not `in`, so `'toString'` cannot name a lane.

## Verification

Both directions on every claim that matters, because a scope that excuses a row is one line from a scope that excuses every row and both look like a green suite:

- a sealed-lane agent with its artifacts in place is not told it cannot run — **and** a broker-lane agent with no broker artifacts still is, naming all seven
- the *same* observations pass sealed and fail broker, so the lane is what differs, not the box
- live: `--lane sealed` renders exactly seven `n/a` rows — **and** the same run with no `--lane` renders none and says why
- the negative control on the box: sealed lane with the pairing removed still exits 1 and names it

11 mutations, no survivors. The two that would have mattered most are L2 (`applies` reduced to `!declared`, excusing every row) and L3 (undeclared defaulting to `sealed`).

Suite unchanged at 107 — this extends `agent_install_state`, which is where the model's tests already live.

## Review

**@My Dude** — this one changes what a gate requires, so it is substantive by the letter. The thing to push on: whether there is a path where `applies()` returns true for a row that should have been demanded. That is the failure that would ship an agent reading as installed while a credential it does need was never asked for.

Drafted with assistance from [Claude Code](https://claude.com/claude-code)