### PR TITLE
Pi is not a Raspberry Pi, and its MCP answer is that there is no MCP (#519)

### DIFF
--- a/src/mcp_runtimes.mjs
+++ b/src/mcp_runtimes.mjs
@@ -212,9 +212,47 @@ export const RUNTIMES = [
     config: '~/.gemini/settings.json',
     configKey: 'mcpServers',
   },
+  // THE RUNTIME WITH NO MCP (#519). Pi is the agent harness at pi.dev, not a board — and this repo
+  // read its own `generic` label as hardware while planning the #486 walk, which is why that label
+  // no longer says it.
+  //
+  // `kind: 'none'` exists because the other two kinds both end in "here is how you register the MCP
+  // server", and for Pi that answer is false. Its docs say there is no built-in MCP and say what to
+  // do instead: build CLI tools with READMEs, or write an extension. Rendering it as `file` would
+  // print an `mcpServers` stanza under a label, and a stanza under a label is an instruction —
+  // pointing an operator at a config file that does not exist, for a subsystem the runtime does not
+  // have. A registry that cannot say "no MCP here" says the wrong thing confidently instead.
+  //
+  // The participation surface is the two tools this repo already ships, which is not a downgrade:
+  // both authenticate by SIGNATURE through `loadNostrSigner`, so neither needs a broker, an ssh
+  // account or a seated key, and neither ever holds one.
+  {
+    id: 'pi',
+    label: 'Pi (pi.dev)',
+    kind: 'none',
+    // Same filename as Codex, DIFFERENT search path: Pi loads it from `~/.pi/agent/`, from parent
+    // directories, and from the current directory. `--startup` prints the path it wrote for exactly
+    // this reason — a file at the wrong one of those is a file nothing reads, and it looks identical
+    // to a file that was read.
+    startupFile: 'AGENTS.md',
+    instead: 'no MCP — Pi has none built in. Participation is the two CLI tools: ' +
+      '`tools/agent-inbox.mjs --watch` to listen, `tools/agent-send.mjs` to speak. ' +
+      'Both sign through `loadNostrSigner`, so a bunker-held identity works with no nsec anywhere.',
+    // "Point your runtime at this directory" is not actionable for a runtime with three search
+    // locations, and the failure it hides is silent: a file at the wrong one of them is a file
+    // nothing reads, and the session looks exactly like one that read it and ignored it. So say the
+    // three, and say which act puts the file in reach of each.
+    startupNote: 'Pi loads AGENTS.md from ~/.pi/agent/, from parent directories, and from the ' +
+      'current directory — so either start the session with this directory as its cwd, or place ' +
+      'the file in ~/.pi/agent/. A file in none of those is read by nothing, and looks identical ' +
+      'to one that was read.',
+  },
   {
     id: 'generic',
-    label: 'Any other MCP host (Raspberry Pi, headless, self-hosted)',
+    // Was "Raspberry Pi, headless, self-hosted". The board was an example of a headless MCP host and
+    // is still a fine one; the word is gone because in this repo Pi now names the harness above, and
+    // an operator picking a runtime by its label is the person that ambiguity costs.
+    label: 'Any other MCP host (headless, self-hosted)',
     kind: 'file',
     // AGENTS.md is the cross-tool convention; a host that reads something else is pointed at it
     // by hand, which is why --startup prints the path it wrote rather than assuming it was read.
@@ -275,7 +313,13 @@ export function stanzaJson(stanza) {
  * operator ends up typing a Claude Code command.
  */
 export function registrationHelp(stanza) {
-  return RUNTIMES.map(r => r.kind === 'cli'
-    ? { id: r.id, label: r.label, kind: 'cli', line: r.add(stanza) }
-    : { id: r.id, label: r.label, kind: 'file', config: r.config, json: stanzaJson(stanza) })
+  return RUNTIMES.map(r => {
+    if (r.kind === 'cli') return { id: r.id, label: r.label, kind: 'cli', line: r.add(stanza) }
+    // A runtime with no MCP gets neither a command nor a stanza — it gets told so, by name. It is
+    // still in the list rather than filtered out of it, because an operator scanning for their
+    // runtime and not finding it concludes the tool does not know about it and picks the nearest
+    // block, which is the `mcpServers` one this branch exists to keep them away from.
+    if (r.kind === 'none') return { id: r.id, label: r.label, kind: 'none', instead: r.instead }
+    return { id: r.id, label: r.label, kind: 'file', config: r.config, json: stanzaJson(stanza) }
+  })
 }

--- a/tests/agent_startup.mjs
+++ b/tests/agent_startup.mjs
@@ -140,7 +140,11 @@ check(RUNTIMES.every(r => typeof r.startupFile === 'string' && r.startupFile.end
 check(RUNTIMES.find(r => r.id === 'claude').startupFile === 'CLAUDE.md', 'Claude Code reads CLAUDE.md')
 check(RUNTIMES.find(r => r.id === 'codex').startupFile === 'AGENTS.md', 'Codex reads AGENTS.md')
 check(RUNTIMES.find(r => r.id === 'gemini').startupFile === 'GEMINI.md', 'Gemini reads GEMINI.md')
-check(RUNTIMES.find(r => r.id === 'generic').startupFile === 'AGENTS.md', 'a Pi or headless host gets AGENTS.md, the cross-tool convention')
+check(RUNTIMES.find(r => r.id === 'generic').startupFile === 'AGENTS.md', 'a headless host gets AGENTS.md, the cross-tool convention')
+// Pi (pi.dev) reads the same filename as Codex from a DIFFERENT set of directories — `~/.pi/agent/`,
+// parent directories, and the cwd. The filename agreeing is not the file being found, which is why
+// `--startup` prints the path it wrote instead of reporting that a runtime read it (#519).
+check(RUNTIMES.find(r => r.id === 'pi').startupFile === 'AGENTS.md', 'Pi reads AGENTS.md too')
 check(new Set(RUNTIMES.map(r => r.startupFile)).size >= 3,
   'and they are not all the same name — writing CLAUDE.md on a Codex box is a file nothing reads')
 

--- a/tests/mcp_runtimes.mjs
+++ b/tests/mcp_runtimes.mjs
@@ -188,7 +188,43 @@ const gemini = help.find(h => h.id === 'gemini')
 check(gemini.kind === 'file' && !gemini.line, 'gemini is file-configured and is given NO command line')
 check(gemini.config.includes('settings.json') && gemini.json.includes('mcpServers'), 'gemini gets a path and the stanza')
 const generic = help.find(h => h.id === 'generic')
-check(!!generic && /pi|headless/i.test(generic.label), `a host with no CLI at all is covered — ${generic.label.slice(0, 40)}…`)
+check(!!generic && /headless/i.test(generic.label), `a host with no CLI at all is covered — ${generic.label.slice(0, 40)}…`)
+
+// ── The runtime with no MCP (#519) ──────────────────────────────────────────────────────────
+// Pi is the agent harness at pi.dev, not a board. It has no built-in MCP, so the one thing this
+// block must never do for it is print an `mcpServers` stanza under its label — that is an
+// instruction pointing at a config file which does not exist, for a subsystem the runtime does not
+// have. The old `generic` label said "Raspberry Pi" and this repo read it as hardware while
+// planning the walk, which is how the wrong block gets picked in the first place.
+const pi = help.find(h => h.id === 'pi')
+check(!!pi && pi.kind === 'none', 'Pi is present and is neither a CLI nor a file-configured runtime')
+check(!pi.json && !pi.line && !pi.config,
+  '  …so it is given NO stanza, NO command line and NO config path — there is nothing to paste')
+check(/no MCP/i.test(pi.instead), '  …and it SAYS there is no MCP, rather than rendering an empty block')
+check(/agent-inbox\.mjs/.test(pi.instead) && /agent-send\.mjs/.test(pi.instead),
+  '  …and names both tools that ARE the participation surface — listen and speak, not one of them')
+check(runtime('pi')?.startupFile === 'AGENTS.md', 'Pi reads AGENTS.md — same filename as Codex, different search path')
+check(!fileRuntimes().some(r => r.id === 'pi') && !cliRuntimes().some(r => r.id === 'pi'),
+  '  …and neither runtime filter picks it up, so no caller renders it as one of those')
+
+// BOTH DIRECTIONS. "No runtime prints a stanza" would pass every assertion above and is the change
+// that silently breaks the other four. Every runtime that is not `none` must still get something
+// pasteable, and no label may name the board again.
+check(help.filter(h => h.kind !== 'none').every(h => h.line || h.json),
+  'BOTH DIRECTIONS — every other runtime still gets a command or a stanza')
+check(help.filter(h => h.kind === 'none').length === 1, '  …and exactly one runtime claims to have no MCP')
+check(RUNTIMES.every(r => !/raspberry/i.test(r.label)),
+  'no runtime label says Raspberry — in this repo "Pi" now names the harness, and an operator picks by label')
+// Where the file has to land. `--startup` writes into the agent root and tells the operator to
+// point the runtime at it, which is not one place for Pi: `~/.pi/agent/`, parent directories, and
+// the cwd. A file in none of the three is read by nothing and looks identical to one that was read.
+const note = runtime('pi').startupNote
+check(/~\/\.pi\/agent\//.test(note) && /parent director/i.test(note) && /current directory/.test(note),
+  'the Pi row names all three places Pi loads AGENTS.md from')
+check(/cwd|current directory/.test(note) && /~\/\.pi\/agent\//.test(note) && /place|start/.test(note),
+  '  …and names an act that puts the file in reach, not only the locations')
+check(RUNTIMES.filter(r => r.startupNote).length === 1,
+  '  …and it is carried on the row, so a second such runtime says it too rather than being special-cased')
 
 // SHELL QUOTING (#464 review). These lines are printed for the operator to paste, and the old
 // `.join(' ')` did not fail on a path with a space in it — it produced a DIFFERENT, valid command

--- a/tools/connect-agent.mjs
+++ b/tools/connect-agent.mjs
@@ -486,6 +486,10 @@ if (has('--stanza')) {
   for (const h of registrationHelp(stanza)) {
     console.log(`\n  ${h.label}`)
     if (h.kind === 'cli') console.log(`    ${h.line}`)
+    // Neither a command nor a stanza. Printed as prose because there is nothing to paste, and the
+    // absence has to be said out loud — a runtime listed with nothing under it reads as a block that
+    // failed to render, and the operator goes looking for the config file it did not print (#519).
+    else if (h.kind === 'none') console.log(`    ${h.instead}`)
     else console.log(`    ${h.config}\n` + h.json.split('\n').map(l => `    ${l}`).join('\n'))
   }
   console.log(`\n  This is an ssh call to the broker host, not a local server: the identity lives there.`)
@@ -537,6 +541,9 @@ if (has('--startup')) {
   }
   console.log(`  point ${rt.label} at ${HERE} so it reads this at session start — registering the MCP`)
   console.log(`  server does not make a runtime read a file next to it.`)
+  // Where a runtime looks, when "point it at this directory" is not one place. Only Pi carries this
+  // today; printed from the row rather than special-cased here, so a second such runtime says it too.
+  if (rt.startupNote) console.log(`  ${rt.startupNote}`)
 }
 // The ceiling on the exit line too, not only in the headline forty lines up. An operator reading
 // the last line for the verdict is the reason this tool prints one (#492).


### PR DESCRIPTION
Closes #519.

`RUNTIMES` knew four runtimes and none of them was Pi, the agent harness at https://pi.dev. The row an operator would reach for instead was labelled **"Any other MCP host (Raspberry Pi, headless, self-hosted)"** — read as hardware in this repo's own planning of the #486 walk.

Picking `generic` for a Pi session produced a fabricated instruction rather than a missing one. Every `kind: 'file'` runtime renders as a config path plus an `mcpServers` stanza, and **Pi has no built-in MCP**: its docs say so, and say to build CLI tools with READMEs or an extension instead. The block sent an operator to edit a file that does not exist, for a subsystem the runtime does not have.

`kind: 'none'` is the third answer the registry could not give. Live:

```
  Pi (pi.dev)
    no MCP — Pi has none built in. Participation is the two CLI tools:
    `tools/agent-inbox.mjs --watch` to listen, `tools/agent-send.mjs` to speak.
    Both sign through `loadNostrSigner`, so a bunker-held identity works with no nsec anywhere.

  Any other MCP host (headless, self-hosted)
    the host's own MCP config
    { "mcpServers": { … } }
```

The row stays in the printed list rather than being filtered out of it — an operator who does not find their runtime picks the nearest block, which is the `mcpServers` one this exists to keep them away from.

`startupNote` carries where the file has to land. "Point your runtime at this directory" is not actionable for a runtime with three search locations, and the failure it hides is silent:

```
$ node tools/connect-agent.mjs --name seated --root … --startup --runtime pi
startup file — Pi (pi.dev)
  wrote …/seated/AGENTS.md (mode 600)
  point Pi (pi.dev) at …/seated so it reads this at session start …
  Pi loads AGENTS.md from ~/.pi/agent/, from parent directories, and from the current
  directory — so either start the session with this directory as its cwd, or place the
  file in ~/.pi/agent/. A file in none of those is read by nothing, and looks identical
  to one that was read.
```

## Verification

Negative control: dropping the `none` branch so Pi falls through to the file renderer fails five assertions, and the restore is clean.

Both directions: `every runtime that is not none still gets a command or a stanza`, and `exactly one runtime claims to have no MCP`. Without those, "no runtime prints a stanza" passes every other assertion in the block.

107 suites rc=0, eslint 0 errors.

## What this does not claim

Whether a Pi session actually reads the AGENTS.md that `--startup` writes is a claim about a runtime this repo cannot observe. The tool prints the path and the search locations; a session reading it is proven by the #486 walk, not by the file existing.

@JAFairweather — docs-and-registry, no delivery path touched, but it changes what an operator is told to paste. Worth a read for the label change if nothing else.

Drafted with assistance from [Claude Code](https://claude.com/claude-code)