### PR TITLE
The startup document told the agent to run a command that does not exist (#522)

### DIFF
--- a/console/VERSION.json
+++ b/console/VERSION.json
@@ -1,3 +1,3 @@
 {
-  "build": "c478d5ef6ff8287cba196c78088e7342"
+  "build": "f2d7684aaf75c8181030c96775a4f29c"
 }

--- a/console/VERSION.json
+++ b/console/VERSION.json
@@ -1,3 +1,3 @@
 {
-  "build": "f2d7684aaf75c8181030c96775a4f29c"
+  "build": "f4c90110d9ffde85f0568fb1647b01cc"
 }

--- a/console/VERSION.json
+++ b/console/VERSION.json
@@ -1,3 +1,3 @@
 {
-  "build": "a1c61204c681e597c1b48eaa126e7577"
+  "build": "43c60808de5ee35877d2bb48583bfb06"
 }

--- a/console/VERSION.json
+++ b/console/VERSION.json
@@ -1,3 +1,3 @@
 {
-  "build": "f4c90110d9ffde85f0568fb1647b01cc"
+  "build": "a1c61204c681e597c1b48eaa126e7577"
 }

--- a/console/agent-startup.mjs
+++ b/console/agent-startup.mjs
@@ -123,8 +123,18 @@ export function startupDoc({ agent, pubkey, channel, bridge, runtimeLabel, brief
   // A name with a space is a real name here (#168), and it would split into two argv words. Quote
   // anything the tool's own --name pattern would not accept, rather than rendering a command whose
   // breakage depends on who is reading it.
-  const nameArg = /^[a-z0-9][a-z0-9._-]{1,63}$/.test(String(agent)) ? String(agent) : `'${String(agent).replace(/'/g, `'\\''`)}'`
-  const checkCmd = `node tools/connect-agent.mjs --name ${nameArg} --check${lane ? ` --lane ${lane}` : ''}`
+  // Twin of `src/agent_startup.mjs`. The predicate is inlined rather than imported because this file
+  // is served to a browser and imports nothing from `src/`; `tests/console_first_prompt.mjs` pins the
+  // two renderers to byte-identical output, so a drift in either copy fails there.
+  const normaliseName = s => String(s ?? '').toLowerCase()
+  const acceptableName = s => /^[a-z0-9][a-z0-9._-]{1,63}$/.test(normaliseName(s))
+  const checkCmd = acceptableName(agent)
+    ? `node tools/connect-agent.mjs --name ${normaliseName(agent)} --check${lane ? ` --lane ${lane}` : ''}`
+    : null
+  const nameRule = `\`--name\` takes a short stable id — lowercase, 2\u201364 characters, from ` +
+    `\`a-z0-9._-\` and starting with a letter or digit \u2014 and \`${String(agent)}\` is not one. ` +
+    `Settle the agent's id first; no command is printed here because the one that would be printed ` +
+    `would fail on that name.`
 
   // Only the rows an agent's own behaviour depends on. A wall of install state is a wall nobody
   // reads, and this file competes for the top of a context window.
@@ -269,8 +279,13 @@ export function startupDoc({ agent, pubkey, channel, bridge, runtimeLabel, brief
       : `${laneTitle(k)} is not in place`
     out.push('')
     out.push(`⚠ **Neither command works yet.** ${laneOpen.map(laneSays).join('; ')}.`)
-    out.push(`Settle that first with \`${checkCmd}\`; running either tool before then fails in a`)
-    out.push(`way that looks like the lane being down.`)
+    if (checkCmd) {
+      out.push(`Settle that first with \`${checkCmd}\`; running either tool before then fails in a`)
+      out.push(`way that looks like the lane being down.`)
+    } else {
+      out.push(`Running either tool before that is settled fails in a way that looks like the lane`)
+      out.push(`being down. ${nameRule}`)
+    }
   }
   out.push('')
   out.push('## Before you speak, know what is actually true')
@@ -281,8 +296,10 @@ export function startupDoc({ agent, pubkey, channel, bridge, runtimeLabel, brief
     const titles = neverChecked.map(k => row(k).title).join(', ')
     out.push(`- **${neverChecked.length} further artifact${neverChecked.length === 1 ? ' was' : 's were'} never checked` +
       ` — do not assume either way:** ${titles}.`)
-    out.push(`  Whatever wrote this could not observe ${neverChecked.length === 1 ? 'it' : 'them'};` +
-      ` run \`${checkCmd}\` on the agent's own machine to settle ${neverChecked.length === 1 ? 'it' : 'them'}.`)
+    out.push(`  Whatever wrote this could not observe ${neverChecked.length === 1 ? 'it' : 'them'}.` +
+      (checkCmd
+        ? ` Run \`${checkCmd}\` on the agent's own machine to settle ${neverChecked.length === 1 ? 'it' : 'them'}.`
+        : ` ${nameRule}`))
   }
   out.push('')
   if (open.length) {

--- a/console/agent-startup.mjs
+++ b/console/agent-startup.mjs
@@ -112,8 +112,19 @@ export function startupDoc({ agent, pubkey, channel, bridge, runtimeLabel, brief
   // flag. Undeclared renders no flag at all, for the same reason `installState` treats undeclared
   // as "every row applies": absent is not sealed. An unknown name is dropped rather than echoed,
   // because a command printed with a lane `installState` would reject is a command that fails.
+  //
+  // It is rendered RUNNABLE, which it was not: `connect-agent --check --lane sealed` is not a
+  // command — there is no `bin` entry and nothing puts it on PATH, so it exits 127 — and it omits
+  // the `--name` the tool cannot run without. Correcting only the path is not enough, and neither
+  // failure is the sharp one: the usage line the tool printed back did not list `--lane`, so an
+  // agent that followed the document was told, in effect, that the document was stale (#522). The
+  // two tools named a few lines above render as `node tools/…`; this one now matches them.
   const lane = Object.prototype.hasOwnProperty.call(LANES, String(report?.lane)) ? String(report.lane) : null
-  const checkCmd = `connect-agent --check${lane ? ` --lane ${lane}` : ''}`
+  // A name with a space is a real name here (#168), and it would split into two argv words. Quote
+  // anything the tool's own --name pattern would not accept, rather than rendering a command whose
+  // breakage depends on who is reading it.
+  const nameArg = /^[a-z0-9][a-z0-9._-]{1,63}$/.test(String(agent)) ? String(agent) : `'${String(agent).replace(/'/g, `'\\''`)}'`
+  const checkCmd = `node tools/connect-agent.mjs --name ${nameArg} --check${lane ? ` --lane ${lane}` : ''}`
 
   // Only the rows an agent's own behaviour depends on. A wall of install state is a wall nobody
   // reads, and this file competes for the top of a context window.

--- a/console/agent-startup.mjs
+++ b/console/agent-startup.mjs
@@ -120,9 +120,6 @@ export function startupDoc({ agent, pubkey, channel, bridge, runtimeLabel, brief
   // agent that followed the document was told, in effect, that the document was stale (#522). The
   // two tools named a few lines above render as `node tools/…`; this one now matches them.
   const lane = Object.prototype.hasOwnProperty.call(LANES, String(report?.lane)) ? String(report.lane) : null
-  // A name with a space is a real name here (#168), and it would split into two argv words. Quote
-  // anything the tool's own --name pattern would not accept, rather than rendering a command whose
-  // breakage depends on who is reading it.
   // Twin of `src/agent_startup.mjs`. The predicate is inlined rather than imported because this file
   // is served to a browser and imports nothing from `src/`; `tests/console_first_prompt.mjs` pins the
   // two renderers to byte-identical output, so a drift in either copy fails there.

--- a/console/build-id.mjs
+++ b/console/build-id.mjs
@@ -2,4 +2,4 @@
 //
 // The id of the console build this module graph belongs to. A page compares it against
 // console/VERSION.json, fetched with no-store, to detect a stale cached graph (#418).
-export const CONSOLE_BUILD_ID = 'f4c90110d9ffde85f0568fb1647b01cc'
+export const CONSOLE_BUILD_ID = 'a1c61204c681e597c1b48eaa126e7577'

--- a/console/build-id.mjs
+++ b/console/build-id.mjs
@@ -2,4 +2,4 @@
 //
 // The id of the console build this module graph belongs to. A page compares it against
 // console/VERSION.json, fetched with no-store, to detect a stale cached graph (#418).
-export const CONSOLE_BUILD_ID = 'a1c61204c681e597c1b48eaa126e7577'
+export const CONSOLE_BUILD_ID = '43c60808de5ee35877d2bb48583bfb06'

--- a/console/build-id.mjs
+++ b/console/build-id.mjs
@@ -2,4 +2,4 @@
 //
 // The id of the console build this module graph belongs to. A page compares it against
 // console/VERSION.json, fetched with no-store, to detect a stale cached graph (#418).
-export const CONSOLE_BUILD_ID = 'f2d7684aaf75c8181030c96775a4f29c'
+export const CONSOLE_BUILD_ID = 'f4c90110d9ffde85f0568fb1647b01cc'

--- a/console/build-id.mjs
+++ b/console/build-id.mjs
@@ -2,4 +2,4 @@
 //
 // The id of the console build this module graph belongs to. A page compares it against
 // console/VERSION.json, fetched with no-store, to detect a stale cached graph (#418).
-export const CONSOLE_BUILD_ID = 'c478d5ef6ff8287cba196c78088e7342'
+export const CONSOLE_BUILD_ID = 'f2d7684aaf75c8181030c96775a4f29c'

--- a/console/connect.html
+++ b/console/connect.html
@@ -537,7 +537,7 @@ $('sign').addEventListener('click', async () => {
 // are `connect-agent --check`'s to answer.
 function renderHandoff(allLanded, proven) {
   const name = $('agent-name').value.trim() || 'agent'
-  const unseen = (key, title) => ({ key, title, state: UNKNOWN, note: 'not observable from the console — run `connect-agent --check` on the agent' })
+  const unseen = (key, title) => ({ key, title, state: UNKNOWN, note: 'not observable from the console — only a --check run on the machine the agent runs on can answer it' })
   const report = { rows: [
     { key: 'admit-grant', title: 'Admitted to the channel',
       state: allLanded ? PRESENT : MISSING,

--- a/src/agent_startup.mjs
+++ b/src/agent_startup.mjs
@@ -28,6 +28,7 @@
 //      An agent that believes it is reachable and is not will report the wall as broken, and that
 //      exact confusion has cost this project a day more than once.
 import { ARTIFACTS, LANES, MISSING, PRESENT, UNKNOWN, UNVERIFIED } from './agent_install_state.mjs'
+import { acceptableName, normaliseName } from './connect_flags.mjs'
 
 // Anything that looks like a credential. Checked against the rendered text, not against the inputs,
 // because the failure that matters is what reaches the file.
@@ -107,11 +108,31 @@ export function startupDoc({ agent, pubkey, channel, bridge, runtimeLabel, brief
   // agent that followed the document was told, in effect, that the document was stale (#522). The
   // two tools named a few lines above render as `node tools/…`; this one now matches them.
   const lane = Object.prototype.hasOwnProperty.call(LANES, String(report?.lane)) ? String(report.lane) : null
-  // A name with a space is a real name here (#168), and it would split into two argv words. Quote
-  // anything the tool's own --name pattern would not accept, rather than rendering a command whose
-  // breakage depends on who is reading it.
-  const nameArg = /^[a-z0-9][a-z0-9._-]{1,63}$/.test(String(agent)) ? String(agent) : `'${String(agent).replace(/'/g, `'\\''`)}'`
-  const checkCmd = `node tools/connect-agent.mjs --name ${nameArg} --check${lane ? ` --lane ${lane}` : ''}`
+  // A name with a space is a real name here (#168) — and QUOTING IT IS THE WRONG FIX, which is what
+  // this line used to do. Quoting buys the command a clean parse and nothing else: `--name` is
+  // lowercased and matched against the pattern, so a name that needed quoting to survive argv
+  // splitting is a name the tool then refuses. The failure quoting prevents is not the failure that
+  // occurs (#523 review).
+  //
+  // The predicate comes from `connect_flags.mjs` rather than being copied here. A copy of it lived
+  // on this line and already disagreed with the tool on day one — it omitted the `.toLowerCase()`,
+  // so `Oliver` was quoted by the renderer and accepted by the tool. Two copies of one predicate,
+  // disagreeing immediately, inside the change whose thesis is that copies drift.
+  //
+  // An unacceptable name renders NO command at all. Rule 2 is that nothing unproven is stated as
+  // fact, and a command that exits 1 on the name it was rendered with is a fact the document does
+  // not have. The reader is told what to settle instead — which is what the operator who typed
+  // `Pi Dog` needed and did not get.
+  const checkCmd = acceptableName(agent)
+    ? `node tools/connect-agent.mjs --name ${normaliseName(agent)} --check${lane ? ` --lane ${lane}` : ''}`
+    : null
+  // What is said INSTEAD of a command, when the name would be refused. It names the rule and the
+  // offending name, because "settle your name" without either is an instruction the reader cannot
+  // act on — and being unable to act on it is how `Pi Dog` became a pasted command that exited 1.
+  const nameRule = `\`--name\` takes a short stable id — lowercase, 2\u201364 characters, from ` +
+    `\`a-z0-9._-\` and starting with a letter or digit \u2014 and \`${String(agent)}\` is not one. ` +
+    `Settle the agent's id first; no command is printed here because the one that would be printed ` +
+    `would fail on that name.`
 
   // Only the rows an agent's own behaviour depends on. A wall of install state is a wall nobody
   // reads, and this file competes for the top of a context window.
@@ -256,8 +277,13 @@ export function startupDoc({ agent, pubkey, channel, bridge, runtimeLabel, brief
       : `${laneTitle(k)} is not in place`
     out.push('')
     out.push(`⚠ **Neither command works yet.** ${laneOpen.map(laneSays).join('; ')}.`)
-    out.push(`Settle that first with \`${checkCmd}\`; running either tool before then fails in a`)
-    out.push(`way that looks like the lane being down.`)
+    if (checkCmd) {
+      out.push(`Settle that first with \`${checkCmd}\`; running either tool before then fails in a`)
+      out.push(`way that looks like the lane being down.`)
+    } else {
+      out.push(`Running either tool before that is settled fails in a way that looks like the lane`)
+      out.push(`being down. ${nameRule}`)
+    }
   }
   out.push('')
   out.push('## Before you speak, know what is actually true')
@@ -268,8 +294,10 @@ export function startupDoc({ agent, pubkey, channel, bridge, runtimeLabel, brief
     const titles = neverChecked.map(k => row(k).title).join(', ')
     out.push(`- **${neverChecked.length} further artifact${neverChecked.length === 1 ? ' was' : 's were'} never checked` +
       ` — do not assume either way:** ${titles}.`)
-    out.push(`  Whatever wrote this could not observe ${neverChecked.length === 1 ? 'it' : 'them'};` +
-      ` run \`${checkCmd}\` on the agent's own machine to settle ${neverChecked.length === 1 ? 'it' : 'them'}.`)
+    out.push(`  Whatever wrote this could not observe ${neverChecked.length === 1 ? 'it' : 'them'}.` +
+      (checkCmd
+        ? ` Run \`${checkCmd}\` on the agent's own machine to settle ${neverChecked.length === 1 ? 'it' : 'them'}.`
+        : ` ${nameRule}`))
   }
   out.push('')
   if (open.length) {

--- a/src/agent_startup.mjs
+++ b/src/agent_startup.mjs
@@ -99,8 +99,19 @@ export function startupDoc({ agent, pubkey, channel, bridge, runtimeLabel, brief
   // flag. Undeclared renders no flag at all, for the same reason `installState` treats undeclared
   // as "every row applies": absent is not sealed. An unknown name is dropped rather than echoed,
   // because a command printed with a lane `installState` would reject is a command that fails.
+  //
+  // It is rendered RUNNABLE, which it was not: `connect-agent --check --lane sealed` is not a
+  // command — there is no `bin` entry and nothing puts it on PATH, so it exits 127 — and it omits
+  // the `--name` the tool cannot run without. Correcting only the path is not enough, and neither
+  // failure is the sharp one: the usage line the tool printed back did not list `--lane`, so an
+  // agent that followed the document was told, in effect, that the document was stale (#522). The
+  // two tools named a few lines above render as `node tools/…`; this one now matches them.
   const lane = Object.prototype.hasOwnProperty.call(LANES, String(report?.lane)) ? String(report.lane) : null
-  const checkCmd = `connect-agent --check${lane ? ` --lane ${lane}` : ''}`
+  // A name with a space is a real name here (#168), and it would split into two argv words. Quote
+  // anything the tool's own --name pattern would not accept, rather than rendering a command whose
+  // breakage depends on who is reading it.
+  const nameArg = /^[a-z0-9][a-z0-9._-]{1,63}$/.test(String(agent)) ? String(agent) : `'${String(agent).replace(/'/g, `'\\''`)}'`
+  const checkCmd = `node tools/connect-agent.mjs --name ${nameArg} --check${lane ? ` --lane ${lane}` : ''}`
 
   // Only the rows an agent's own behaviour depends on. A wall of install state is a wall nobody
   // reads, and this file competes for the top of a context window.

--- a/src/connect_flags.mjs
+++ b/src/connect_flags.mjs
@@ -42,6 +42,21 @@ const KNOWN = new Set(FLAGS.map(f => f.flag))
 /** Is this a flag the tool declares? Used to refuse reading one that is not. */
 export const knownFlag = n => KNOWN.has(n)
 
+/**
+ * The `--name` predicate, exported so there is ONE of it.
+ *
+ * This module exists because a literal drifted from what the tool parses. The first cut of it then
+ * hand-copied the name pattern into `src/agent_startup.mjs`, and the two disagreed on day one — the
+ * renderer's copy omitted the `.toLowerCase()`, so `--name Oliver` was quoted by the renderer and
+ * accepted by the tool. Two copies of one predicate, disagreeing immediately, inside the change
+ * whose thesis is that copies drift (#523 review).
+ *
+ * `normaliseName` is half the predicate and must be applied before it: the tool lowercases before
+ * matching, so a renderer that tests the raw string answers a different question than the tool.
+ */
+export const normaliseName = s => String(s ?? '').toLowerCase()
+export const acceptableName = s => /^[a-z0-9][a-z0-9._-]{1,63}$/.test(normaliseName(s))
+
 /** One token as it appears in usage: `--name <short-stable-id>`, or `[--check]` when optional. */
 const token = f => {
   const body = f.value ? `${f.flag} <${f.value}>` : f.flag
@@ -57,7 +72,12 @@ const token = f => {
  */
 export function usageLine(width = 96) {
   const lines = []
-  let cur = 'usage: connect-agent'
+  // `node tools/connect-agent.mjs`, not `connect-agent`. The whole premise of #522 is that
+  // `connect-agent` is not a command — there is no bin entry and nothing puts it on PATH — so a
+  // usage line opening with it sends the reader to the exact 127 this change removed from the
+  // startup document. A refusal that explains itself incorrectly is worse than one that says
+  // nothing, and this was the one message left still doing it (#523 review, must-fix).
+  let cur = 'usage: node tools/connect-agent.mjs'
   for (const f of FLAGS) {
     const t = token(f)
     if (cur.length + 1 + t.length > width) { lines.push(cur); cur = '       ' + t } else { cur += ' ' + t }

--- a/src/connect_flags.mjs
+++ b/src/connect_flags.mjs
@@ -1,0 +1,67 @@
+// connect_flags.mjs — every flag `tools/connect-agent.mjs` reads, declared in one place (#522).
+//
+// The usage line used to be a literal, and it had drifted to five of nineteen flags. That is not a
+// tidiness problem, because of what the missing ones are used for:
+//
+//   The startup document tells an agent to settle its install with `--lane sealed`. The agent runs
+//   it, the tool dies on the `--name` the document omitted, and the usage line it prints back does
+//   not list `--lane` at all. So the message the agent acts on argues that the document is stale
+//   and the flag unsupported. Both were wrong, and the agent has no way to tell.
+//
+// A refusal that explains itself incorrectly is worse than one that says nothing, because it sends
+// the reader somewhere. Hence the catalogue: `usageLine` renders from it, and `knownFlag` lets the
+// tool refuse to read a flag that is not declared here. A flag added without a line in this table
+// then fails at first use, loudly, instead of going missing from a message months later.
+//
+// `value: null` means the flag is a bare switch — `has('--check')`, no argument follows it.
+
+export const FLAGS = Object.freeze([
+  { flag: '--name', value: 'short-stable-id', required: true, what: 'which agent — names the directory under --root' },
+  { flag: '--check', value: null, what: 'report install state and change nothing' },
+  { flag: '--lane', value: 'sealed|broker', what: 'scope the check to one participation lane; undeclared means every row applies' },
+  { flag: '--root', value: 'dir', what: 'where agent directories live (default ~/.nvoy/desktop)' },
+  { flag: '--pubkey', value: '64-hex', what: 'the identity this install must resolve to' },
+  { flag: '--owner', value: '64-hex', what: 'the owner key that granted admission' },
+  { flag: '--whoami', value: 'path', what: 'a captured nvoy_whoami result, compared against --pubkey' },
+  { flag: '--from', value: 'instance', what: 'mirror an existing agent manifest' },
+  { flag: '--from-file', value: 'path', what: 'mirror from an exported manifest file' },
+  { flag: '--export', value: null, what: 'write a portable manifest instead of checking' },
+  { flag: '--out', value: 'path', what: 'where --export or --startup writes' },
+  { flag: '--print', value: null, what: 'print to stdout rather than writing a file' },
+  { flag: '--startup', value: null, what: "render the runtime's startup document" },
+  { flag: '--runtime', value: 'id', what: 'which runtime the startup file and stanza are for' },
+  { flag: '--stanza', value: null, what: 'print the channel registration for each runtime' },
+  { flag: '--bridge', value: '64-hex', what: "waggle's own key, for the speak command in the startup document" },
+  { flag: '--channel', value: 'uuid', what: 'the destination channel, for the same' },
+  { flag: '--channel-host', value: 'host', what: 'the channel host a registration stanza points at' },
+  { flag: '--channel-user', value: 'user', what: 'the account the channel transport authenticates as' },
+])
+
+const KNOWN = new Set(FLAGS.map(f => f.flag))
+
+/** Is this a flag the tool declares? Used to refuse reading one that is not. */
+export const knownFlag = n => KNOWN.has(n)
+
+/** One token as it appears in usage: `--name <short-stable-id>`, or `[--check]` when optional. */
+const token = f => {
+  const body = f.value ? `${f.flag} <${f.value}>` : f.flag
+  return f.required ? body : `[${body}]`
+}
+
+/**
+ * The usage line, rendered from the catalogue so it cannot drift from what the tool reads.
+ *
+ * Wrapped rather than run out to one 400-column line, because a usage message that a terminal
+ * folds at an arbitrary point is one nobody reads to the end of — and the flag the reader is
+ * looking for is as likely to be past the fold as before it.
+ */
+export function usageLine(width = 96) {
+  const lines = []
+  let cur = 'usage: connect-agent'
+  for (const f of FLAGS) {
+    const t = token(f)
+    if (cur.length + 1 + t.length > width) { lines.push(cur); cur = '       ' + t } else { cur += ' ' + t }
+  }
+  lines.push(cur)
+  return lines.join('\n')
+}

--- a/tests/agent_startup.mjs
+++ b/tests/agent_startup.mjs
@@ -17,7 +17,7 @@ import { fileURLToPath } from 'node:url'
 import { MISSING, PRESENT, UNKNOWN, installState } from '../src/agent_install_state.mjs'
 import { secretInText, startupDoc } from '../src/agent_startup.mjs'
 import { RUNTIMES } from '../src/mcp_runtimes.mjs'
-import { FLAGS, knownFlag, usageLine } from '../src/connect_flags.mjs'
+import { FLAGS, acceptableName, knownFlag, normaliseName, usageLine } from '../src/connect_flags.mjs'
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..')
 let pass = 0, fail = 0
@@ -332,6 +332,64 @@ let bogusRc = 0
 try { execFileSync('/bin/sh', ['-c', 'connect-agent --check'], { cwd: ROOT, stdio: 'pipe' }) } catch (e) { bogusRc = e.status }
 check(bogusRc === 127, 'POSITIVE CONTROL — the OLD rendering still exits 127 here, so the probe can tell the difference')
 rmSync(remedyRoot, { recursive: true, force: true })
+
+console.log('\n5f. the name in the rendered command is one --name accepts')
+// This line used to QUOTE a name it could not use, which buys a clean argv split and nothing else:
+// `--name` is lowercased and matched against a pattern, so a name that needed quoting to survive
+// splitting is a name the tool then refuses. The operator who named an agent `Pi Dog` pasted the
+// rendered command and got exit 1 and a usage line (#523 review).
+const nameDoc = agent => startupDoc({ agent, pubkey: PUB,
+  report: { lane: 'sealed', rows: [{ key: 'bunker-uri', title: 'Bunker pairing', state: MISSING },
+    { key: 'profile', title: 'Published profile', state: UNKNOWN }] } })
+
+const okName = remedies(nameDoc('oliver'))
+check(okName.length >= 2 && okName.every(l => /--name oliver\b/.test(l)),
+  'BOTH DIRECTIONS — a name the tool ACCEPTS still renders a command, in every remedy line')
+// The exact disagreement the hand-copied predicate had on day one: it omitted `.toLowerCase()`, so
+// `Oliver` was quoted by the renderer and accepted by the tool. One predicate now, so both lower.
+const upper = remedies(nameDoc('Oliver'))
+check(upper.length >= 2 && upper.every(l => /--name oliver\b/.test(l) && !/--name ['"]/.test(l)),
+  'a name that only needed LOWERCASING is lowercased and rendered bare, not quoted')
+
+const badDoc = nameDoc('Pi Dog')
+check(remedies(badDoc).length === 0,
+  'a name the tool REFUSES renders no command at all — the document does not state a fact it does not have')
+// `--name` still appears, inside the rule the document states; what must not appear is an ARGUMENT
+// after it — a quoted one is the old behaviour and a bare one would split into two argv words.
+check(!/--name\s/.test(badDoc), '…and --name is never given an argument, quoted or bare')
+check(badDoc.includes('Pi Dog') && /Settle the agent's id first/.test(badDoc),
+  'it names the offending name and what to settle — "settle your name" with neither is not actionable')
+check(/lowercase, 2–64 characters/.test(badDoc) && /a-z0-9\._-/.test(badDoc),
+  '…and states the rule, so the reader can pick a name that will work rather than guess again')
+// NEGATIVE CONTROL on the block above: a document that simply went silent would pass every
+// "no command" assertion. The two sections that carry the remedy must still be present and say why.
+check(/Neither command works yet/.test(badDoc) && /never checked/.test(badDoc),
+  'NEGATIVE CONTROL — the refusing document still renders both sections; it withholds the command, not the warning')
+
+// The renderer and the tool must AGREE, and the only way to know is to drive the tool. Ten fixtures,
+// both verdicts represented, run through the real argv path — spaces and all, hence execFileSync
+// with an array rather than a shell string.
+const nameRoot = mkdtempSync(join(tmpdir(), 'wb-name-'))
+const toolTakes = n => {
+  try {
+    execFileSync(process.execPath, [join(ROOT, 'tools', 'connect-agent.mjs'), '--name', n,
+      '--check', '--root', nameRoot], { cwd: ROOT, encoding: 'utf8', stdio: 'pipe' })
+    return true
+  } catch (e) { return !/usage:/.test(`${e.stdout || ''}${e.stderr || ''}`) }
+}
+const NAME_FIXTURES = ['oliver', 'Oliver', 'pi-dog', 'Pi Dog', 'mc-claude', 'my.dude_1',
+  'a', '@dennis', 'Dennis', 'has/slash']
+let agreed = 0
+for (const n of NAME_FIXTURES) {
+  const r = acceptableName(n), t = toolTakes(n)
+  check(r === t, `renderer and tool agree on ${JSON.stringify(n)} — both ${r ? 'accept' : 'refuse'}`)
+  if (r === t) agreed++
+}
+check(NAME_FIXTURES.some(acceptableName) && !NAME_FIXTURES.every(acceptableName),
+  `POSITIVE CONTROL — the fixture set exercises BOTH verdicts (${agreed}/${NAME_FIXTURES.length} agreed), so agreement is not "it refuses everything"`)
+check(normaliseName('Pi Dog') === 'pi dog' && !acceptableName('pi dog'),
+  'normalising is not accepting — lowercasing a name with a space does not make it a name')
+rmSync(nameRoot, { recursive: true, force: true })
 
 // The usage line is the message an agent acts on when it gets the call wrong, and it had drifted to
 // five of nineteen flags — omitting every flag #513, #514 and #519 added. Rendered from the

--- a/tests/agent_startup.mjs
+++ b/tests/agent_startup.mjs
@@ -10,13 +10,14 @@
 //      the wall as broken — that exact confusion has cost this project a day more than once.
 import { strict as assert } from 'node:assert'
 import { execFileSync } from 'node:child_process'
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { MISSING, PRESENT, UNKNOWN, installState } from '../src/agent_install_state.mjs'
 import { secretInText, startupDoc } from '../src/agent_startup.mjs'
 import { RUNTIMES } from '../src/mcp_runtimes.mjs'
+import { FLAGS, knownFlag, usageLine } from '../src/connect_flags.mjs'
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..')
 let pass = 0, fail = 0
@@ -276,19 +277,22 @@ console.log('\n5d. the remedy command carries the right lane')
 // written with `--lane sealed` baked into the string, so a BROKER-lane agent following its own
 // onboarding document scoped out the rows it depends on — `applies` refusing to assume the cheaper
 // lane, arriving through the document instead of the flag.
-const remedies = doc => doc.split('\n').filter(l => l.includes('connect-agent --check'))
+// `--check`, not just the tool name: the document also names `tools/connect-agent.mjs --startup` as
+// its own provenance, and that line is not a remedy. A filter that swept it in would assert the
+// lane flag against a line that has no business carrying one.
+const remedies = doc => doc.split('\n').filter(l => l.includes('tools/connect-agent.mjs') && l.includes('--check'))
 const laneDoc = lane => startupDoc({ agent: 'oliver', pubkey: PUB,
   report: { lane, rows: [{ key: 'bunker-uri', title: 'Bunker pairing', state: MISSING },
     { key: 'profile', title: 'Published profile', state: UNKNOWN }] } })
 
 const broker = remedies(laneDoc('broker'))
 check(broker.length >= 2, 'the document prints the remedy command more than once, so one right and one wrong is possible')
-check(broker.every(l => /connect-agent --check --lane broker/.test(l)),
+check(broker.every(l => /--check --lane broker/.test(l)),
   'a BROKER-lane report renders --lane broker in EVERY remedy line')
 check(!broker.some(l => /--lane sealed/.test(l)),
   '  …and never the other lane — this rendered `--lane sealed` for a broker agent')
 const sealedDoc = remedies(laneDoc('sealed'))
-check(sealedDoc.every(l => /connect-agent --check --lane sealed/.test(l)),
+check(sealedDoc.every(l => /--check --lane sealed/.test(l)),
   'BOTH DIRECTIONS — a SEALED-lane report still renders --lane sealed, so the fix is not "drop the flag"')
 // Undeclared is not sealed — `installState` treats silence as "every row applies", and a document
 // that supplied the flag anyway would talk an undeclared agent into the permissive reading.
@@ -297,6 +301,49 @@ check(noLane.length >= 2 && noLane.every(l => !/--lane/.test(l)),
   'an UNDECLARED lane prints no --lane at all — silence is not a declaration here either')
 check(remedies(laneDoc('brokr')).every(l => !/--lane/.test(l)),
   'an unrecognised lane is DROPPED, not echoed — `installState` would refuse it, so printing it hands over a command that fails')
+
+console.log('\n5e. the remedy command is one that RUNS')
+// Every assertion above is about the text of the command, and the text was right while the command
+// was not: `connect-agent --check --lane sealed` is not on PATH (exit 127) and omits the --name the
+// tool requires. Asserting the property means running it, not grepping it (#522).
+const cmdOf = doc => {
+  const m = doc.match(/`(node tools\/connect-agent\.mjs[^`]*)`/)
+  return m ? m[1] : null
+}
+const sealedCmd = cmdOf(laneDoc('sealed'))
+check(sealedCmd !== null, 'the remedy renders as `node tools/…`, the same form as the two tools named beside it')
+check(/--name \S+/.test(sealedCmd || ''), '…and carries --name, which the tool cannot run without')
+
+// Drive it. Exit 127 is "no such command", exit 1 with a usage line is "you called it wrong"; both
+// were what the old string produced, and neither is what a remedy may do.
+const remedyRoot = mkdtempSync(join(tmpdir(), 'wb-remedy-'))
+let remedyRc = -1, remedyOut = ''
+try {
+  execFileSync('/bin/sh', ['-c', `${sealedCmd} --root ${remedyRoot}`], { cwd: ROOT, encoding: 'utf8', stdio: 'pipe' })
+  remedyRc = 0
+} catch (e) { remedyRc = e.status; remedyOut = `${e.stdout || ''}${e.stderr || ''}` }
+check(remedyRc !== 127, `the documented command EXISTS — it exited 127, command-not-found, until #522 (rc=${remedyRc})`)
+check(!/usage:/.test(remedyOut), 'and it is not a usage error — the tool understood every flag the document told the agent to pass')
+check(/Declared participation lane/.test(remedyOut) && /sealed/.test(remedyOut),
+  '…and it did the thing it was documented to do: reported install state, scoped to the declared lane')
+// POSITIVE CONTROL on the probe itself. If `execFileSync` silently succeeded on anything, the three
+// checks above would pass for a command that does nothing.
+let bogusRc = 0
+try { execFileSync('/bin/sh', ['-c', 'connect-agent --check'], { cwd: ROOT, stdio: 'pipe' }) } catch (e) { bogusRc = e.status }
+check(bogusRc === 127, 'POSITIVE CONTROL — the OLD rendering still exits 127 here, so the probe can tell the difference')
+rmSync(remedyRoot, { recursive: true, force: true })
+
+// The usage line is the message an agent acts on when it gets the call wrong, and it had drifted to
+// five of nineteen flags — omitting every flag #513, #514 and #519 added. Rendered from the
+// catalogue now, so this asserts the catalogue and the tool agree rather than re-checking a literal.
+const usage = usageLine()
+for (const f of FLAGS) check(usage.includes(f.flag), `usage names ${f.flag}`)
+const readsFlags = [...readFileSync(join(ROOT, 'tools', 'connect-agent.mjs'), 'utf8')
+  .matchAll(/(?:flag|has)\('(--[a-z-]+)'\)/g)].map(m => m[1])
+check(readsFlags.length > 0, 'the source scan found flags at all — a scan that matches nothing reports everything clean')
+const undeclared = [...new Set(readsFlags)].filter(f => !knownFlag(f))
+check(undeclared.length === 0, `every flag the tool reads is declared${undeclared.length ? ` — undeclared: ${undeclared.join(' ')}` : ''}`)
+check(!knownFlag('--not-a-flag'), 'NEGATIVE CONTROL — knownFlag says no to a name that is not in the catalogue')
 
 // ── 6. The tool, not the function ───────────────────────────────────────────────────────────
 console.log('\n6. what connect-agent actually writes')

--- a/tests/agent_startup.mjs
+++ b/tests/agent_startup.mjs
@@ -395,6 +395,10 @@ rmSync(nameRoot, { recursive: true, force: true })
 // five of nineteen flags — omitting every flag #513, #514 and #519 added. Rendered from the
 // catalogue now, so this asserts the catalogue and the tool agree rather than re-checking a literal.
 const usage = usageLine()
+// The flag loop below asserts every flag NAME and never the program name, so the line could have
+// read `usage: connect-agent` — the exact 127 this change removes — and stayed green (#523 review).
+check(usage.startsWith('usage: node tools/connect-agent.mjs'),
+  'the usage line names a command that RUNS — `connect-agent` alone is the 127 this change removed')
 for (const f of FLAGS) check(usage.includes(f.flag), `usage names ${f.flag}`)
 const readsFlags = [...readFileSync(join(ROOT, 'tools', 'connect-agent.mjs'), 'utf8')
   .matchAll(/(?:flag|has)\('(--[a-z-]+)'\)/g)].map(m => m[1])

--- a/tests/console_first_prompt.mjs
+++ b/tests/console_first_prompt.mjs
@@ -115,6 +115,16 @@ const MATRIX = [
   ['a SEALED-lane report', { report: { lane: 'sealed', rows: rows({ 'bunker-uri': MISSING, profile: UNKNOWN }) } }],
   ['an unrecognised lane — dropped, not echoed', { report: { lane: 'brokr',
     rows: rows({ 'bunker-uri': MISSING, profile: UNKNOWN }) } }],
+  // The NAME is on this axis, because it is the one input the two copies judge with SEPARATE code:
+  // the browser cannot import `src/connect_flags.mjs`, so it inlines the predicate. Every other
+  // fixture here is `pi-agent` — already lowercase, already acceptable — and two predicates cannot
+  // disagree about it, so the byte comparison was blind to exactly the drift it exists to catch
+  // (#523 review). These two cover both halves and both verdicts: drop `.toLowerCase()` from the
+  // console copy and `Oliver` diverges; drop the pattern and `Pi Dog` does.
+  ['a name that only NORMALISES — Oliver, a command exists once it is lowercased',
+    { agent: 'Oliver', report: { rows: rows({ 'bunker-uri': MISSING, profile: UNKNOWN }) } }],
+  ['a name that is REFUSED — Pi Dog, no command exists for it at all',
+    { agent: 'Pi Dog', report: { rows: rows({ 'bunker-uri': MISSING, profile: UNKNOWN }) } }],
 ]
 
 for (const [what, extra] of MATRIX) {

--- a/tests/console_first_prompt.mjs
+++ b/tests/console_first_prompt.mjs
@@ -119,7 +119,7 @@ const MATRIX = [
 
 for (const [what, extra] of MATRIX) {
   const args = {
-    agent: 'Pi Agent', pubkey: PUB, channel: CHAN,
+    agent: 'pi-agent', pubkey: PUB, channel: CHAN,
     runtimeLabel: 'Any other MCP host (Raspberry Pi, headless, self-hosted)', ...extra,
   }
   if (what.startsWith('no runtime label')) { delete args.runtimeLabel; delete args.channel; delete args.pubkey }
@@ -134,7 +134,7 @@ for (const [what, extra] of MATRIX) {
 // byte for byte. Each is asserted to render it, and to render the other branches differently — a
 // copy that hardcoded one lane passes the identity check and fails here.
 for (const [label, copy] of [['node', node], ['browser', web]]) {
-  const remedy = lane => (copy.startupDoc({ agent: 'Pi Agent', pubkey: PUB,
+  const remedy = lane => (copy.startupDoc({ agent: 'pi-agent', pubkey: PUB,
     report: { lane, rows: rows({ 'bunker-uri': MISSING, profile: UNKNOWN }) } })
     .split('\n').filter(l => l.includes('connect-agent.mjs') && l.includes('--check')))
   const broker = remedy('broker')
@@ -145,6 +145,21 @@ for (const [label, copy] of [['node', node], ['browser', web]]) {
   check(remedy(null).every(l => !l.includes('--lane')) && remedy('brokr').every(l => !l.includes('--lane')),
     `${label}:   …and neither an undeclared nor an unrecognised lane prints a flag`)
 }
+// BOTH DIRECTIONS on the name predicate, across the twin. The fixtures above use `pi-agent`, an id
+// the tool accepts; the console's `agent-name` field is free text, so a DISPLAY name reaches this
+// renderer in production and it must withhold the command rather than print one that exits 1 — the
+// failure an operator who typed `Pi Dog` actually hit (#523 review). Both copies, because a browser
+// copy that kept the old quoting would render a failing command to the only producer that can.
+for (const [label, copy] of [['node', node], ['browser', web]]) {
+  const doc = copy.startupDoc({ agent: 'Pi Dog', pubkey: PUB,
+    report: { lane: 'sealed', rows: rows({ 'bunker-uri': MISSING, profile: UNKNOWN }) } })
+  check(!/--name\s/.test(doc), `${label}: a DISPLAY name renders no --name argument at all`)
+  check(doc.includes('Pi Dog') && /Settle the agent's id first/.test(doc),
+    `${label}:   …and names the offending name and the rule instead`)
+  check(/Neither command works yet/.test(doc) && /never checked/.test(doc),
+    `${label}:   NEGATIVE CONTROL — it withholds the command, not the surrounding warning`)
+}
+
 // The lane names themselves, pinned. A stale list in the browser copy does not render a wrong
 // sentence — it drops a valid `--lane` flag, or prints one `installState` would refuse.
 check(Object.keys(web.LANES).sort().join(',') === Object.keys(nodeState.LANES).sort().join(','),
@@ -152,7 +167,7 @@ check(Object.keys(web.LANES).sort().join(',') === Object.keys(nodeState.LANES).s
 
 for (const copy of [['node', node], ['browser', web]]) {
   const [label, mod] = copy
-  const doc = mod.startupDoc({ agent: 'Pi Agent', briefPath: 'docs/OTHER_BRIEF.md', report: { rows: [] } })
+  const doc = mod.startupDoc({ agent: 'pi-agent', briefPath: 'docs/OTHER_BRIEF.md', report: { rows: [] } })
   check(doc.includes('docs/OTHER_BRIEF.md') && !doc.includes('docs/AGENT_BRIEF.md'),
     `the ${label} copy renders the briefPath it was GIVEN, and drops the default it replaced`)
   let threw = null
@@ -162,15 +177,15 @@ for (const copy of [['node', node], ['browser', web]]) {
 
 // A property the byte-comparison alone cannot state: that the comparison is comparing something.
 // Two functions that both returned '' would pass every assertion above.
-const sample = node.startupDoc({ agent: 'Pi Agent', pubkey: PUB, report: { rows: rows({ 'admit-grant': PRESENT }) } })
-check(sample.length > 1500 && sample.includes('# Pi Agent — you are a participant'),
+const sample = node.startupDoc({ agent: 'pi-agent', pubkey: PUB, report: { rows: rows({ 'admit-grant': PRESENT }) } })
+check(sample.length > 1500 && sample.includes('# pi-agent — you are a participant'),
   `SIZE FLOOR — the rendered body is real (${sample.length} bytes, headed by the agent's name)`)
 check(sample.includes('You do not get read'),
   'and carries the wall paragraph, the one claim an agent most often reports as a defect')
 
 // The names differ between copies, so a stale twin cannot pass by echoing a constant.
-const other = web.startupDoc({ agent: 'Second Agent', pubkey: 'b'.repeat(64), report: { rows: [] } })
-check(other.includes('# Second Agent —') && !other.includes('Pi Agent'),
+const other = web.startupDoc({ agent: 'second-agent', pubkey: 'b'.repeat(64), report: { rows: [] } })
+check(other.includes('# second-agent —') && !other.includes('pi-agent'),
   'the twin renders the name it was given, not a baked-in one')
 
 // ------------------------------------------------------------------------------------------
@@ -178,7 +193,7 @@ console.log('\n4. NEGATIVE CONTROL — a report carrying a credential refuses, i
 // #490 asks for a control that FIRES. A `bunker://` reaches the document through a row NOTE, which
 // is machine-generated text from a tool this file does not control — the exact path the sweep was
 // put there to cover.
-const poisoned = { agent: 'Pi Agent', pubkey: PUB, report: { rows: [
+const poisoned = { agent: 'pi-agent', pubkey: PUB, report: { rows: [
   { key: 'bunker-uri', title: 'bunker-uri', state: MISSING, note: 'try bunker://deadbeef?relay=wss://r' },
 ] } }
 let nodeErr = null, webErr = null
@@ -192,7 +207,7 @@ check(String(nodeErr).includes('a bunker:// pairing URI'),
 
 // The bound, stated rather than implied. `src/agent_startup.mjs` says this in its header; a suite
 // that left it out would read as if the sweep were a guarantee of "nothing secret".
-const rawKeyRow = { agent: 'Pi Agent', pubkey: PUB, report: { rows: [
+const rawKeyRow = { agent: 'pi-agent', pubkey: PUB, report: { rows: [
   { key: 'admit-grant', title: 'admit-grant', state: MISSING, note: `seeded from ${'f'.repeat(64)}` },
 ] } }
 const rendered = web.startupDoc(rawKeyRow)
@@ -207,13 +222,13 @@ console.log('\n5. provenance — the document says who actually wrote it')
 // that nothing unproven is stated as fact. `--startup` writes one; the console pastes one; each
 // has to name itself, because the agent's first instinct on reading "regenerate it" is to run the
 // named command, and the wrong name sends it to a machine nothing observed.
-const provenance = args => node.startupDoc({ agent: 'Pi Agent', report: { rows: [] }, ...args }).split('\n')[2]
+const provenance = args => node.startupDoc({ agent: 'pi-agent', report: { rows: [] }, ...args }).split('\n')[2]
 check(provenance({}) === "Written by `tools/connect-agent.mjs --startup` from this agent's own install state.",
   'the DEFAULT is unchanged — the tool\'s output is byte-for-byte what it was before #490')
 check(provenance({ writtenBy: 'the waggle console, at connect time,' })
     === "Written by the waggle console, at connect time, from this agent's own install state.",
   'and an override reads as a sentence, not as a slot with a command dropped into it')
-check(provenance({ writtenBy: 'X' }) === web.startupDoc({ agent: 'Pi Agent', report: { rows: [] }, writtenBy: 'X' }).split('\n')[2],
+check(provenance({ writtenBy: 'X' }) === web.startupDoc({ agent: 'pi-agent', report: { rows: [] }, writtenBy: 'X' }).split('\n')[2],
   'both copies carry the override — the twin did not keep the old hard-coded line')
 
 // ------------------------------------------------------------------------------------------
@@ -257,7 +272,7 @@ console.log('\n7. the never-checked rows collapse, and the alarm stays variable'
 // perfect install. A constant is not a signal; an alarm that always fires and one that never fires
 // fail identically. Both directions are asserted below, because "collapse the rows" done wrong is
 // indistinguishable from "stop reporting them".
-const consoleShape = node.startupDoc({ agent: 'Pi Agent', pubkey: PUB, report: { rows: rows({
+const consoleShape = node.startupDoc({ agent: 'pi-agent', pubkey: PUB, report: { rows: rows({
   'bunker-uri': UNKNOWN, 'bunker-client': UNKNOWN, 'signer-identity': UNKNOWN, 'dm-relays': UNKNOWN,
   'admit-grant': PRESENT, 'mcp-registration': UNKNOWN, 'mcp-exclusive': UNKNOWN,
   'mcp-identity': UNKNOWN, profile: UNKNOWN }) } })
@@ -293,7 +308,7 @@ check(!/Every artifact above is confirmed/.test(consoleShape),
 // POSITIVE CONTROL, the direction that matters most. Same shape, one row that was actually looked
 // at and found MISSING: the alarm must fire. Without this the assertions above are satisfied by a
 // document that has simply stopped warning about anything.
-const realNegative = node.startupDoc({ agent: 'Pi Agent', pubkey: PUB, report: { rows: rows({
+const realNegative = node.startupDoc({ agent: 'pi-agent', pubkey: PUB, report: { rows: rows({
   'bunker-uri': UNKNOWN, 'bunker-client': UNKNOWN, 'signer-identity': UNKNOWN, 'dm-relays': MISSING,
   'admit-grant': PRESENT, 'mcp-registration': UNKNOWN, 'mcp-exclusive': UNKNOWN,
   'mcp-identity': UNKNOWN, profile: UNKNOWN }) } })

--- a/tests/console_first_prompt.mjs
+++ b/tests/console_first_prompt.mjs
@@ -136,7 +136,7 @@ for (const [what, extra] of MATRIX) {
 for (const [label, copy] of [['node', node], ['browser', web]]) {
   const remedy = lane => (copy.startupDoc({ agent: 'Pi Agent', pubkey: PUB,
     report: { lane, rows: rows({ 'bunker-uri': MISSING, profile: UNKNOWN }) } })
-    .split('\n').filter(l => l.includes('connect-agent --check')))
+    .split('\n').filter(l => l.includes('connect-agent.mjs') && l.includes('--check')))
   const broker = remedy('broker')
   check(broker.length >= 2 && broker.every(l => l.includes('--lane broker')),
     `${label}: a broker-lane report renders --lane broker in every remedy line`)
@@ -279,7 +279,7 @@ check(consoleShape.split('\n').filter(l => /further artifacts? w(as|ere) never c
 const beforeYouSpeak = (consoleShape.split('## Before you speak, know what is actually true')[1] || '').split('\n## ')[0]
 check(beforeYouSpeak.trim().length > 0,
   '  …and the section being measured is actually present — an empty slice passes every filter below')
-check((beforeYouSpeak.match(/connect-agent --check/g) || []).length === 1,
+check((beforeYouSpeak.match(/connect-agent\.mjs [^`]*--check/g) || []).length === 1,
   '  …and the remedy once, not eight times')
 // Nothing may be lost in the collapse: an agent has to be able to name what was not checked.
 for (const k of ['bunker-uri', 'dm-relays', 'mcp-identity', 'profile']) {
@@ -307,7 +307,7 @@ check(realNegative.includes('nothing can reach you'),
 // The size claim the change was made for, measured rather than asserted in prose. The block those
 // eight rows occupy was ~1,100 bytes; the collapsed form is the two lines between the observed row
 // and the blank line that follows. A ceiling here fails if someone re-expands it one row at a time.
-const block = beforeYouSpeak.split('\n').filter(l => /never checked|connect-agent --check/.test(l)).join('\n')
+const block = beforeYouSpeak.split('\n').filter(l => /never checked|connect-agent\.mjs [^`]*--check/.test(l)).join('\n')
 check(block.length > 0 && block.length < 400,
   `NEVER-CHECKED BLOCK is ${block.length} bytes, down from ~1,100 — and non-empty, so this is measuring something`)
 

--- a/tools/connect-agent.mjs
+++ b/tools/connect-agent.mjs
@@ -54,17 +54,23 @@ import { dirname, join } from 'node:path'
 import { LANES, boundIdentity, installState, renderState } from '../src/agent_install_state.mjs'
 import { exportTemplate, importTemplate } from '../src/agent_manifest_transfer.mjs'
 import { channelCommand, credentialPaths, credentialReport, registeredForm, sameVector } from '../src/channel_registration.mjs'
+import { knownFlag, usageLine } from '../src/connect_flags.mjs'
 import { RUNTIMES, channelStanza, cliRuntimes, exclusivityVerdict, foreignServers, isMine, registrationHelp, runtime } from '../src/mcp_runtimes.mjs'
 import { startupDoc } from '../src/agent_startup.mjs'
 
-const flag = n => { const i = process.argv.indexOf(n); return i < 0 ? '' : (process.argv[i + 1] || '') }
-const has = n => process.argv.includes(n)
+// Reading a flag that is not in the catalogue throws rather than quietly returning ''. That is what
+// keeps `usageLine` from drifting away from what this tool actually parses — it had drifted to five
+// of nineteen, and the flags missing from it were the ones the startup document tells an agent to
+// run (#522).
+const declared = n => { if (!knownFlag(n)) throw new Error(`connect-agent: reads ${n}, which is not declared in src/connect_flags.mjs`); return n }
+const flag = n => { const i = process.argv.indexOf(declared(n)); return i < 0 ? '' : (process.argv[i + 1] || '') }
+const has = n => process.argv.includes(declared(n))
 const die = m => { console.error(`connect-agent: ${m}`); process.exit(1) }
 const HEX64 = /^[0-9a-f]{64}$/i
 const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
 const name = flag('--name').toLowerCase()
-if (!/^[a-z0-9][a-z0-9._-]{1,63}$/.test(name)) die('usage: --name <short-stable-id> [--pubkey <64-hex>] [--owner <64-hex>] [--from <instance>] [--check]')
+if (!/^[a-z0-9][a-z0-9._-]{1,63}$/.test(name)) die(usageLine())
 const CHECK = has('--check')
 const ROOT = flag('--root') || join(homedir(), '.nvoy', 'desktop')
 const HERE = join(ROOT, name)

--- a/tools/connect-agent.mjs
+++ b/tools/connect-agent.mjs
@@ -54,7 +54,7 @@ import { dirname, join } from 'node:path'
 import { LANES, boundIdentity, installState, renderState } from '../src/agent_install_state.mjs'
 import { exportTemplate, importTemplate } from '../src/agent_manifest_transfer.mjs'
 import { channelCommand, credentialPaths, credentialReport, registeredForm, sameVector } from '../src/channel_registration.mjs'
-import { knownFlag, usageLine } from '../src/connect_flags.mjs'
+import { acceptableName, knownFlag, normaliseName, usageLine } from '../src/connect_flags.mjs'
 import { RUNTIMES, channelStanza, cliRuntimes, exclusivityVerdict, foreignServers, isMine, registrationHelp, runtime } from '../src/mcp_runtimes.mjs'
 import { startupDoc } from '../src/agent_startup.mjs'
 
@@ -69,8 +69,10 @@ const die = m => { console.error(`connect-agent: ${m}`); process.exit(1) }
 const HEX64 = /^[0-9a-f]{64}$/i
 const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
-const name = flag('--name').toLowerCase()
-if (!/^[a-z0-9][a-z0-9._-]{1,63}$/.test(name)) die(usageLine())
+// One predicate, from `connect_flags.mjs`. The pattern used to be a literal here and a second
+// literal in `src/agent_startup.mjs`, and the two already disagreed (#523 review).
+const name = normaliseName(flag('--name'))
+if (!acceptableName(name)) die(usageLine())
 const CHECK = has('--check')
 const ROOT = flag('--root') || join(homedir(), '.nvoy', 'desktop')
 const HERE = join(ROOT, name)


### PR DESCRIPTION
Closes #522. Found walking `main` at `dd1d6828` in a clean room — fresh clone, isolated `HOME`.

## What was wrong

The startup document #514 added ends by telling the agent to settle its install state. That command does not run:

```
$ connect-agent --check --lane sealed
sh: connect-agent: command not found          rc=127

$ node tools/connect-agent.mjs --check --lane sealed
connect-agent: usage: --name <short-stable-id> [--pubkey <64-hex>] …    rc=1
```

No `bin` entry, nothing on PATH, and the remedy omits the `--name` the tool requires. The two tools named a few lines above it in the same document render as `node tools/agent-inbox.mjs` and `node tools/agent-send.mjs`, so the document was already inconsistent with itself and the inconsistent one was the one that failed.

**The sharp part is the usage line.** It listed five flags and did not include `--lane`. An agent that followed the document, ran the command, and read the error was told in effect that the document was stale and the flag unsupported. Both were wrong. A refusal that explains itself incorrectly is worse than one that says nothing, because it sends the reader somewhere — same lesson as the invisible-character refusal in CLAUDE.md.

The literal had drifted to **five of nineteen** flags, missing every flag #513, #514 and #519 added.

## The fix

`src/connect_flags.mjs` holds the flag catalogue. `usageLine()` renders from it, and `flag`/`has` throw on a name not declared there — so a flag added without a table entry fails at first use rather than going missing from a message months later.

The remedy renders as `node tools/connect-agent.mjs --name <name> --check [--lane <lane>]`, shell-quoted when the name would not survive argv splitting. A name with a space is a real name here (#168); rendering it unquoted produces a command whose breakage depends on who is reading it.

## Why the suites did not see it, and what now does

`tests/agent_startup.mjs` asserted the rendered line contains `--lane sealed`. It did. The text was right and the thing the text referred to was not there.

Block 5e drives the command instead of grepping it:

```
ok   the documented command EXISTS — it exited 127, command-not-found, until #522 (rc=1)
ok   and it is not a usage error — the tool understood every flag the document told the agent to pass
ok   …and it did the thing it was documented to do: reported install state, scoped to the declared lane
ok   POSITIVE CONTROL — the OLD rendering still exits 127 here, so the probe can tell the difference
ok   every flag the tool reads is declared
ok   NEGATIVE CONTROL — knownFlag says no to a name that is not in the catalogue
```

The positive control matters: without it, three checks would pass for a probe that silently succeeds on anything.

**Negative controls run, both restored after:**
- Restoring the old `connect-agent --check` rendering fails six assertions, including the 127 check reporting `rc=127`.
- Removing `--lane` from the catalogue makes the tool throw `reads --lane, which is not declared in src/connect_flags.mjs` at first use, and fails the source-scan assertion by name.

108 suites rc=0, eslint 0 errors. `node tools/gen-console-build-id.mjs` re-run.

## Reviewer

**@My Dude** — `tools/connect-agent.mjs` handles credential paths, so this is not docs-exempt. The two things worth an adversarial read: whether `declared()` throwing is right for a tool an operator runs interactively (it converts a typo in the *source* into a crash, not a typo on the command line — an unknown flag typed by the operator is still ignored, which is the pre-existing behaviour and arguably the next issue), and whether the shell-quoting belongs in the document renderer at all rather than the document telling the reader to use the name the tool would accept.

Drafted with assistance from [Claude Code](https://claude.com/claude-code)
