### PR TITLE
The MCP rows need an MCP, so a Pi is not blocked by a hazard its runtime cannot have

### DIFF
--- a/console/VERSION.json
+++ b/console/VERSION.json
@@ -1,3 +1,3 @@
 {
-  "build": "3dcf7a739a16fe78affc574ec01ca22c"
+  "build": "e39d935608eefb89095dae6bcd386280"
 }

--- a/console/VERSION.json
+++ b/console/VERSION.json
@@ -1,3 +1,3 @@
 {
-  "build": "a08ec8f3f4ebb81111f81ff45c9b504c"
+  "build": "3dcf7a739a16fe78affc574ec01ca22c"
 }

--- a/console/agent-startup.mjs
+++ b/console/agent-startup.mjs
@@ -154,7 +154,7 @@ export function startupDoc({ agent, pubkey, channel, bridge, runtimeLabel, runti
   // change removes, and this time with no caveat to explain it, because a path WAS supplied
   // (#525 review). So anything going into a COMMAND is shell-quoted when it needs to be. Prose
   // paths are not: a quoted `docs/…` reference reads as a defect, and nobody pastes it to a shell.
-  const shq = s => (/^[A-Za-z0-9_@%+=:,./-]+$/.test(s) ? s : `'${String(s).replace(/'/g, `'\''`)}'`)
+  const shq = s => (/^[A-Za-z0-9_@%+=:,./-]+$/.test(s) ? s : `'${String(s).replace(/'/g, `'\\''`)}'`)
   const cmd = p => shq(at(p))
   // `--runtime` for the same reason as `--lane`, and it is not cosmetic either: the MCP rows are
   // scoped by whether the runtime HAS an MCP client, and absent means they apply (#526). So a Pi

--- a/console/agent-startup.mjs
+++ b/console/agent-startup.mjs
@@ -42,6 +42,11 @@ const LANE_TITLES = {
 // agent is told to run and cannot.
 export const LANES = Object.freeze({ sealed: true, broker: true })
 
+// The runtime ids, inlined for the same reason and exported so `tests/console_first_prompt.mjs` can
+// pin them against `RUNTIMES` in `src/mcp_runtimes.mjs`. Same failure mode as a stale lane list: a
+// `--runtime` flag the node side rejects, in a command an agent is told to run.
+export const RUNTIME_IDS = Object.freeze(['claude', 'codex', 'gemini', 'pi', 'generic'])
+
 // Anything that looks like a credential. Checked against the rendered text, not against the inputs,
 // because the failure that matters is what reaches the file.
 const HEX64 = /^[0-9a-f]{64}$/
@@ -93,7 +98,7 @@ const SAYS = {
  * works. `facts` carries the public identifiers. Everything else here is invariant role text, and
  * every line of it is a rule an agent has broken confidently at least once.
  */
-export function startupDoc({ agent, pubkey, channel, bridge, runtimeLabel, repo, briefPath = 'docs/AGENT_BRIEF.md', report,
+export function startupDoc({ agent, pubkey, channel, bridge, runtimeLabel, runtimeId, repo, briefPath = 'docs/AGENT_BRIEF.md', report,
   writtenBy = '`tools/connect-agent.mjs --startup`' }) {
   if (!agent) throw new Error('startupDoc needs the agent name')
   const rows = report?.rows || []
@@ -149,10 +154,15 @@ export function startupDoc({ agent, pubkey, channel, bridge, runtimeLabel, repo,
   // change removes, and this time with no caveat to explain it, because a path WAS supplied
   // (#525 review). So anything going into a COMMAND is shell-quoted when it needs to be. Prose
   // paths are not: a quoted `docs/…` reference reads as a defect, and nobody pastes it to a shell.
-  const shq = s => (/^[A-Za-z0-9_@%+=:,./-]+$/.test(s) ? s : `'${String(s).replace(/'/g, `'\\''`)}'`)
+  const shq = s => (/^[A-Za-z0-9_@%+=:,./-]+$/.test(s) ? s : `'${String(s).replace(/'/g, `'\''`)}'`)
   const cmd = p => shq(at(p))
+  // `--runtime` for the same reason as `--lane`, and it is not cosmetic either: the MCP rows are
+  // scoped by whether the runtime HAS an MCP client, and absent means they apply (#526). So a Pi
+  // whose document omits the flag runs a check that blocks it on a hazard its runtime cannot have.
+  // An unknown id is dropped rather than echoed, because the tool would die on it.
+  const rtArg = RUNTIME_IDS.includes(String(runtimeId)) ? String(runtimeId) : null
   const checkCmd = acceptableName(agent)
-    ? `node ${cmd('tools/connect-agent.mjs')} --name ${normaliseName(agent)} --check${lane ? ` --lane ${lane}` : ''}`
+    ? `node ${cmd('tools/connect-agent.mjs')} --name ${normaliseName(agent)} --check${lane ? ` --lane ${lane}` : ''}${rtArg ? ` --runtime ${rtArg}` : ''}`
     : null
   const nameRule = `\`--name\` takes a short stable id — lowercase, 2\u201364 characters, from ` +
     `\`a-z0-9._-\` and starting with a letter or digit \u2014 and \`${String(agent)}\` is not one. ` +

--- a/console/build-id.mjs
+++ b/console/build-id.mjs
@@ -2,4 +2,4 @@
 //
 // The id of the console build this module graph belongs to. A page compares it against
 // console/VERSION.json, fetched with no-store, to detect a stale cached graph (#418).
-export const CONSOLE_BUILD_ID = 'a08ec8f3f4ebb81111f81ff45c9b504c'
+export const CONSOLE_BUILD_ID = '3dcf7a739a16fe78affc574ec01ca22c'

--- a/console/build-id.mjs
+++ b/console/build-id.mjs
@@ -2,4 +2,4 @@
 //
 // The id of the console build this module graph belongs to. A page compares it against
 // console/VERSION.json, fetched with no-store, to detect a stale cached graph (#418).
-export const CONSOLE_BUILD_ID = '3dcf7a739a16fe78affc574ec01ca22c'
+export const CONSOLE_BUILD_ID = 'e39d935608eefb89095dae6bcd386280'

--- a/src/agent_install_state.mjs
+++ b/src/agent_install_state.mjs
@@ -108,7 +108,19 @@ export const ARTIFACTS = [
   // `nvoy-<name>`, and a sealed-lane agent has no such server — so every nvoy server in that
   // session counts as foreign. The one lane with nothing of its own to compare against was the
   // lane the row was scoped out of.
-  { key: 'mcp-exclusive', title: 'No other nvoy server registered', blocking: true,
+  // `needsMcp`, and deliberately NOT `lanes: ['broker']` — the paragraph above is right that the
+  // hazard belongs to the session rather than to the transport, and scoping this by lane would undo
+  // a decision already taken once. The axis that bounds the hazard is whether the session has an
+  // MCP client at all. Pi's runtime is `kind: 'none'` (#520): no config to register a server in and
+  // nothing in the session that could call one. A hazard that requires an MCP client cannot reach a
+  // runtime that has none, and this was the row standing between a correctly-seated Pi and a clean
+  // check.
+  //
+  // Measured, not reasoned about: it failed for EVERY agent seated on this machine, and for
+  // mc-claude — which participates daily — it was the only failing row, so its verdict was "this
+  // agent cannot run" (#526). A blocking row that every agent fails at once cannot separate a broken
+  // install from a working one, which is the single thing this module exists to do.
+  { key: 'mcp-exclusive', title: 'No other nvoy server registered', blocking: true, needsMcp: true,
     why: 'Registered is not sole. A generically-named server alongside carries the tools that sign, bound to somebody else.' },
   // ── Broker-lane only, all six. Every one of them exists to reach an ssh channel on another
   // box, and a sealed-lane agent reaches the bridge by signature instead. Two of these were the
@@ -121,7 +133,7 @@ export const ARTIFACTS = [
     why: "StrictHostKeyChecking refuses an unknown host, so without this the channel will not connect. It is the broker's host key and comes from the broker doctor on that box — it cannot be minted here, and this tool will never write one." },
   { key: 'channel-authorized', title: 'The public half is seated on the broker', blocking: true, lanes: ['broker'],
     why: "The other box's authorized_keys, under its forced command. Nothing on this machine can see it, so it is UNKNOWN until an operator confirms it — never assumed from the key existing here." },
-  { key: 'mcp-registration', title: 'Registered as an MCP server', blocking: true, lanes: ['broker'],
+  { key: 'mcp-registration', title: 'Registered as an MCP server', blocking: true, lanes: ['broker'], needsMcp: true,
     why: 'How a new session becomes this agent. Needs the instance root set explicitly; the default path does not exist here.' },
   // #338. Sole is not YOURS. An agent was handed a session whose attached server answered `whoami`
   // with a different agent's identity — it would have read that identity's sealed inbox and posted
@@ -129,7 +141,7 @@ export const ARTIFACTS = [
   // perfectly. The Bunker path has refused this since day one via EXPECT_PUBKEY. The MCP path had
   // no equivalent, so the same class of defect moved one layer up from Pair to Bind and found no
   // guard there.
-  { key: 'mcp-identity', title: 'The server answers as THIS agent', blocking: true, lanes: ['broker'],
+  { key: 'mcp-identity', title: 'The server answers as THIS agent', blocking: true, lanes: ['broker'], needsMcp: true,
     why: 'Registered is not sole, and sole is not yours. Proven by whoami equalling the minted key — never by the registration existing. That proof is a saved capture, not a live signer: it has no freshness and no binding to the session under test, so it passes forever once taken (#462).' },
   { key: 'channel-answers', title: 'Channel server answers', blocking: true, lanes: ['broker'],
     why: 'Registered is not running. Proven by initialize + tools/list, not by the registration existing.' },
@@ -203,7 +215,7 @@ export function ceilingReached({ unverified = [], unknown = [], missing = [] } =
  * it work" is the one people skip. Defaulting the skipped case to `present` is how a report
  * becomes a green light for an agent nobody checked.
  */
-export function installState(observations = {}, { lane = null } = {}) {
+export function installState(observations = {}, { lane = null, mcp = null } = {}) {
   // A lane counts as declared only if it is a string naming one we know. An unrecognised name is a
   // typo or a future lane, and neither may excuse a row: `applies` falls back to "every row
   // applies", which is the demanding answer. `--lane brokr` must not quietly become `--lane sealed`.
@@ -215,7 +227,13 @@ export function installState(observations = {}, { lane = null } = {}) {
   const declared = typeof lane === 'string' && Object.prototype.hasOwnProperty.call(LANES, lane) ? lane : null
   // No `lanes` on a row → every lane needs it. No declared lane → every row applies, because the
   // permissive reading of silence is the one this whole module exists to refuse.
-  const applies = artifact => !declared || !artifact.lanes || artifact.lanes.includes(declared)
+  // The same demanding reading of silence, on a second axis. `mcp` is a boolean or it is nothing:
+  // only an explicit `false` — "this runtime has no MCP client" — scopes an MCP row out. Undefined,
+  // null, `'false'`, 0 all mean undeclared, and undeclared means the row applies, because a caller
+  // that did not say is not a caller claiming the hazard is absent (#526).
+  const noMcp = mcp === false
+  const applies = artifact => (!declared || !artifact.lanes || artifact.lanes.includes(declared)) &&
+    !(artifact.needsMcp && noMcp)
 
   const rows = ARTIFACTS.map(artifact => {
     const seen = observations[artifact.key]

--- a/src/agent_startup.mjs
+++ b/src/agent_startup.mjs
@@ -153,7 +153,7 @@ export function startupDoc({ agent, pubkey, channel, bridge, runtimeLabel, runti
   // change removes, and this time with no caveat to explain it, because a path WAS supplied
   // (#525 review). So anything going into a COMMAND is shell-quoted when it needs to be. Prose
   // paths are not: a quoted `docs/…` reference reads as a defect, and nobody pastes it to a shell.
-  const shq = s => (/^[A-Za-z0-9_@%+=:,./-]+$/.test(s) ? s : `'${String(s).replace(/'/g, `'\''`)}'`)
+  const shq = s => (/^[A-Za-z0-9_@%+=:,./-]+$/.test(s) ? s : `'${String(s).replace(/'/g, `'\\''`)}'`)
   const cmd = p => shq(at(p))
   // `--runtime` for the same reason as `--lane`, and it is not cosmetic either: the MCP rows are
   // scoped by whether the runtime HAS an MCP client, and absent means they apply (#526). So a Pi

--- a/src/agent_startup.mjs
+++ b/src/agent_startup.mjs
@@ -29,6 +29,12 @@
 //      exact confusion has cost this project a day more than once.
 import { ARTIFACTS, LANES, MISSING, PRESENT, UNKNOWN, UNVERIFIED } from './agent_install_state.mjs'
 import { acceptableName, normaliseName } from './connect_flags.mjs'
+import { RUNTIMES } from './mcp_runtimes.mjs'
+
+// Derived from the registry rather than listed, so a runtime added there is renderable here without
+// a second list to keep in step. The browser copy inlines the same ids and `console_first_prompt`
+// pins the two together — a stale list there renders a `--runtime` flag the node side would reject.
+const RUNTIME_IDS = RUNTIMES.map(r => r.id)
 
 // Anything that looks like a credential. Checked against the rendered text, not against the inputs,
 // because the failure that matters is what reaches the file.
@@ -81,7 +87,7 @@ const SAYS = {
  * works. `facts` carries the public identifiers. Everything else here is invariant role text, and
  * every line of it is a rule an agent has broken confidently at least once.
  */
-export function startupDoc({ agent, pubkey, channel, bridge, runtimeLabel, repo, briefPath = 'docs/AGENT_BRIEF.md', report,
+export function startupDoc({ agent, pubkey, channel, bridge, runtimeLabel, runtimeId, repo, briefPath = 'docs/AGENT_BRIEF.md', report,
   writtenBy = '`tools/connect-agent.mjs --startup`' }) {
   if (!agent) throw new Error('startupDoc needs the agent name')
   const rows = report?.rows || []
@@ -147,10 +153,15 @@ export function startupDoc({ agent, pubkey, channel, bridge, runtimeLabel, repo,
   // change removes, and this time with no caveat to explain it, because a path WAS supplied
   // (#525 review). So anything going into a COMMAND is shell-quoted when it needs to be. Prose
   // paths are not: a quoted `docs/…` reference reads as a defect, and nobody pastes it to a shell.
-  const shq = s => (/^[A-Za-z0-9_@%+=:,./-]+$/.test(s) ? s : `'${String(s).replace(/'/g, `'\\''`)}'`)
+  const shq = s => (/^[A-Za-z0-9_@%+=:,./-]+$/.test(s) ? s : `'${String(s).replace(/'/g, `'\''`)}'`)
   const cmd = p => shq(at(p))
+  // `--runtime` for the same reason as `--lane`, and it is not cosmetic either: the MCP rows are
+  // scoped by whether the runtime HAS an MCP client, and absent means they apply (#526). So a Pi
+  // whose document omits the flag runs a check that blocks it on a hazard its runtime cannot have.
+  // An unknown id is dropped rather than echoed, because the tool would die on it.
+  const rtArg = RUNTIME_IDS.includes(String(runtimeId)) ? String(runtimeId) : null
   const checkCmd = acceptableName(agent)
-    ? `node ${cmd('tools/connect-agent.mjs')} --name ${normaliseName(agent)} --check${lane ? ` --lane ${lane}` : ''}`
+    ? `node ${cmd('tools/connect-agent.mjs')} --name ${normaliseName(agent)} --check${lane ? ` --lane ${lane}` : ''}${rtArg ? ` --runtime ${rtArg}` : ''}`
     : null
   // What is said INSTEAD of a command, when the name would be refused. It names the rule and the
   // offending name, because "settle your name" without either is an instruction the reader cannot

--- a/tests/agent_install_state.mjs
+++ b/tests/agent_install_state.mjs
@@ -763,9 +763,31 @@ check(ARTIFACTS.some(a => a.blocking) && ARTIFACTS.some(a => !a.blocking),
     "a runtime with no MCP client scopes the exclusivity row out — Pi is kind:'none', so the hazard cannot reach it")
   check(!/\[ok \][^\n]*No other nvoy server/.test(piRun.out),
     '  …as NOT-APPLICABLE and never as ok — "did not apply" and "passed" must not collapse into one cell')
-  // The direction that matters more. A fix that simply stopped checking would pass the line above.
-  check(rowState(claudeRun.out, EXCL) === 'x' || rowState(claudeRun.out, EXCL) === 'ok',
-    'BOTH DIRECTIONS — a runtime that HAS an MCP is still judged on the row, not scoped out of it')
+  // The direction that matters more, and the LIVE run cannot always answer it: the exclusivity row
+  // is only rendered on a machine that has an MCP host installed at all. On CI there is none, the
+  // row is absent, and an absent row is INCONCLUSIVE — it is not evidence that the runtime was
+  // judged. This assertion pinned the verdict itself (`x`) and went green here and red on CI, for
+  // the plain reason that it was a statement about what is registered on this laptop.
+  //
+  // So it is pinned twice. On the function, where it is the same everywhere; and live, where it is
+  // asserted only when the row exists and SAYS SO when it does not, rather than passing by silence.
+  const claudeCell = rowState(claudeRun.out, EXCL)
+  if (claudeCell === null) {
+    console.log('  --   the live run could not judge the exclusivity row — no MCP host on this machine, ' +
+      'so the row is absent. INCONCLUSIVE here; the function-level check below is the one that binds.')
+  } else {
+    check(claudeCell !== 'n/a',
+      `BOTH DIRECTIONS — live, a runtime that HAS an MCP is still JUDGED on the row, whatever the verdict — never scoped out (rendered [${claudeCell}])`)
+  }
+  // The same property on `installState`, which does not depend on what this machine has installed.
+  const exclState = mcp => (installState({ 'mcp-exclusive': { found: false, verified: false } },
+    { lane: 'sealed', mcp }).rows.find(r => r.key === 'mcp-exclusive') || {}).state
+  check(exclState(false) === NOT_APPLICABLE,
+    'a runtime with no MCP client scopes the exclusivity row out — on the function, so CI proves it too')
+  check(exclState(true) !== NOT_APPLICABLE && exclState(true) !== undefined,
+    `BOTH DIRECTIONS — mcp:true keeps the row in scope (${exclState(true)}), so the fix is not "stop checking"`)
+  check(exclState(null) !== NOT_APPLICABLE,
+    '  …and an unknown runtime keeps it too — silence is not a claim that the hazard is absent')
   check(rowState(undeclaredRun.out, EXCL) !== 'n/a',
     'and an UNDECLARED runtime still applies it — silence is not a claim that the hazard is absent')
   const badRt = run([...base, '--runtime', 'nope'])

--- a/tests/agent_install_state.mjs
+++ b/tests/agent_install_state.mjs
@@ -693,8 +693,14 @@ check(ARTIFACTS.some(a => a.blocking) && ARTIFACTS.some(a => !a.blocking),
     console.error(`agent_install_state: INCONCLUSIVE — connect-agent.mjs read back only ${src.length} bytes`)
     process.exit(3)
   }
-  check(/installState\(obs,\s*\{\s*lane\s*\}\)/.test(src),
-    'the tool passes the declared lane to installState — a flag it parses and drops changes nothing')
+  // BOTH scoping axes, because a flag the tool parses and drops changes nothing. `--runtime` joined
+  // `--lane` here when the MCP rows started reading it (#526): the tool grew the flag, and a version
+  // that read it and never passed it on would leave a Pi blocked by exactly the row the flag exists
+  // to scope out — with the command line looking correct.
+  check(/installState\(obs,\s*\{\s*lane,\s*mcp:\s*HAS_MCP\s*\}\)/.test(src),
+    'the tool passes the declared lane AND the runtime MCP verdict to installState')
+  check(/const HAS_MCP = runtimeId \? runtime\(runtimeId\)\.kind !== 'none' : null/.test(src),
+    "…and derives that verdict from the runtime registry's own kind, not from a second list of ids")
   // Key material created "just in case" is key material nobody is tracking, and a sealed-lane agent
   // has no broker to present an ssh key to.
   check(/!CHECK && !STARTUP_ONLY && !SEALED/.test(src),
@@ -741,6 +747,30 @@ check(ARTIFACTS.some(a => a.blocking) && ARTIFACTS.some(a => !a.blocking),
   }
   check(!/\[n\/a\]/.test(undeclaredRun.out) && /no --lane given/.test(undeclaredRun.out),
     'BOTH DIRECTIONS — the same run with no --lane scopes nothing out, and says why')
+
+  // ── The MCP rows need an MCP, live through the tool (#526) ──────────────────────────────────
+  // Driven through the tool rather than asserted on `installState` alone, because the defect was in
+  // the seam: the module could scope the row perfectly and the tool never tell it which runtime.
+  const EXCL = /No other nvoy server registered/
+  const rowState = (out, re) => (out.split('\n').find(l => re.test(l)) || '').match(/\[(.{1,3})\]/)?.[1]?.trim() ?? null
+  const piRun = run([...base, '--lane', 'sealed', '--runtime', 'pi'])
+  const claudeRun = run([...base, '--lane', 'sealed', '--runtime', 'claude'])
+  if (!piRun?.out || !claudeRun?.out || piRun.out.length < 500 || claudeRun.out.length < 500) {
+    console.error('agent_install_state: INCONCLUSIVE — a runtime-scoped run produced no report')
+    rmSync(probeRoot, { recursive: true, force: true }); process.exit(3)
+  }
+  check(rowState(piRun.out, EXCL) === 'n/a',
+    "a runtime with no MCP client scopes the exclusivity row out — Pi is kind:'none', so the hazard cannot reach it")
+  check(!/\[ok \][^\n]*No other nvoy server/.test(piRun.out),
+    '  …as NOT-APPLICABLE and never as ok — "did not apply" and "passed" must not collapse into one cell')
+  // The direction that matters more. A fix that simply stopped checking would pass the line above.
+  check(rowState(claudeRun.out, EXCL) === 'x' || rowState(claudeRun.out, EXCL) === 'ok',
+    'BOTH DIRECTIONS — a runtime that HAS an MCP is still judged on the row, not scoped out of it')
+  check(rowState(undeclaredRun.out, EXCL) !== 'n/a',
+    'and an UNDECLARED runtime still applies it — silence is not a claim that the hazard is absent')
+  const badRt = run([...base, '--runtime', 'nope'])
+  check(badRt?.code === 1 && /--runtime nope is not one of/.test(badRt.out || ''),
+    'an unknown --runtime is refused by name, rather than resolving to "no MCP" and scoping the row out')
   rmSync(probeRoot, { recursive: true, force: true })
 }
 

--- a/tools/connect-agent.mjs
+++ b/tools/connect-agent.mjs
@@ -101,6 +101,20 @@ if (has('--lane') && !Object.prototype.hasOwnProperty.call(LANES, lane)) {
 }
 const SEALED = lane === 'sealed'
 
+// Whether this runtime has an MCP client, for the rows whose hazard needs one (#526). Refused the
+// same way `--lane` is: an unrecognised id dies here rather than resolving to `undefined` and
+// quietly declaring "no MCP", which would scope out the very rows it was mistyped past.
+//
+// Absent `--runtime` yields `null`, NOT `true` — the rows then apply, which is the demanding answer
+// and the same reading of silence `installState` gives an undeclared lane. It deliberately does not
+// borrow the `--startup` branch's default of `claude`: defaulting a CHECK to a runtime that has an
+// MCP would keep telling a Pi it cannot run, which is the defect.
+const runtimeId = flag('--runtime')
+if (has('--runtime') && !runtime(runtimeId)) {
+  die(`--runtime ${runtimeId} is not one of: ${RUNTIMES.map(r => r.id).join(', ')}`)
+}
+const HAS_MCP = runtimeId ? runtime(runtimeId).kind !== 'none' : null
+
 // Shape-check the two operator-pasted values HERE, at the boundary, before anything renders them
 // (#466 review §3). Both have a known shape, so an allowlist is available and an allowlist is
 // bounded: it makes `bunker://…` in `--channel` unreachable by construction rather than caught by
@@ -504,7 +518,7 @@ if (bind.match === false) warn.push(`this session answers as ${bind.resolved.sli
 see('channel-answers', registered === true ? true : null, false, 'registered is not running — prove with an initialize + tools/list handshake')
 
 // ── Report ──────────────────────────────────────────────────────────────────────────────────
-const report = installState(obs, { lane })
+const report = installState(obs, { lane, mcp: HAS_MCP })
 if (did.length) { console.log(`\nchanged:`); for (const d of did) console.log(`  + ${d}`) }
 if (CHECK) console.log(`\n(--check: nothing was changed)`)
 console.log(`\n${name} — ${HERE}\n`)
@@ -572,7 +586,7 @@ if (has('--startup')) {
         // Passed through when the operator supplies it, and left undefined otherwise so the
         // document prints the caveat rather than a command that exits 3 (#514 review).
         bridge: flag('--bridge') || process.env.WAGGLE_BRIDGE_PUBKEY || undefined,
-        runtimeLabel: rt.label, repo: REPO, report,
+        runtimeLabel: rt.label, runtimeId: rt.id, repo: REPO, report,
       })
     } catch (e) { die(e.message) }
     if (has('--print')) console.log(body.split('\n').map(l => `  | ${l}`).join('\n'))


### PR DESCRIPTION
Closes #526. Third in the stack — merge #523, then #525, then this.

`connect-agent --check` reported `No other nvoy server registered — MISSING` for **every** agent seated on this machine. The row is `blocking`, so each exited 1 with "this agent cannot run".

| agent | exit | blocking rows failing |
|---|---|---|
| mc-claude | 1 | 1 — this row, and only this row |
| oliver | 1 | 1 |
| lukedog | 1 | 1 |
| codex-jaf | 1 | 2 |

mc-claude sends and receives daily. A blocking row that every agent fails at once cannot separate a broken install from a working one, which is the one thing this module exists to do.

## The scoping axis is not the lane

My first framing in #526 was wrong and is corrected here: I proposed `lanes: ['broker']`, which would have undone a deliberate decision. The comment above the row already argues, correctly, that the hazard belongs to the **session**, not the transport, and that scoping it by lane is what a previous commit got wrong.

What actually bounds the hazard is whether the session has an MCP client. Pi's runtime is `kind: 'none'` (#520) — no config to register a server in, nothing in the session that could call one. A hazard requiring an MCP client cannot reach a runtime that has none. That argument survives the existing comment because it is a different axis.

The residual question — whether a server registered in *another runtime's* config should count against this agent at all — is left open, deliberately. It is a judgement about #338's blast radius and it is not mine to settle.

## Change

- rows carry `needsMcp`; `installState` takes `mcp`
- only an explicit `false` scopes them out. `undefined`, `null`, `'false'`, `0` all mean undeclared, and undeclared means the row applies — the same demanding reading of silence an undeclared lane gets
- `connect-agent` derives the verdict from the registry's own `kind`, and refuses an unknown `--runtime` by name rather than letting a typo resolve to "no MCP" and scope out the rows it was mistyped past
- the startup document renders `--runtime` into its check command for the same reason it renders `--lane`: a Pi whose document omits the flag runs a check that blocks it on this row

## Verification

Driven through the tool, not just the module — the defect was in the seam, where the module could scope perfectly and the tool never say which runtime.

- `--runtime pi` → row renders `NOT-APPLICABLE`, and asserted **never** `ok`, because "did not apply" and "passed" must not collapse (#513)
- **the direction that matters more:** `--runtime claude` still fails the row. A fix that merely stopped checking would pass the first assertion alone
- no `--runtime` still fails it — silence is not a claim the hazard is absent
- `--runtime nope` exits 1 naming the valid ids
- source-scan assertion widened to pin **both** axes reaching `installState`; the old one pinned only `{ lane }` and would have gone green on a tool that parsed `--runtime` and dropped it

Full suite rc=0, eslint 0 errors, console build id regenerated. Measured against the real `pi-dog` agent as well as the temp-root fixtures.

## Review

**@My Dude** — the argument to check is the axis choice: `needsMcp` rather than `lanes: ['broker']`, and whether leaving the cross-runtime-config question open is the right call or a dodge.

Drafted with assistance from [Claude Code](https://claude.com/claude-code)