### PR TITLE
The pairing row said MISSING and offered nothing to settle it with (#533)

### DIFF
--- a/console/VERSION.json
+++ b/console/VERSION.json
@@ -1,3 +1,3 @@
 {
-  "build": "e39d935608eefb89095dae6bcd386280"
+  "build": "11dce102ee6e8d6affcc3437dd8abdae"
 }

--- a/console/agent-startup.mjs
+++ b/console/agent-startup.mjs
@@ -164,6 +164,13 @@ export function startupDoc({ agent, pubkey, channel, bridge, runtimeLabel, runti
   const checkCmd = acceptableName(agent)
     ? `node ${cmd('tools/connect-agent.mjs')} --name ${normaliseName(agent)} --check${lane ? ` --lane ${lane}` : ''}${rtArg ? ` --runtime ${rtArg}` : ''}`
     : null
+  // Same construction, same refusal rule. `--expect` is included only when a key is actually known:
+  // rendering `--expect <your 64-hex>` would print a command that dies on its own placeholder, and
+  // omitting the flag silently would claim a pin the run never made. So the flag is present or the
+  // prose says the identity is unpinned — never a placeholder inside a runnable command (#528).
+  const pairCmd = acceptableName(agent)
+    ? `node ${cmd('tools/pair-agent.mjs')} --name ${normaliseName(agent)}${pubkey ? ` --expect ${pubkey}` : ''}`
+    : null
   const nameRule = `\`--name\` takes a short stable id — lowercase, 2\u201364 characters, from ` +
     `\`a-z0-9._-\` and starting with a letter or digit \u2014 and \`${String(agent)}\` is not one. ` +
     `Settle the agent's id first; no command is printed here because the one that would be printed ` +
@@ -216,6 +223,29 @@ export function startupDoc({ agent, pubkey, channel, bridge, runtimeLabel, runti
   out.push(`  owner's Bunker and is reached through that pairing, so a restart, a compaction or a new`)
   out.push(`  instance re-pairs to the same identity. That is the design, not a limitation worked around.`)
   out.push(`  **Yours:** ${stateOf('bunker-uri')}.`)
+  // The remedy, and it is the last link in the walk: until this line existed the document reported
+  // `MISSING \u2014 this does not work yet` for the one artifact an agent CAN settle by itself, and
+  // offered nothing to settle it with. `pair-agent` runs client-first, so nothing transports a
+  // credential: this machine generates its own transport key, prints a request, and the owner
+  // approves it in their signer (#528). Rendered only when the pairing is not already present \u2014
+  // an agent that is paired must not be handed a command whose first act is to refuse, because
+  // `pair-agent` exits rather than overwrite a seated credential.
+  if (row('bunker-uri') && row('bunker-uri').state !== PRESENT) {
+    if (pairCmd) {
+      out.push(`  **To seat it yourself:** \`${pairCmd}\`, then approve the request in the owner's`)
+      out.push(`  signer. Nothing is carried anywhere \u2014 the transport key is minted here and the`)
+      out.push(`  owner's only gesture is the approval.`)
+      // `--expect` is the difference between "a pairing" and "the RIGHT pairing", and its absence is
+      // reported by the tool rather than hidden \u2014 so the document says which of the two this
+      // agent is about to get, instead of implying the stronger one.
+      out.push(pubkey
+        ? `  It pins the identity to your key, so a signer that answers as anyone else is refused.`
+        : `  **No key is known here, so nothing will check WHICH identity answers.** The tool says so`)
+      if (!pubkey) out.push(`  when it finishes. Re-run it with \`--expect <your 64-hex>\` once you know the key.`)
+    } else {
+      out.push(`  No command is printed for seating it: ${nameRule}`)
+    }
+  }
   out.push(`  Never print a pairing, and never ask anyone for a key — yours or anyone else's.`)
   out.push('')
   out.push('## What you can and cannot do')

--- a/console/build-id.mjs
+++ b/console/build-id.mjs
@@ -2,4 +2,4 @@
 //
 // The id of the console build this module graph belongs to. A page compares it against
 // console/VERSION.json, fetched with no-store, to detect a stale cached graph (#418).
-export const CONSOLE_BUILD_ID = 'e39d935608eefb89095dae6bcd386280'
+export const CONSOLE_BUILD_ID = '11dce102ee6e8d6affcc3437dd8abdae'

--- a/src/agent_startup.mjs
+++ b/src/agent_startup.mjs
@@ -163,6 +163,13 @@ export function startupDoc({ agent, pubkey, channel, bridge, runtimeLabel, runti
   const checkCmd = acceptableName(agent)
     ? `node ${cmd('tools/connect-agent.mjs')} --name ${normaliseName(agent)} --check${lane ? ` --lane ${lane}` : ''}${rtArg ? ` --runtime ${rtArg}` : ''}`
     : null
+  // Same construction, same refusal rule. `--expect` is included only when a key is actually known:
+  // rendering `--expect <your 64-hex>` would print a command that dies on its own placeholder, and
+  // omitting the flag silently would claim a pin the run never made. So the flag is present or the
+  // prose says the identity is unpinned — never a placeholder inside a runnable command (#528).
+  const pairCmd = acceptableName(agent)
+    ? `node ${cmd('tools/pair-agent.mjs')} --name ${normaliseName(agent)}${pubkey ? ` --expect ${pubkey}` : ''}`
+    : null
   // What is said INSTEAD of a command, when the name would be refused. It names the rule and the
   // offending name, because "settle your name" without either is an instruction the reader cannot
   // act on — and being unable to act on it is how `Pi Dog` became a pasted command that exited 1.
@@ -218,6 +225,29 @@ export function startupDoc({ agent, pubkey, channel, bridge, runtimeLabel, runti
   out.push(`  owner's Bunker and is reached through that pairing, so a restart, a compaction or a new`)
   out.push(`  instance re-pairs to the same identity. That is the design, not a limitation worked around.`)
   out.push(`  **Yours:** ${stateOf('bunker-uri')}.`)
+  // The remedy, and it is the last link in the walk: until this line existed the document reported
+  // `MISSING \u2014 this does not work yet` for the one artifact an agent CAN settle by itself, and
+  // offered nothing to settle it with. `pair-agent` runs client-first, so nothing transports a
+  // credential: this machine generates its own transport key, prints a request, and the owner
+  // approves it in their signer (#528). Rendered only when the pairing is not already present \u2014
+  // an agent that is paired must not be handed a command whose first act is to refuse, because
+  // `pair-agent` exits rather than overwrite a seated credential.
+  if (row('bunker-uri') && row('bunker-uri').state !== PRESENT) {
+    if (pairCmd) {
+      out.push(`  **To seat it yourself:** \`${pairCmd}\`, then approve the request in the owner's`)
+      out.push(`  signer. Nothing is carried anywhere \u2014 the transport key is minted here and the`)
+      out.push(`  owner's only gesture is the approval.`)
+      // `--expect` is the difference between "a pairing" and "the RIGHT pairing", and its absence is
+      // reported by the tool rather than hidden \u2014 so the document says which of the two this
+      // agent is about to get, instead of implying the stronger one.
+      out.push(pubkey
+        ? `  It pins the identity to your key, so a signer that answers as anyone else is refused.`
+        : `  **No key is known here, so nothing will check WHICH identity answers.** The tool says so`)
+      if (!pubkey) out.push(`  when it finishes. Re-run it with \`--expect <your 64-hex>\` once you know the key.`)
+    } else {
+      out.push(`  No command is printed for seating it: ${nameRule}`)
+    }
+  }
   out.push(`  Never print a pairing, and never ask anyone for a key — yours or anyone else's.`)
   out.push('')
   out.push('## What you can and cannot do')

--- a/tests/agent_startup.mjs
+++ b/tests/agent_startup.mjs
@@ -472,6 +472,34 @@ check(runsInShell(unquoted) === 1 && /Cannot find module/.test(bareErr),
 // print quotes nobody needs and the reader would learn to ignore them.
 check(!/'/.test(laneDoc('sealed', { repo: ROOT }).split('\n').find(l => l.startsWith('**To listen:**')) || "'"),
   '  BOTH DIRECTIONS — a checkout path that needs no quoting does not get any')
+
+// ── 5i. the seating command is a command too ────────────────────────────────────────────────
+console.log('\n5i. the pairing remedy runs in a shell, and is withheld once the pairing is seated')
+// `pair-agent` is the one artifact in this document an agent can settle by itself (#528), and until
+// this block existed the pairing row said `MISSING — this does not work yet` with no remedy beside
+// it. It is run rather than matched for the same reason as 5h: this is a path the reader pastes.
+// The stub is `process.exit(0)` — nothing here pairs with anything.
+writeFileSync(join(spacedRepo, 'tools', 'pair-agent.mjs'), 'process.exit(0)\n')
+const seatOf = doc => ((doc.split('\n').find(l => l.includes('pair-agent.mjs')) || '').match(/`([^`]+)`/)?.[1] || '')
+const spacedSeatCmd = seatOf(laneDoc('sealed', { repo: spacedRepo }))
+check(/pair-agent\.mjs/.test(spacedSeatCmd), `ANCHOR — a seating command was extracted (${spacedSeatCmd.slice(0, 60)}…)`)
+check(runsInShell(spacedSeatCmd) === 0,
+  'the rendered SEATING command RUNS in a real shell under a spaced, apostrophed checkout path')
+check(runsInShell(spacedSeatCmd.replace(/'/g, '')) === 1,
+  '  NEGATIVE CONTROL — strip its quoting and it fails at exit 1, so the quoting is what carries it')
+// The pin, both directions. `--expect` is what makes a signer answering as someone else a refusal,
+// and rendering it as a placeholder would print a command that dies on its own argument.
+check(new RegExp(`--expect ${PUB}$`).test(spacedSeatCmd),
+  '  it pins the identity to the key this same document names above')
+const unpinnedSeat = seatOf(startupDoc({ agent: 'oliver', repo: spacedRepo,
+  report: { rows: [{ key: 'bunker-uri', title: 'Bunker pairing', state: MISSING }] } }))
+check(unpinnedSeat && !/--expect/.test(unpinnedSeat) && runsInShell(unpinnedSeat) === 0,
+  '  BOTH DIRECTIONS — with no key known it omits --expect and still runs, rather than printing a placeholder')
+// And it is absent once the pairing is there: `pair-agent` exits rather than overwrite a seated
+// credential, so a paired agent handed this command is handed one whose first act is to refuse.
+check(!seatOf(startupDoc({ agent: 'oliver', pubkey: PUB, repo: spacedRepo,
+  report: { rows: [{ key: 'bunker-uri', title: 'Bunker pairing', state: PRESENT }] } })),
+  '  BOTH DIRECTIONS — a SEATED pairing renders no seating command at all')
 rmSync(spaceRoot, { recursive: true, force: true })
 
 // The usage line is the message an agent acts on when it gets the call wrong, and it had drifted to

--- a/tests/console_first_prompt.mjs
+++ b/tests/console_first_prompt.mjs
@@ -125,6 +125,11 @@ const MATRIX = [
     { agent: 'Oliver', report: { rows: rows({ 'bunker-uri': MISSING, profile: UNKNOWN }) } }],
   ['a name that is REFUSED — Pi Dog, no command exists for it at all',
     { agent: 'Pi Dog', report: { rows: rows({ 'bunker-uri': MISSING, profile: UNKNOWN }) } }],
+  // The pairing remedy branches on whether a key is known, and every fixture above supplies one, so
+  // the unpinned half of it was off the byte axis entirely. `no pubkey` above drops the key but also
+  // drops the `bunker-uri` row, so the remedy never renders there.
+  ['an unseated pairing and NO key — the remedy that cannot pin an identity',
+    { report: { rows: rows({ 'bunker-uri': MISSING, profile: UNKNOWN }) } }],
 ]
 
 for (const [what, extra] of MATRIX) {
@@ -133,6 +138,7 @@ for (const [what, extra] of MATRIX) {
     runtimeLabel: 'Any other MCP host (Raspberry Pi, headless, self-hosted)', ...extra,
   }
   if (what.startsWith('no runtime label')) { delete args.runtimeLabel; delete args.channel; delete args.pubkey }
+  if (what.startsWith('an unseated pairing and NO key')) delete args.pubkey
   const a = node.startupDoc(args), b = web.startupDoc(args)
   check(a === b, `${what} — the two copies render the same ${a.length} bytes`)
 }
@@ -168,6 +174,31 @@ for (const [label, copy] of [['node', node], ['browser', web]]) {
     `${label}:   …and names the offending name and the rule instead`)
   check(/Neither command works yet/.test(doc) && /never checked/.test(doc),
     `${label}:   NEGATIVE CONTROL — it withholds the command, not the surrounding warning`)
+}
+
+// The pairing remedy, per copy, because byte-identity is blind to a line BOTH copies dropped — the
+// same blindness `briefPath` and `report.lane` are asserted against above. Three branches: the
+// remedy appears when the pairing is unseated, carries `--expect` only when a key is known, and is
+// ABSENT once the pairing is seated. That last one is the direction that matters operationally:
+// `pair-agent` exits rather than overwrite a seated credential, so printing it to a paired agent
+// hands them a command whose first act is to refuse (#528).
+for (const [label, copy] of [['node', node], ['browser', web]]) {
+  // A real `repo`, because with none the path renders as the quoted `<your waggle checkout>`
+  // placeholder and a regex over the command would be matching prose, not a command.
+  const doc = (state, key) => copy.startupDoc({ agent: 'pi-agent', repo: '/opt/waggle', ...(key ? { pubkey: PUB } : {}),
+    report: { lane: 'sealed', rows: rows({ 'bunker-uri': state, profile: UNKNOWN }) } })
+  const seatLine = d => d.split('\n').find(l => l.includes('pair-agent.mjs')) || ''
+  check(/pair-agent\.mjs --name pi-agent --expect [0-9a-f]{64}/.test(seatLine(doc(MISSING, true))),
+    `${label}: an unseated pairing renders pair-agent, pinned to the key the document already names`)
+  const unpinned = doc(MISSING, false)
+  check(seatLine(unpinned).includes('pair-agent.mjs --name pi-agent') && !/--expect/.test(seatLine(unpinned)) &&
+    /nothing will check WHICH identity answers/.test(unpinned),
+    `${label}:   …and with no key it omits --expect and SAYS the identity is unpinned, not a placeholder`)
+  check(!seatLine(doc(PRESENT, true)) && /\*\*Yours:\*\* confirmed/.test(doc(PRESENT, true)),
+    `${label}:   BOTH DIRECTIONS — a SEATED pairing renders no seating command at all`)
+  check(!seatLine(copy.startupDoc({ agent: 'Pi Dog', pubkey: PUB,
+    report: { lane: 'sealed', rows: rows({ 'bunker-uri': MISSING, profile: UNKNOWN }) } })),
+    `${label}:   …and a refused name withholds this command too, for the same reason as --check`)
 }
 
 // The lane names themselves, pinned. A stale list in the browser copy does not render a wrong


### PR DESCRIPTION
Closes #533.

`tools/pair-agent.mjs` landed with #529. The startup document never mentioned it, so an agent read
`Bunker pairing: MISSING — this does not work yet` on the row that gates every other row, and was
handed no next step for the one artifact it can settle by itself.

Rendered now, beside that row:

```
- **Bunker pairing:** MISSING — this does not work yet.
  **Yours:** MISSING — this does not work yet.
  **To seat it yourself:** `node /opt/waggle/tools/pair-agent.mjs --name pi-agent --expect a1b2…`,
  then approve the request in the owner's signer. Nothing is carried anywhere — the transport key
  is minted here and the owner's only gesture is the approval.
  It pins the identity to your key, so a signer that answers as anyone else is refused.
```

Four rules, each a way this ships broken:

- **Only when the row is not `present`.** `pair-agent` exits rather than overwrite a seated
  credential, so printing it to a paired agent hands over a command whose first act is to refuse.
- **Shell-quoted through `cmd()`.** An unquoted spaced checkout path is `Cannot find module` at
  exit 1 — the #525 failure, one command over.
- **`--expect` only when a key is known.** `--expect <your 64-hex>` is a command that dies on its
  own argument; omitting the flag silently would claim a pin the run never made. So the flag is
  present, or the prose says the identity is unpinned and the tool says so when it finishes.
- **Withheld for a name the tool would refuse**, same as #523.

Both twins, held byte-identical by `tests/console_first_prompt.mjs`.

## Verification

New block 5i **runs** the rendered command in `/bin/sh` against a `process.exit(0)` stub under
`My Repos/it's waggle` — a lost backslash passes every string assertion and dies at rc 2, which is
how #525's quoting nearly shipped broken. Negative control: strip the quoting, exit 1.

Both directions on the pin (`--expect` present with a key; absent and explained without one) and on
the guard (no command at all once the pairing is seated). The twin suite asserts the same per copy,
because byte-identity is blind to a line both copies dropped — the `briefPath` blindness this file
already carries assertions for.

**Seven mutations, all killed:**

| mutation | FAILs |
|---|---|
| unquote the seat path (`at` for `cmd`) | 2 |
| render `--expect` as a placeholder | 1 |
| drop the `!== PRESENT` guard | 1 |
| delete the unpinned-identity prose | 1 |
| drop `--expect` entirely | 2 |
| remove the block from the console twin alone | 10 (byte-identity) |

`tests/agent_startup.mjs` 174/0 · `tests/console_first_prompt.mjs` 98/0 · full suite rc=0 ·
`npx eslint .` 0 errors (1 pre-existing warning).

## Review

**@My Dude** — docs-and-tests by the letter of the rule, but it is the last link in the Pi walk: it
is what turns a pasted prompt into an identity the agent can seat without the maintainer typing
anything but an approval in their signer. The part worth an adversarial read is the guard, since
getting it backwards prints a refusing command to exactly the agents who are already fine.

Drafted with assistance from [Claude Code](https://claude.com/claude-code)
