### PR TITLE
Two defects in the document a new agent reads at startup (#539, #541)

### DIFF
--- a/console/VERSION.json
+++ b/console/VERSION.json
@@ -1,3 +1,3 @@
 {
-  "build": "11dce102ee6e8d6affcc3437dd8abdae"
+  "build": "b19f5f064248ca34c03f4d0bcb54cc41"
 }

--- a/console/agent-startup.mjs
+++ b/console/agent-startup.mjs
@@ -349,17 +349,39 @@ export function startupDoc({ agent, pubkey, channel, bridge, runtimeLabel, runti
     // exist, and for a key that is not a harmless no-op. Latent when written, because neither
     // producer mixed the states; it stops being latent as soon as one does. Each piece now carries
     // its own verb, which also removes the plural/singular disagreement the old sentence had.
+    //
+    // UNVERIFIED IS ITS OWN VERB, for the same reason (#541). `is not in place` was reached by
+    // everything that was not UNKNOWN, so a pairing that is present at mode 600 and merely unproven
+    // from this machine read as absent, under a heading saying neither command works. pi-dog was in
+    // exactly that state on a day both of its commands ran — one of them into the channel. Telling
+    // an agent to create a credential it already holds is the failure the third state exists to
+    // stop, and for a key it is not a harmless no-op.
     const laneSays = k => laneState(k) === UNKNOWN
       ? `${laneTitle(k)} was never checked, which is not the same as absent`
-      : `${laneTitle(k)} is not in place`
+      : laneState(k) === UNVERIFIED
+        ? `${laneTitle(k)} is in place but was not proven from this machine`
+        : `${laneTitle(k)} is not in place`
+    // Nothing absent, only unproven: the commands are expected to work, and running them is what
+    // settles the rest. A blocked heading here would be the same false statement in the other
+    // direction — and an agent that reads "this does not work" does not try.
+    const blocked = laneOpen.some(k => laneState(k) === MISSING || laneState(k) === UNKNOWN)
     out.push('')
-    out.push(`⚠ **Neither command works yet.** ${laneOpen.map(laneSays).join('; ')}.`)
-    if (checkCmd) {
+    out.push(blocked
+      ? `⚠ **Neither command works yet.** ${laneOpen.map(laneSays).join('; ')}.`
+      : `⚠ **Not everything here was proven from this machine.** ${laneOpen.map(laneSays).join('; ')}.`)
+    if (blocked && checkCmd) {
       out.push(`Settle that first with \`${checkCmd}\`; running either tool before then fails in a`)
       out.push(`way that looks like the lane being down.`)
-    } else {
+    } else if (blocked) {
       out.push(`Running either tool before that is settled fails in a way that looks like the lane`)
       out.push(`being down. ${nameRule}`)
+    } else {
+      // The instruments are the ones the document already names, so this points at them rather than
+      // inventing a ceremony: a signature pinned with --expect, and mail that actually opens.
+      out.push(`That is not a reason to wait. Both commands are expected to work, and running them is`)
+      out.push(`what settles it: the send pins the signer with \`--expect\`, and a read that opens mail`)
+      out.push(`proves the bunker decrypts as well as signs. A bunker that signs but cannot decrypt`)
+      out.push(`reports as an empty inbox, which is why neither is assumed here.`)
     }
   }
   out.push('')

--- a/console/build-id.mjs
+++ b/console/build-id.mjs
@@ -2,4 +2,4 @@
 //
 // The id of the console build this module graph belongs to. A page compares it against
 // console/VERSION.json, fetched with no-store, to detect a stale cached graph (#418).
-export const CONSOLE_BUILD_ID = '11dce102ee6e8d6affcc3437dd8abdae'
+export const CONSOLE_BUILD_ID = 'b19f5f064248ca34c03f4d0bcb54cc41'

--- a/src/agent_startup.mjs
+++ b/src/agent_startup.mjs
@@ -351,17 +351,39 @@ export function startupDoc({ agent, pubkey, channel, bridge, runtimeLabel, runti
     // exist, and for a key that is not a harmless no-op. Latent when written, because neither
     // producer mixed the states; it stops being latent as soon as one does. Each piece now carries
     // its own verb, which also removes the plural/singular disagreement the old sentence had.
+    //
+    // UNVERIFIED IS ITS OWN VERB, for the same reason (#541). `is not in place` was reached by
+    // everything that was not UNKNOWN, so a pairing that is present at mode 600 and merely unproven
+    // from this machine read as absent, under a heading saying neither command works. pi-dog was in
+    // exactly that state on a day both of its commands ran — one of them into the channel. Telling
+    // an agent to create a credential it already holds is the failure the third state exists to
+    // stop, and for a key it is not a harmless no-op.
     const laneSays = k => laneState(k) === UNKNOWN
       ? `${laneTitle(k)} was never checked, which is not the same as absent`
-      : `${laneTitle(k)} is not in place`
+      : laneState(k) === UNVERIFIED
+        ? `${laneTitle(k)} is in place but was not proven from this machine`
+        : `${laneTitle(k)} is not in place`
+    // Nothing absent, only unproven: the commands are expected to work, and running them is what
+    // settles the rest. A blocked heading here would be the same false statement in the other
+    // direction — and an agent that reads "this does not work" does not try.
+    const blocked = laneOpen.some(k => laneState(k) === MISSING || laneState(k) === UNKNOWN)
     out.push('')
-    out.push(`⚠ **Neither command works yet.** ${laneOpen.map(laneSays).join('; ')}.`)
-    if (checkCmd) {
+    out.push(blocked
+      ? `⚠ **Neither command works yet.** ${laneOpen.map(laneSays).join('; ')}.`
+      : `⚠ **Not everything here was proven from this machine.** ${laneOpen.map(laneSays).join('; ')}.`)
+    if (blocked && checkCmd) {
       out.push(`Settle that first with \`${checkCmd}\`; running either tool before then fails in a`)
       out.push(`way that looks like the lane being down.`)
-    } else {
+    } else if (blocked) {
       out.push(`Running either tool before that is settled fails in a way that looks like the lane`)
       out.push(`being down. ${nameRule}`)
+    } else {
+      // The instruments are the ones the document already names, so this points at them rather than
+      // inventing a ceremony: a signature pinned with --expect, and mail that actually opens.
+      out.push(`That is not a reason to wait. Both commands are expected to work, and running them is`)
+      out.push(`what settles it: the send pins the signer with \`--expect\`, and a read that opens mail`)
+      out.push(`proves the bunker decrypts as well as signs. A bunker that signs but cannot decrypt`)
+      out.push(`reports as an empty inbox, which is why neither is assumed here.`)
     }
   }
   out.push('')

--- a/tests/agent_startup.mjs
+++ b/tests/agent_startup.mjs
@@ -14,7 +14,7 @@ import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'nod
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { MISSING, PRESENT, UNKNOWN, installState } from '../src/agent_install_state.mjs'
+import { MISSING, PRESENT, UNKNOWN, UNVERIFIED, installState } from '../src/agent_install_state.mjs'
 import { secretInText, startupDoc } from '../src/agent_startup.mjs'
 import { RUNTIMES } from '../src/mcp_runtimes.mjs'
 import { FLAGS, acceptableName, knownFlag, normaliseName, usageLine } from '../src/connect_flags.mjs'
@@ -270,6 +270,42 @@ const mixedLine = (laneMixed.split('\n').find(l => l.includes('Neither command w
 check(/Bunker pairing is not in place/.test(mixedLine), 'a MISSING piece beside an unchecked one is still reported missing')
 check(/Client transport key was never checked/.test(mixedLine),
   '  …and the unchecked one KEEPS its own state — all-or-nothing silenced this the moment the states mixed')
+
+// The same collapse, one state along (#541). UNVERIFIED reached the `is not in place` verb because
+// it was merely "not PRESENT", so a pairing sitting at mode 600 and only unproven read as absent,
+// under a heading saying neither command works. pi-dog was in that state on a day both commands ran,
+// one of them into the Buzz channel — so the document told a working agent its lane was down and
+// sent it to create a key it already held.
+const laneUnproven = startupDoc({ agent: 'oliver', pubkey: PUB, report: { rows: [
+  { key: 'bunker-uri', title: 'Bunker pairing', state: UNVERIFIED },
+  { key: 'bunker-client', title: 'Client transport key', state: PRESENT },
+  { key: 'signer-identity', title: 'Signer resolves to the right key', state: UNVERIFIED },
+] } })
+const unprovenLine = (laneUnproven.split('\n').find(l => l.includes('was not proven from this machine')) || '')
+check(/Bunker pairing is in place but was not proven/.test(unprovenLine),
+  'an UNVERIFIED pairing is reported as unproven, NOT as absent')
+check(!/is not in place/.test(unprovenLine),
+  '  …and the missing-verb never appears on that line — that verb sends an agent to re-create a key it holds')
+check(!/Neither command works yet/.test(laneUnproven),
+  'and the heading does not claim the commands are broken when nothing is actually absent')
+check(/Not everything here was proven from this machine/.test(laneUnproven),
+  '  …it says what is true instead: unproven, which is a different fact from broken')
+check(/running them is/.test(laneUnproven) && /--expect/.test(laneUnproven),
+  '  …and points at the instruments that settle it, because an agent told "this does not work" does not try')
+
+// NEGATIVE CONTROL, and it is the one that matters: a document that always warns and one that never
+// warns fail identically. One genuinely MISSING piece beside the unproven ones must still produce
+// the hard heading — otherwise the change above has just deleted the warning.
+const laneUnprovenPlusMissing = startupDoc({ agent: 'oliver', pubkey: PUB, report: { rows: [
+  { key: 'bunker-uri', title: 'Bunker pairing', state: UNVERIFIED },
+  { key: 'bunker-client', title: 'Client transport key', state: MISSING },
+  { key: 'signer-identity', title: 'Signer resolves to the right key', state: UNVERIFIED },
+] } })
+check(/Neither command works yet/.test(laneUnprovenPlusMissing),
+  'NEGATIVE CONTROL — one MISSING piece still produces the hard warning, unproven neighbours notwithstanding')
+const bothLine = (laneUnprovenPlusMissing.split('\n').find(l => l.includes('Neither command works yet')) || '')
+check(/Client transport key is not in place/.test(bothLine) && /Bunker pairing is in place but was not proven/.test(bothLine),
+  '  …and each piece still carries its OWN verb on that line, rather than the worst one spreading')
 
 // ── 5d. the check command names the lane it was checked under ───────────────────────────────
 console.log('\n5d. the remedy command carries the right lane')

--- a/tests/agent_startup.mjs
+++ b/tests/agent_startup.mjs
@@ -561,6 +561,63 @@ check(unseated !== null && !/act as this key/.test(unseated),
 check(unseated !== null && /nomanifest/.test(unseated),
   'and the file is still written and still addressed to the agent')
 
+// ── 6b. A document already on disk can still be compared against a fresh one (#539) ─────────
+console.log('\n6b. --print renders a FRESH document even when one already exists')
+// The file is never overwritten, deliberately. So the only defence against a stale one is reading
+// a fresh copy beside it — and `--print` was consulted only when the file was ABSENT, which turned
+// it off in the one case it is for. The message told the operator to compare, and the command it
+// suggested landed back in the same branch and printed the suggestion again.
+//
+// This is not hypothetical: pi-dog's document, written before its bunker was seated, still said
+// `this does not work yet` on a day when both of its commands were exercised live. Nothing in the
+// tool would show the operator otherwise.
+const runStartupRaw = (agent, extra = []) => {
+  const args = [join(ROOT, 'tools', 'connect-agent.mjs'), '--name', agent, '--root', probeRoot,
+    '--startup', '--runtime', 'generic', ...extra]
+  try { return execFileSync(process.execPath, args, { encoding: 'utf8', timeout: 60000, stdio: ['ignore', 'pipe', 'pipe'] }) }
+  catch (e) { return typeof e?.stdout === 'string' ? e.stdout : null }
+}
+const STALE = 'stalecheck'
+const stalePath = join(probeRoot, STALE, 'AGENTS.md')
+
+// 1. Written while the agent has NO manifest — so the document cannot name a key.
+const wrote = runStartupRaw(STALE)
+check(wrote !== null && /wrote /.test(wrote), 'a first run with no --print writes the file')
+const onDisk = readFileSync(stalePath, 'utf8')
+check(!onDisk.includes(TOOL_PUB), 'and that file does NOT name a key, because there was no manifest to hold one')
+
+// 2. The state then changes underneath it — exactly what a seating does.
+mkdirSync(join(probeRoot, STALE, 'instances'), { recursive: true })
+writeFileSync(join(probeRoot, STALE, 'instances', `${STALE}.json`), JSON.stringify({
+  version: 1, id: STALE, pubkey: TOOL_PUB, grantors: [], task_carriers: [],
+  relays: ['wss://nos.lol'], broker_mode: 'local', delivery_mode: 'notify_only',
+}) + '\n')
+
+const printed = runStartupRaw(STALE, ['--print'])
+check(printed !== null && /act as this key/.test(printed),
+  'a later run WITH --print prints a document, instead of only reporting that one exists')
+// The property that matters. Echoing the file back would satisfy "prints a document" and would be
+// useless — what is needed is the document the tool would write TODAY.
+check(printed !== null && printed.includes(TOOL_PUB),
+  'and it is rendered fresh — it names the key seated AFTER the file was written, which the file cannot')
+check(printed !== null && /NOT overwritten/.test(printed),
+  'and it still says the existing file was not overwritten, so nobody reads the fresh copy as the saved one')
+check(readFileSync(stalePath, 'utf8') === onDisk,
+  'and the file on disk is byte-identical afterwards — --print writes nothing')
+
+// NEGATIVE CONTROL, both halves. Without --print the existing branch must still refuse to render,
+// or "it prints a document" is a statement about the tool always printing rather than about --print.
+const quiet = runStartupRaw(STALE)
+check(quiet !== null && /NOT overwritten/.test(quiet) && !/act as this key/.test(quiet),
+  'NEGATIVE CONTROL — without --print it reports the file and renders nothing')
+check(quiet !== null && /--print/.test(quiet),
+  'and the command it suggests ends in --print, which is now a command that prints')
+// The suggestion has to carry the lane, or the fresh copy is rendered for a DIFFERENT lane and the
+// comparison reports differences that are the missing flag rather than the file being stale.
+const laned = runStartupRaw(STALE, ['--lane', 'sealed'])
+check(laned !== null && /--lane sealed/.test(laned),
+  'and it carries --lane through, so the comparison is against the same lane')
+
 // ── 7. The boundary allowlist ───────────────────────────────────────────────────────────────
 console.log('\n7. the two pasted fields are held to a shape before anything renders them')
 // `secretInText` is a denylist over rendered text, and no denylist can be proven complete. The two

--- a/tools/connect-agent.mjs
+++ b/tools/connect-agent.mjs
@@ -566,21 +566,11 @@ if (has('--startup')) {
   const rt = runtime(target)
   if (!rt) die(`--runtime ${target} is not one of: ${RUNTIMES.map(r => r.id).join(', ')}`)
   const dest = join(HERE, rt.startupFile)
+  const exists = existsSync(dest)
   console.log(`\nstartup file — ${rt.label}`)
-  if (existsSync(dest)) {
-    console.log(`  unchanged: ${dest} already exists and was NOT overwritten`)
-    // Carries --root and --channel through. Without them the pasted line reads a DIFFERENT agent
-    // root and renders a document with no channel, so the comparison it exists for is against the
-    // wrong file (#466 review §4).
-    const carried = [flag('--root') ? `--root ${flag('--root')}` : '', channel ? `--channel ${channel}` : '']
-      .filter(Boolean).join(' ')
-    console.log(`  compare it against a fresh one with: ${process.argv[1]} --name ${name}${carried ? ` ${carried}` : ''} --check --startup --runtime ${target} --print`)
-  } else if (CHECK && !has('--print')) {
-    console.log(`  would write: ${dest}  (--check: nothing was written)`)
-  } else {
-    let body
+  const render = () => {
     try {
-      body = startupDoc({
+      return startupDoc({
         agent: name, pubkey: pubkey || manifestPubkey, channel,
         // Nothing on this machine models waggle's own public key — no artifact, no manifest field.
         // Passed through when the operator supplies it, and left undefined otherwise so the
@@ -589,12 +579,33 @@ if (has('--startup')) {
         runtimeLabel: rt.label, runtimeId: rt.id, repo: REPO, report,
       })
     } catch (e) { die(e.message) }
-    if (has('--print')) console.log(body.split('\n').map(l => `  | ${l}`).join('\n'))
-    else {
-      mkdirSync(HERE, { recursive: true, mode: 0o700 })
-      writeFileSync(dest, body, { mode: 0o600, flag: 'wx' })
-      console.log(`  wrote ${dest} (mode 600)`)
-    }
+  }
+  // --print renders a fresh document and writes nothing, whether or not one is already on disk.
+  //
+  // It used to be consulted only when the file was ABSENT, which disabled it in the single case it
+  // exists for (#539). The file is never overwritten, so the only defence against a stale document
+  // is comparing it with a fresh one — and the message below says exactly that, then suggested a
+  // command that landed back in this branch and printed the suggestion again. The remedy was
+  // circular, because the file existing is the precondition of the branch that emits it. Meanwhile
+  // an agent whose credentials had since been seated was still reading `this does not work yet`.
+  if (has('--print')) {
+    if (exists) console.log(`  unchanged: ${dest} already exists and was NOT overwritten — printed below is the FRESH one, for comparison`)
+    console.log(render().split('\n').map(l => `  | ${l}`).join('\n'))
+  } else if (exists) {
+    console.log(`  unchanged: ${dest} already exists and was NOT overwritten`)
+    // Carries --root, --channel and --lane through. Without them the pasted line reads a DIFFERENT
+    // agent root and renders a document with no channel (#466 review §4) — and without the lane it
+    // renders a different lane's rows, so the comparison reports differences that are the missing
+    // flag rather than the file being stale.
+    const carried = [flag('--root') ? `--root ${flag('--root')}` : '', channel ? `--channel ${channel}` : '',
+      flag('--lane') ? `--lane ${flag('--lane')}` : ''].filter(Boolean).join(' ')
+    console.log(`  compare it against a fresh one with: ${process.argv[1]} --name ${name}${carried ? ` ${carried}` : ''} --startup --runtime ${target} --print`)
+  } else if (CHECK) {
+    console.log(`  would write: ${dest}  (--check: nothing was written)`)
+  } else {
+    mkdirSync(HERE, { recursive: true, mode: 0o700 })
+    writeFileSync(dest, render(), { mode: 0o600, flag: 'wx' })
+    console.log(`  wrote ${dest} (mode 600)`)
   }
   console.log(`  point ${rt.label} at ${HERE} so it reads this at session start — registering the MCP`)
   console.log(`  server does not make a runtime read a file next to it.`)


### PR DESCRIPTION
Both found walking the Pi path with a real bunker-held identity, and both were on the critical path
of that walk.

## #539 — `--print` was ignored once the file existed

`--startup --print` reported "already exists and was NOT overwritten" and printed nothing. The tool's
own remedy line tells the reader to *"compare it against a fresh one with … --print"*, so the command
it hands you does exactly what you just did. There was no way to see a fresh document without moving
the file out of the way.

`--print` now always renders, and says plainly that what is printed is the fresh one and the file on
disk was not touched.

## #541 — an UNVERIFIED credential was rendered as "is not in place"

`laneSays` reached the missing-verb for everything that was not `UNKNOWN`, so a pairing present at
mode 600 and merely unproven from this machine was reported **absent**, under a heading saying
neither command works.

pi-dog was in exactly that state on a day both of its commands ran, one of them into the Buzz
channel. The document told a working agent its lane was down and pointed it at creating a key it
already held — which for a key is not a harmless no-op, and is the failure the fourth install state
exists to prevent (`src/agent_install_state.mjs:27`).

`UNVERIFIED` now carries its own verb, and the hard heading is gated on something actually being
`MISSING` or `UNKNOWN`. With nothing absent the document says what is true — unproven — and points at
the instruments that settle it: `--expect` on the send, and a read that opens mail, because a bunker
that signs but cannot decrypt reports as an empty inbox.

The fix landed in `src/` first and **`tests/console_first_prompt.mjs` caught the twin divergence** as
a byte mismatch, which is what that parity matrix is for. Both copies now carry it.

## Verification

- `tests/agent_startup.mjs` 190/190; §6b drives the real CLI as a subprocess rather than matching
  strings, and asserts `--print` names the key seated **after** the file was written — which
  distinguishes "renders fresh" from "prints something" — with the file byte-identical afterwards.
- #541 mutations, all killed: revert the `UNVERIFIED` verb, force `blocked` true, force `blocked`
  false. The third is the negative control that matters — a document that always warns and one that
  never warns fail identically, so one genuinely `MISSING` piece beside two unproven ones must still
  produce the hard heading, and each piece keeps its own verb rather than the worst one spreading.
- 110 suites rc=0, eslint 0 errors. Console build id regenerated.

Closes #539. Closes #541.

Drafted with assistance from [Claude Code](https://claude.com/claude-code)