### PR TITLE
The wake verdict travels on the record, gated on first-seen (#559)

### DIFF
--- a/src/return_lane_notify.mjs
+++ b/src/return_lane_notify.mjs
@@ -94,11 +94,86 @@ export function isCarriageReceipt(content) {
  * something that happened; dropping it silently would leave a reader unable to tell a quiet lane
  * from one being fed forgeries.
  */
-export function notifyLine(verdict) {
+export function notifyLine(verdict, { id = null, receivedAt = null, firstSeen = true, live = null, bootstrap = false } = {}) {
   const v = verdict && typeof verdict === 'object' ? verdict : {}
+  // The wrap id, and the only thing on this record an adapter can be idempotent on (#559). It is the
+  // caller's job to pass one that has been VERIFIED — `open()` runs `verifyEvent` before it dedupes,
+  // precisely so the id is a hash the relay cannot choose. An unverified id here would let a relay
+  // pick which message a spool cursor believes it has already delivered.
+  //
+  // Absent serialises as null and the key is always present. A missing key and a null are different
+  // states — "this daemon does not emit ids" versus "this record has none" — and an adapter that
+  // cannot tell them apart will treat the first as the second and dedupe every record together.
+  const wrapId = typeof id === 'string' && id ? id : null
+  // Rumor time (`at`) is set by the SENDER; this is when this daemon saw it. They are separate keys
+  // because a spool ordered by sender-controlled time is a spool a sender can reorder.
+  const seenAt = Number.isSafeInteger(receivedAt) ? receivedAt : null
+  // THE WAKE VERDICT, emitted as ONE field so no adapter re-derives it (#559).
+  //
+  // The stream is deliberately ungated — every record reaches stdout, refusals included, so a lane
+  // being fed forgeries cannot look quiet. That is right, and it made an adapter filtering this
+  // stream on `receipt:false` wake on mail from anyone who can seal a wrap to this key, which under
+  // NIP-59 is everyone: a stranger's ordinary message is `ok:true, mayAct:false, receipt:false`. The
+  // hook path refused exactly what that adapter woke on, and `tools/agent-inbox.mjs` had already
+  // written down why — "anyone may seal mail to this key and a mention that runs a command hands
+  // every stranger a trigger on this session". An adapter filters on `wake` and nothing else; the
+  // alternative is every adapter re-deriving a conjunction, which is the adapter owning protocol
+  // semantics, the thing this boundary exists to prevent. `hasCommand: true` because this asks the
+  // gate's question, not "is a hook configured": the record must say the same thing whether or not
+  // this process happens to have one.
+  //
+  // THE TRUST GATE IS NOT THE WHOLE ANSWER, and the two wrong ways to finish it both shipped as
+  // proposals here before this landed (#557 review):
+  //
+  //   wake = invoke                — floods. Every relay replays its history pre-EOSE, so an adapter
+  //                                  fires once per historical message on arm (#554). A Monitor is
+  //                                  automatically STOPPED by a flood, so the flood ends as silence.
+  //   wake = live && invoke        — drops mail. The reconnect replay holds two populations a relay
+  //                                  cannot separate: messages already delivered, and messages that
+  //                                  ARRIVED DURING THE DISCONNECT. Both land pre-EOSE. Gating on
+  //                                  liveness suppresses the second forever, which is the very bug
+  //                                  #557 was filed about, rebuilt inside the field meant to fix it.
+  //
+  // So the gate is FIRST-SEEN, not liveness. Liveness was only ever a stand-in for a dedupe index
+  // that did not exist yet; a durable index retires the stand-in, and keeping both is what loses the
+  // disconnect-window mail. `live` and `bootstrap` stay on the record as audit facts — they explain
+  // why something arrived as replay — and they do not gate.
+  //
+  // `firstSeen` IS THE CALLER'S CLAIM AND THIS MODULE CANNOT CHECK IT. The index is durable state
+  // and lives in the daemon. Reaching this function is supposed to mean the caller's dedupe already
+  // claimed this id — `tools/agent-inbox.mjs` returns early on a hit, so every record it emits is
+  // first-seen by construction.
+  //
+  // BOTH DEFAULTS POINT AT WAKING, deliberately. A caller that forgets either flag gets duplicate
+  // wakes; a caller that forgets them under the opposite defaults gets silence. Those are not
+  // symmetric: a duplicate is noise somebody notices, and a suppression is permanent, because a
+  // first-seen claim is irreversible and no replay ever surfaces that message again. Wrong-and-loud
+  // over wrong-and-quiet, the same direction the spool's fsync ordering takes.
+  //
+  // BOOTSTRAP IS THE ONE CASE LIVENESS STILL OWNS. A first-ever start has an empty index, so a relay
+  // full of history is all-unseen and all-wake — the flood, arriving through the correct gate. The
+  // daemon seeds the index from that population without waking and passes `bootstrap: true` to say
+  // so. That is a per-run fact, not a per-message one, which is why it is a separate argument and
+  // not folded into `firstSeen`: those records ARE first-seen, and recording them as anything else
+  // would make the spool lie about what the index now contains.
+  const isFirstSeen = firstSeen === true
+  const isBootstrap = bootstrap === true
+  const { wake, why: wakeReason } = wakeVerdict(v, { firstSeen, bootstrap })
   const record = v.ok === true
     ? {
         ok: true,
+        id: wrapId,
+        received_at: seenAt,
+        wake,
+        wake_reason: wakeReason,
+        // THE THREE FACTS THE WAKE WAS COMPUTED FROM, each serialised on its own. One `wake:false`
+        // cannot say whether this was history, an already-delivered replay, or a stranger — and an
+        // operator debugging a quiet lane needs to tell those apart before they know what is wrong.
+        // `live` never gates; it is here so a replay is explicable rather than mysterious, and it is
+        // null when the emitter has no notion of a connection at all.
+        first_seen: isFirstSeen,
+        bootstrap: isBootstrap,
+        live: live === null || live === undefined ? null : live === true,
         author: String(v.author || ''),
         disposition: String(v.disposition || ''),
         // The gate, restated in the record rather than left to be re-derived by every adapter that
@@ -115,7 +190,19 @@ export function notifyLine(verdict) {
         reason: String(v.reason || ''),
         content: String(v.content ?? ''),
       }
-    : { ok: false, reason: String(v.reason || 'refused'), disposition: 'refused', mayAct: false, forMe: false }
+    // THE REFUSAL CARRIES AN ID TOO, and it is the branch that most needs one. An adapter that cannot
+    // dedupe a refusal re-wakes on every restart for a lane being fed forgeries — the one case where
+    // the records keep coming and none of them is worth waking for.
+    : {
+        ok: false, id: wrapId, received_at: seenAt,
+        // Carried on this branch too, and not hardcoded to false. An adapter greps one field; a
+        // record that simply omits it on refusals makes "absent" and "false" indistinguishable to
+        // that grep, and the refusal branch is the one a forgery-fed lane produces in volume.
+        wake, wake_reason: wakeReason,
+        first_seen: isFirstSeen, bootstrap: isBootstrap,
+        live: live === null || live === undefined ? null : live === true,
+        reason: String(v.reason || 'refused'), disposition: 'refused', mayAct: false, forMe: false,
+      }
   return JSON.stringify(record).split(U2028).join(String.raw`\u2028`).split(U2029).join(String.raw`\u2029`)
 }
 
@@ -153,6 +240,37 @@ export function notifyDecision(verdict, { hasCommand = true } = {}) {
 }
 
 /**
+ * Should this record wake anybody? The trust gate, plus the two delivery facts it does not know.
+ *
+ * ONE FUNCTION SO THE TWO PATHS CANNOT DISAGREE. `notifyLine` serialises this as `wake` and
+ * `invokeHook` gates on it, and they are the same call rather than two derivations of the same
+ * rule. The version of this that had a hook gate on one side and a stream an adapter re-derived on
+ * the other is how a proven, briefed adapter ended up waking on mail the hook path refused — a
+ * stranger's ordinary message is `ok:true, mayAct:false, receipt:false`, and the adapter matched it.
+ *
+ * The reason is returned either way, and it names the FIRST fact that refused rather than the last
+ * one checked, because this string is what an operator debugging a quiet lane reads before they know
+ * what is wrong. "Refused" and "refused with a misleading explanation" are indistinguishable to an
+ * assertion that only checks `!wake`.
+ */
+export function wakeVerdict(verdict, { firstSeen = true, bootstrap = false, hasCommand = true } = {}) {
+  if (firstSeen !== true) {
+    return Object.freeze({
+      wake: false,
+      why: 'already delivered — no durable first-seen claim was made for this id, so nobody is woken again',
+    })
+  }
+  if (bootstrap === true) {
+    return Object.freeze({
+      wake: false,
+      why: 'seeding the dedupe index on a first start — this history is recorded, not announced',
+    })
+  }
+  const decision = notifyDecision(verdict, { hasCommand })
+  return Object.freeze({ wake: decision.invoke === true, why: String(decision.why || '') })
+}
+
+/**
  * Run the wake hook for one message.
  *
  * `spawn` is injected so a suite can drive this with the REAL `node:child_process.spawn` against a
@@ -173,10 +291,14 @@ export function notifyDecision(verdict, { hasCommand = true } = {}) {
  * never fires and one that always fires are indistinguishable from outside, and a wake adapter that
  * is silently absent is the exact thing this exists to remove.
  */
-export async function invokeHook({ command, verdict, spawn, hasCommand = Boolean(command) } = {}) {
-  const decision = notifyDecision(verdict, { hasCommand })
-  if (!decision.invoke) return Object.freeze({ ran: false, ok: true, why: decision.why })
-  const line = notifyLine(verdict) + '\n'
+export async function invokeHook({ command, verdict, spawn, id = null, receivedAt = null, firstSeen = true, live = null, bootstrap = false, hasCommand = Boolean(command) } = {}) {
+  // THE SAME CALL `notifyLine` SERIALISES AS `wake`. Not the same rule written twice.
+  const decision = wakeVerdict(verdict, { firstSeen, bootstrap, hasCommand })
+  if (!decision.wake) return Object.freeze({ ran: false, ok: true, why: decision.why })
+  // THE SAME RECORD THE STREAM GETS, id included. A hook reading one shape and a spool reading
+  // another would disagree about what arrived, and the disagreement would only show up as an adapter
+  // that re-wakes on messages the stream considers already delivered.
+  const line = notifyLine(verdict, { id, receivedAt, firstSeen, live, bootstrap }) + '\n'
   return await new Promise(resolve => {
     let child
     const fail = e => resolve(Object.freeze({

--- a/src/return_lane_notify.mjs
+++ b/src/return_lane_notify.mjs
@@ -293,6 +293,19 @@ export function wakeVerdict(verdict, { firstSeen = true, bootstrap = false, hasC
  */
 export async function invokeHook({ command, verdict, spawn, id = null, receivedAt = null, firstSeen = true, live = null, bootstrap = false, hasCommand = Boolean(command) } = {}) {
   // THE SAME CALL `notifyLine` SERIALISES AS `wake`. Not the same rule written twice.
+  //
+  // `hasCommand` IS THE ONE ARGUMENT THE TWO SITES DELIBERATELY DISAGREE ON, and the asymmetry is the
+  // point rather than an oversight (#561 review, item 3). This site passes `Boolean(command)`, because
+  // it is about to run something and there must be something to run. `notifyLine` takes the default
+  // `true`, because a record answers the GATE's question — "would this have been allowed to wake
+  // anybody" — not "does this particular process happen to have a hook wired up". A spool written by
+  // a daemon with no hook must say the same thing as one written by a daemon with one, or an adapter
+  // reading it inherits a fact about somebody else's configuration.
+  //
+  // It cannot produce a disagreeing pair. With no command this returns before `notifyLine` is reached,
+  // so no record is emitted here at all; the only record in that case is the stream's, which is
+  // correct on its own terms. The suite pins the direction: `wake_reason` never blames a missing
+  // --on-message.
   const decision = wakeVerdict(verdict, { firstSeen, bootstrap, hasCommand })
   if (!decision.wake) return Object.freeze({ ran: false, ok: true, why: decision.why })
   // THE SAME RECORD THE STREAM GETS, id included. A hook reading one shape and a spool reading

--- a/tests/return_lane_notify.mjs
+++ b/tests/return_lane_notify.mjs
@@ -22,7 +22,7 @@ import { spawn, spawnSync } from 'node:child_process'
 import { chmodSync, existsSync, mkdtempSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { isCarriageReceipt, invokeHook, notifyDecision, notifyLine } from '../src/return_lane_notify.mjs'
+import { isCarriageReceipt, invokeHook, notifyDecision, notifyLine, wakeVerdict } from '../src/return_lane_notify.mjs'
 // The BRIDGE's own renderer, so the fixtures below are the strings the lane really sends. A suite
 // that hand-copies the prose cannot notice the renderer changing, and the failure that hides is a
 // real mention silently waking nobody.
@@ -94,6 +94,144 @@ check(rec.forMe === true && rec.mayAct === false,
   'the envelope carries forMe and mayAct as separate fields — being addressed is reported, never conflated with authority')
 check(JSON.parse(notifyLine({ ok: false, reason: 'attributed to nobody' })).ok === false,
   'a refusal is emitted as a record too — dropping it would leave a reader unable to tell a quiet lane from one being fed forgeries')
+
+// --------------------------------------------- the field an adapter filters on, and only that (#559)
+
+console.log('\nthe wake verdict travels on the record')
+
+// THE DEFECT THIS SECTION EXISTS FOR. The record stream is deliberately ungated — every record
+// reaches stdout so a lane being fed forgeries cannot look quiet — and a Claude Code adapter filtered
+// it with `grep '"receipt":false'`. A stranger's ordinary message is ok:true, mayAct:false,
+// receipt:false, so that woke on mail from anyone who can seal a wrap to this key, which under NIP-59
+// is everyone. The hook path refused precisely what the adapter woke on. Proven live on `ab65e477`
+// before this field existed; the fix is that both are now the SAME CALL, not two rules kept in step.
+const wakeOf = v => JSON.parse(notifyLine(v))
+const wakeOf2 = (v, id, receivedAt = null) => JSON.parse(notifyLine(v, { id, receivedAt }))
+
+check(wakeOf(verdict()).wake === true,
+  'a trusted sender wakes — the positive control, without which every refusal below proves nothing')
+
+// The exact record the broken filter matched. This is the assertion that would have caught it.
+const strangerRec = wakeOf(mentionedStranger)
+check(strangerRec.receipt === false && strangerRec.ok === true,
+  'a mentioning stranger still serialises as ok:true and receipt:false — the shape the old filter matched, unchanged')
+check(strangerRec.wake === false,
+  '  …and wake is false, so an adapter filtering ONE field refuses what `receipt` alone let through')
+
+check(wakeOf(verdict({ disposition: 'self', mayAct: false })).wake === false,
+  'this agent\'s own echo does not wake')
+check(wakeOf({ ok: false, reason: 'attributed to nobody' }).wake === false,
+  'a refusal does not wake, and still carries the field rather than omitting it')
+check(Object.prototype.hasOwnProperty.call(wakeOf({ ok: false, reason: 'x' }), 'wake'),
+  '  …present as a key on the refusal branch — an absent key and a false read the same to a filter that greps')
+
+// THE PROPERTY THAT MAKES THE BOUNDARY REAL. Not "wake agrees with notifyDecision" — they are the
+// same call, and this asserts that across every case rather than on one fixture.
+const cases = [
+  ['trusted', verdict()],
+  ['mentioning stranger', mentionedStranger],
+  ['copied stranger', verdict({ disposition: 'data', mayAct: false, forMe: false })],
+  ['own echo', verdict({ disposition: 'self', mayAct: false })],
+  ['refusal', { ok: false, reason: 'attributed to nobody' }],
+  // The trusted-carriage-receipt case is asserted in the #550 section below, against the BRIDGE's own
+  // renderer rather than a hand-copied string — it cannot be listed here because that fixture is
+  // built further down the file.
+]
+check(cases.every(([, v]) => wakeOf(v).wake === wakeVerdict(v).wake),
+  `the record's wake equals wakeVerdict for all ${cases.length} cases — the hook gate and the wake filter cannot disagree because they are one call`)
+// And that shared call still reduces to the trust gate when the two delivery facts say nothing. This
+// is what stops the first-seen work from having quietly widened or narrowed who may wake anybody.
+check(cases.every(([, v]) => wakeVerdict(v).wake === notifyDecision(v, { hasCommand: true }).invoke),
+  '  …and for a first-seen, non-bootstrap message it is exactly notifyDecision — the trust gate is unchanged by #557')
+
+// A wake:false whose stated cause is this daemon's own configuration would send an operator to fix a
+// flag when the truth is about the sender. The spool is not a hook and must never say otherwise.
+check(!/no --on-message command was given/.test(wakeOf(mentionedStranger).wake_reason),
+  'wake_reason never blames a missing --on-message — the record answers the gate\'s question, not "is a hook configured"')
+check(/not on the trust list/.test(wakeOf(mentionedStranger).wake_reason),
+  '  …it names the real cause, because this string is what an operator acts on')
+
+// ------------------------------- what gates the wake, and what only explains it (#557 review)
+
+console.log('\nfirst-seen gates the wake; liveness only annotates it')
+
+const wake3 = (v, o) => JSON.parse(notifyLine(v, o))
+const T = verdict()   // trusted, mayAct, not a receipt — wakes whenever the delivery facts allow it
+
+// CASE 1 — the flood. A first-ever start reads a relay full of history, every message of it unseen,
+// and must seed the index without announcing any of it. Its control is the line above: the SAME
+// verdict with bootstrap off wakes, so this is measuring the flag and not a fixture that never wakes.
+check(wake3(T, { bootstrap: false }).wake === true,
+  'the bootstrap control: this exact verdict wakes when it is not history')
+check(wake3(T, { bootstrap: true }).wake === false,
+  'a first-start backfill record does not wake — the #554 flood, which a Monitor answers by stopping itself, so the flood ends as silence')
+check(/seeding the dedupe index/.test(wake3(T, { bootstrap: true }).wake_reason),
+  '  …and says it was history, not that the sender was untrusted — those send an operator to different places')
+
+// CASE 2 — the one the strict formula fails. A relay's reconnect replay holds two populations it
+// cannot separate: already-delivered mail, and mail that ARRIVED DURING THE DISCONNECT. Both come
+// pre-EOSE, so both have live:false. Gating on liveness would suppress the second permanently, which
+// is the bug #557 was filed about, rebuilt inside the field meant to fix it.
+check(wake3(T, { live: false, firstSeen: true }).wake === true,
+  'a never-seen message replayed pre-EOSE DOES wake — mail that arrived during a disconnect is not history, and liveness cannot tell them apart')
+check(wake3(T, { live: false, firstSeen: false }).wake === false,
+  '  …while the already-delivered half of that same replay does not, because the dedupe claim is what separates them')
+check(/already delivered/.test(wake3(T, { firstSeen: false }).wake_reason),
+  '  …named as a re-delivery rather than a trust refusal')
+
+// The audit facts are on the record, distinctly. One `wake:false` cannot say whether a message was
+// history, a re-delivery, or a stranger, and an operator debugging a quiet lane needs to know which.
+const hist = wake3(T, { bootstrap: true, live: false })
+check(hist.bootstrap === true && hist.live === false && hist.first_seen === true,
+  'bootstrap, live and first_seen are three separate serialised facts — a bootstrap record is still first-seen, and a spool that said otherwise would lie about what the index now holds')
+check(wake3(T, {}).live === null,
+  'live is null when the emitter has no notion of a connection — absent and false are different claims')
+check([wake3(T, { firstSeen: false }), wake3({ ok: false, reason: 'nobody' }, { bootstrap: true })]
+  .every(r => ['wake', 'wake_reason', 'first_seen', 'bootstrap', 'live'].every(k => Object.prototype.hasOwnProperty.call(r, k))),
+  'all five keys are present on both branches — a refusal that omits them is indistinguishable from one that denies them, to an adapter that greps')
+
+// THE DEFAULTS POINT AT WAKING, and that is a decision rather than an accident. A caller who forgets
+// a flag gets a duplicate wake, which is noise somebody notices; under the opposite defaults they get
+// silence, and a first-seen claim is irreversible, so no replay ever surfaces that message again.
+check(wake3(T, {}).wake === true && wake3(T, {}).first_seen === true && wake3(T, {}).bootstrap === false,
+  'omitting both delivery facts wakes — the failure mode of a forgotten flag is a duplicate, never a permanent suppression')
+
+// Neither fact can OPEN the gate. They are only ever able to take away, the same property that makes
+// the content-shaped receipt test safe — otherwise `bootstrap:false` would be a way past the trust list.
+check([mentionedStranger, verdict({ disposition: 'self', mayAct: false }), { ok: false, reason: 'x' }]
+  .every(v => [{ firstSeen: true }, { bootstrap: false }, { live: true }, { firstSeen: true, bootstrap: false, live: true }]
+    .every(o => wake3(v, o).wake === false)),
+  'no combination of first_seen, bootstrap or live wakes an untrusted sender, an echo or a refusal — the delivery facts narrow the trust gate and can never widen it')
+
+// ------------------------------------------------------- the id an adapter is idempotent on (#559)
+
+console.log('\nthe record can be named')
+
+const ID1 = '1'.repeat(64), ID2 = '2'.repeat(64)
+
+// THE ONE THAT MATTERS MORE THAN "an id is present". Two distinct messages must not collapse: a
+// re-send is how this crew retries a message that reached nobody, so identical bodies from the same
+// author at the same second are a real case, not a contrived one.
+const same = { content: 'ping', author: A, at: 1_800_000_000 }
+check(wakeOf2(verdict(same), ID1).id !== wakeOf2(verdict(same), ID2).id,
+  'two wraps with IDENTICAL author, body and timestamp still get different ids — otherwise dedupe silently eats a deliberate re-send')
+check(wakeOf2(verdict(same), ID1).id === wakeOf2(verdict(same), ID1).id,
+  'and the same wrap seen twice gets the same id, which is what makes an adapter restart idempotent')
+
+check(wakeOf(verdict()).id === null,
+  'with no id passed the key is null, not undefined — "this daemon emits no ids" and "this record has none" are different states')
+check(Object.prototype.hasOwnProperty.call(wakeOf(verdict()), 'id'),
+  '  …and the key is present either way, so a reader can tell them apart at all')
+check(wakeOf2({ ok: false, reason: 'attributed to nobody' }, ID1).id === ID1,
+  'a refusal carries an id too — an adapter that cannot dedupe refusals re-wakes forever on a lane being fed forgeries')
+
+// `at` is the SENDER's clock and `--since` is answered from it. A spool ordered by that is a spool a
+// sender can reorder, so the daemon's own observation is a separate field.
+const stamped = JSON.parse(notifyLine(verdict({ at: 1_800_000_000 }), { id: ID1, receivedAt: 1_900_000_000 }))
+check(stamped.at === 1_800_000_000 && stamped.received_at === 1_900_000_000,
+  'rumor time and receive time are separate fields — a spool ordered by sender-controlled time is one a sender can reorder')
+check(JSON.parse(notifyLine(verdict(), { id: ID1, receivedAt: 1.5 })).received_at === null,
+  'a non-integer received_at lands as null rather than being written through — a cursor comparing it would silently misorder')
 
 // ------------------------------------------------- a trusted courier's echo is not news (#550)
 
@@ -180,6 +318,10 @@ check(isCarriageReceipt(JSON.stringify({ ok: false, channel: 'c', buzz_event_id:
 const recRec = JSON.parse(notifyLine(verdict({ content: RECEIPT })))
 check(recRec.receipt === true && recRec.content === RECEIPT,
   'the receipt is still emitted as a record, flagged — suppressing the record would break a send/ack tally')
+// The third case the wake verdict has to carry, listed with the others in the #559 section above but
+// asserted here, against the renderer's own output rather than a hand-copied string.
+check(recRec.wake === false && recRec.wake === notifyDecision(verdict({ content: RECEIPT }), { hasCommand: true }).invoke,
+  '  …and it does not wake, by the same call the hook path uses — spooled and visible, but nobody said it')
 check(JSON.parse(notifyLine(verdict({ content: CARRIED }))).receipt === false,
   'and a real message is flagged as not a receipt')
 

--- a/tools/agent-inbox.mjs
+++ b/tools/agent-inbox.mjs
@@ -96,7 +96,17 @@ const seen = new Set()
 // Two decrypts with a signature check BETWEEN them, exactly as src/nostr_egress.mjs insists: the
 // seal's signature is the authorship proof, and doing the second (expensive) decrypt before it holds
 // would run unauthenticated input through the signer.
-async function open(wrap, live = true) {
+// The two fields an adapter needs and this module is the only place that has (#559): the VERIFIED
+// wrap id, and when this process saw it. `wrap.id` is only safe to use after `verifyEvent` below —
+// until then it is a field in unauthenticated relay JSON, and a relay that could choose it could
+// choose which record a spool cursor believes it has already delivered. Every call site here is
+// downstream of that check.
+//
+// `received_at` is deliberately not `at`. `at` is rumor time, set by the sender, and `--since` is
+// answered from it; ordering a spool by it would let a sender reorder the spool.
+const stamp = wrap => ({ id: String(wrap?.id || ''), receivedAt: Math.floor(Date.now() / 1000) })
+
+async function open(wrap, live = true, bootstrap = false) {
   // VERIFY BEFORE DEDUPING. `seen` is keyed on `wrap.id`, and until this line nothing had proved
   // that id was the event's own hash — it was a field in unauthenticated relay JSON. An event
   // carrying a colliding id, delivered first, would take the slot and silently suppress the real
@@ -112,7 +122,14 @@ async function open(wrap, live = true) {
     return
   }
   if (seen.has(wrap.id)) return
+  // THE FIRST-SEEN CLAIM. Reaching past this line means this id was not in the index, which is the
+  // fact `notifyLine` serialises as `first_seen` and gates `wake` on — so it is claimed here, once,
+  // and carried rather than re-derived downstream. In this process the index is in memory and dies
+  // with it; the durable one is the daemon's half of #557.
   seen.add(wrap.id)
+  // Stamped ONCE per message, not once per emit site: three calls to Date.now() would put three
+  // different `received_at` values on records describing the same arrival.
+  const meta = { ...stamp(wrap), firstSeen: true, live, bootstrap }
   if (wrapAddressedTo(wrap, self).ok !== true) return
   let seal
   try { seal = JSON.parse(await signer.nip44Decrypt(wrap.pubkey, wrap.content)) }
@@ -129,7 +146,7 @@ async function open(wrap, live = true) {
     // nobody — and it used to return before the emit below. A lane being fed forged seals then put
     // zero lines on stdout and looked exactly like a quiet one, which is the sentence this record
     // stream exists to prevent.
-    if (jsonl) process.stdout.write(notifyLine(author) + '\n')
+    if (jsonl) process.stdout.write(notifyLine(author, meta) + '\n')
     return
   }
   let rumor
@@ -146,7 +163,7 @@ async function open(wrap, live = true) {
   if (jsonl) {
     // One record per line on stdout, refusals included. Dropping a refusal silently would leave a
     // reader unable to tell a quiet lane from one being fed forgeries.
-    process.stdout.write(notifyLine(verdict) + '\n')
+    process.stdout.write(notifyLine(verdict, meta) + '\n')
   } else if (verdict.ok === true) {
     const mark = verdict.disposition === 'trusted' ? 'TRUSTED' : verdict.disposition.toUpperCase()
     console.log(`\n[${mark}] ${verdict.author.slice(0, 16)}…${verdict.forMe ? '' : '  (this agent was copied, not addressed)'}`)
@@ -157,17 +174,24 @@ async function open(wrap, live = true) {
   } else {
     console.log(`\n[REFUSED] ${verdict.reason}`)
   }
-  // THE BACKFILL MUST NOT WAKE ANYONE (#554). In --watch, every relay replays its history before
-  // EOSE, so a hook gated only on the verdict fires once per historical message the moment the
-  // watcher starts — the Pi runtime widened its window to see fresh mail at all and got a flood of
-  // old ones instead. A restart replays it again, so this also removes the need for a persisted
-  // seen-set: the backfill simply never reaches the hook.
+  // THE BACKFILL MUST NOT WAKE ANYONE (#554), AND THE RECONNECT REPLAY MUST (#557 review). This
+  // line used to read `if (onMessage && (live || !watch))`, gating the hook on liveness. That stops
+  // the first-start flood, and it also drops mail: the replay after a reconnect holds two
+  // populations the relay does not distinguish — messages already delivered, and messages that
+  // ARRIVED DURING THE DISCONNECT, never seen by anyone. Both land pre-EOSE with `live === false`.
+  // Suppressing the second is the bug #557 was filed about, and the backoff runs to 60s.
   //
-  // A ONE-SHOT RUN IS THE OTHER CASE and it deliberately still fires. There `live` defaults to true,
+  // So liveness no longer gates. `invokeHook` applies the same `wakeVerdict` the record stream is
+  // serialised from, and its gate is the first-seen claim above: an already-delivered replay never
+  // reaches this line at all, because the dedupe returned early. What liveness still owns is
+  // `bootstrap` — the history a relay owes us on a FIRST connection, which is all-unseen and would
+  // otherwise be all-wake. That is a per-run fact, computed at the subscription, and it is the only
+  // thing standing between an arm and a flood.
+  //
+  // A ONE-SHOT RUN IS THE OTHER CASE and it deliberately still fires: `bootstrap` is false there,
   // because a read with no --watch IS an intentional drain of the mailbox into whatever the hook
-  // does with it. The two modes want opposite things from the same history and this is the line
-  // where they part.
-  if (onMessage && (live || !watch)) track(runHook(verdict))
+  // does with it.
+  if (onMessage) track(runHook(verdict, meta))
 }
 
 // The wake hook. Gated on notifyDecision, which is gated on the trust list and NOTHING else — a
@@ -181,8 +205,8 @@ async function open(wrap, live = true) {
 // A hook that cannot be spawned is counted as FAILED, not ignored. An alarm that never fires and
 // one that always fires are indistinguishable from outside, and a wake adapter that silently is not
 // there is the exact failure this tool exists to remove.
-async function runHook(verdict) {
-  const r = await invokeHook({ command: onMessage, verdict, spawn })
+async function runHook(verdict, meta) {
+  const r = await invokeHook({ command: onMessage, verdict, spawn, ...meta })
   // ITS OWN COUNTER, NEVER `failed`. `failed` is what inboxSummary renders as "could not be opened",
   // whose stated cause is a signer that signs but will not decrypt. A hook that exits non-zero AFTER
   // the message was opened and emitted would have sent the operator to debug their bunker about a
@@ -242,7 +266,23 @@ await Promise.all(RELAYS.map(url => new Promise(resolve => {
   const t = setTimeout(end, watch ? 0x7fffffff : 12000)
 
   let live = false
+  // Per RELAY, and it NEVER goes back to false — which is the whole reason it is separate from
+  // `live`, which does reset below. A relay owes us its entire history once, on the first
+  // connection. After this flips, a pre-EOSE envelope from that relay can no longer be assumed to be
+  // history: it may be mail that arrived while we were away, and nothing on the wire tells them apart.
+  //
+  // TWO FLAGS RATHER THAN ONE, so `bootstrap` stays correct whichever way `live` behaves. Until this
+  // change `live` was declared here, outside `connect()` — and `connect()` is re-invoked from
+  // `onclose`, so it was never reset and stayed true for the life of the process, while the comment
+  // below asserted the opposite. Anything deriving "is this backfill" from `live` alone was therefore
+  // inert after the first reconnect. Found by My Dude in #557 review, correcting his own first
+  // reading of it; this flag is monotonic by construction and does not depend on the answer.
+  let everSynced = false
   const connect = () => {
+    // Reset per connection, so the field means what its name and the comment below claim: arrived
+    // after THIS connection's EOSE. It is an AUDIT fact and nothing gates on it — an audit field that
+    // quietly means something other than its name is worse than no field, because a reader acts on it.
+    live = false
     try { ws = new WebSocket(url) } catch { return end() }
     ws.onopen = () => {
       backoff = 1000
@@ -252,16 +292,23 @@ await Promise.all(RELAYS.map(url => new Promise(resolve => {
       let m
       try { m = JSON.parse(e.data) } catch { return /* a relay that speaks nonsense is one relay, not a crash */ }
       if (m[0] === 'EVENT' && m[2]) {
+        // Bootstrap is the first connection's backfill and nothing else. In a one-shot read it is
+        // always false: that whole run is a deliberate drain.
+        const bootstrap = watch && !live && !everSynced
         // `live` is per-connection and flips at THIS relay's EOSE, so an envelope is live only if it
-        // arrived after the backfill that relay owed us. On a reconnect the subscription replays and
-        // `live` goes false again, which is correct: those are old messages arriving a second time.
-        track(open(m[2], live).catch(err => {
+        // arrived after the backfill that relay owed us. On a reconnect it goes false again and the
+        // subscription replays — but that replay is NOT simply "old messages arriving a second time",
+        // which is what this comment used to say and what a review took from it instead of from the
+        // code. It holds two populations the relay does not distinguish: messages already delivered,
+        // and messages that arrived DURING the disconnect and have been seen by nobody. Only the
+        // dedupe index separates them, which is why the wake gates on that and not on this.
+        track(open(m[2], live, bootstrap).catch(err => {
           failed++
           console.error(`  an opener threw — ${String(err?.message || err).slice(0, 160)}`)
         }))
         return
       }
-      if (m[0] === 'EOSE') { answered++; live = true; if (!watch) { clearTimeout(t); end() } }
+      if (m[0] === 'EOSE') { answered++; live = true; everSynced = true; if (!watch) { clearTimeout(t); end() } }
     }
     // `ws` emits 'close' after 'error', so the close handler is the single place this is decided.
     ws.onerror = () => {}


### PR DESCRIPTION
Closes #559 and #560. First piece of #557, built against the contract worked out on the lane with @Pi Dog, @Dennis and My Dude.

## The defect

The `--jsonl` record stream is deliberately ungated — every record reaches stdout, refusals included, so a lane being fed forgeries cannot look quiet (`tools/agent-inbox.mjs:146-149`). The trust gate lives only on the hook path (`:170` → `notifyDecision` → `src/return_lane_notify.mjs:133`).

My live Claude Code adapter filtered that stream with `grep '"receipt":false'`. A stranger's ordinary message serialises as `ok:true, disposition:'data', mayAct:false, receipt:false` — so it woke on mail from anyone who can seal a wrap to this key, which under NIP-59 is everyone. The hook path refused precisely what the adapter woke on. Found by My Dude, verified at `ab65e477`.

Body text cannot forge the filter — `JSON.stringify` escapes the quotes, so a hostile body renders `\"receipt\":false`. That is a relied-upon property now, not an accident.

## The fix, and the two wrong versions of it

One field, `wake`, emitted by the same call the hook gates on. Not the same rule kept in step in two places — that is what failed.

| formula | fails how |
|---|---|
| `wake = invoke` | floods. Every relay replays history pre-EOSE, so an adapter fires once per historical message on arm (#554). A Monitor answers a flood by **stopping itself**, so the flood ends as silence. |
| `wake = live && invoke` | drops mail. The reconnect replay holds messages already delivered **and** messages that arrived during the disconnect, seen by nobody. Both land pre-EOSE. |
| `wake = first_seen && invoke` | survives both. |

Liveness was only ever a stand-in for a dedupe index that did not exist yet. The record carries `first_seen`, `bootstrap` and `live` as three separate facts: one `wake:false` cannot say whether a message was history, a re-delivery, or a stranger, and those send an operator to different places. Bootstrap is the one case liveness still owns — a first start has an empty index, so its whole backfill is unseen and would be all-wake.

Both defaults point at waking. A forgotten flag then costs a duplicate wake, which is noise somebody notices; under the opposite defaults it costs silence, and a first-seen claim is irreversible.

Also on the record: `id`, the verified wrap id — taken after `verifyEvent`, so it is a hash the relay cannot choose, rather than a field in unauthenticated relay JSON that would let a relay pick which record a cursor believes it delivered. And `received_at`, this process's own clock, separate from the sender-controlled `at`.

## Two subscription bugs this closes

**`live` never reset.** It was declared outside `connect()`, which is re-invoked from `onclose` — so it stayed true for the life of the process, while its own comment claimed it went false on reconnect. Anything deriving "is this backfill" from it was inert after the first reconnect, with only the in-memory `seen` set behind it. My Dude found this correcting his own earlier reading; it is on `main` independently of #557 and is filed as #560, which this closes. `live` now resets per connection and means what it says, and `bootstrap` reads a separate monotonic flag so it is correct either way.

**The hook gated on `live`.** `if (onMessage && (live || !watch))` dropped mail arriving during a disconnect, on a backoff that runs to 60s. Liveness no longer gates anything; `bootstrap` and the first-seen claim do.

## Scope: this fixes HALF of the gap-mail case

Corrected after review — the first version of this body read as though the headline case was closed. It is not.

**Reconnect gap-mail is fixed here.** `live` is already true when the replay arrives, `everSynced` is true, so `bootstrap` is false and the first-seen claim decides — mail that arrived while the socket was down wakes.

**Restart gap-mail is not, and cannot be until the index is durable.** `everSynced` is per process and `seen` is in-memory, so on a fresh start the whole first backfill is `bootstrap: true` and is seeded without waking. That is the correct bootstrap rule and it is exactly right for a first-ever start — but with an in-memory index **every restart is a first-ever start**, and the pilot unit runs `Restart=always` with `RestartSec=5`. Restarts are the ordinary case there, not the exception.

Both halves are #557's headline. Do not stop looking at #557 because this merged.

## Verification

- `tests/return_lane_notify.mjs` — **77 passed, 0 failed** (was 65).
- The assertion that would have caught the original defect: a mentioning stranger still serialises `ok:true, receipt:false` — the shape the broken filter matched, unchanged — **and** `wake === false`.
- Both mandatory cases from the review, each with its positive control, so a never-waking fixture cannot pass them: a bootstrap record does not wake while the same verdict does when it is not history; a never-seen message replayed pre-EOSE **does** wake while the already-delivered half of that same replay does not.
- No combination of `first_seen`, `bootstrap` or `live` wakes an untrusted sender, an echo or a refusal — the delivery facts can only narrow the trust gate.
- **`first_seen: false` is unreachable through the tool today.** `open()` returns early on the `seen.has(wrap.id)` check, before the record is built, so a duplicate produces no record at all and `firstSeen` is hardcoded true at the only call site. The mutation kills on that branch are therefore evidence about the **module**, not about `agent-inbox`. The daemon is what will pass `false`. Whether a duplicate should be spooled as `wake:false, first_seen:false` rather than vanishing is a live contract question for @Pi Dog — an audit trail that silently omits duplicates cannot answer "why did this not wake", which is the question the three separated facts exist to answer.
- **Six mutations of the wake formula, all killed**, including the withdrawn `live && invoke` (5 failures) and serialising `wake` from `notifyDecision` alone, bypassing the shared call (5 failures). Every mutation asserts its anchor first.
- `npx eslint .` — 0 errors.
- `npm test` — `install_state: 2 FAILED`, which is the known fresh-worktree failure from an absent `config.json`. Confirmed identical at `HEAD` with my changes stashed, not reasoned about.

## What is not in this

The durable half of #557 — the spool, the persisted index, fsync ordering, the service unit. This is the record layer that half will write. Still open from the review and not addressed here: bootstrap must key on an explicit positive marker rather than the absence of an index, and the spool record must be durable before the claim is.

Review: @My Dude — you found this one and corrected the fix twice; the call sites are the part worth your attention, since the module is tested hard and `tools/agent-inbox.mjs` is where the flags are computed.

Drafted with assistance from [Claude Code](https://claude.com/claude-code)


