### PR TITLE
A space in a server name made the whole Claude Code registry unreadable (#566)

### DIFF
--- a/src/mcp_runtimes.mjs
+++ b/src/mcp_runtimes.mjs
@@ -103,8 +103,44 @@ export function exclusivityVerdict(foreign, unreadable = 0) {
  * Now every non-blank line must be recognised or the whole read is null. A format change surfaces
  * as INCONCLUSIVE, which is the correct direction to be wrong in and the reason the four-state
  * report exists at all.
+ *
+ * A SERVER NAME MAY CONTAIN SPACES, and until #566 one that did took the whole registry down with
+ * it. The claude.ai-hosted connectors are named `claude.ai Google Drive`, `claude.ai Gmail` and so
+ * on; five of them on the maintainer's Mac meant `null` every time, so the row never saw what was
+ * registered in Claude Code and reported only what Codex had. It failed CLOSED — `unreadable > 0`
+ * is never a pass — so it was not a false green. It was worse in the quieter way: the operator was
+ * told to remove one foreign server and not told about the two the discarded list held.
+ *
+ * THE GUARD MOVED TO THE OTHER END OF THE LINE, and that is the whole design. The name is now
+ * `[^:]+` — anything up to the first colon — which is the denylist the paragraph above blames for
+ * parsing `Error: unable to read config` as a server called `Error`. It is safe here only because
+ * the trailing status is checked instead: a line must end in ` - ` followed by a status, so that
+ * error line still reads as null, and so do `zsh: command not found: claude` and a stack trace.
+ * Every case #464 lists is still refused; the refusal just comes from the end of the line rather
+ * than the start.
+ *
+ * Trying it the other way is what proved it. The first fix kept an allowlist name and merely added
+ * spaces to it — and a mutation widening that name to `[^:]+` could not be killed, because with the
+ * status anchored the two are equivalent for every line either would ever see. What the narrow
+ * class still did was give a LEGITIMATE name one more way to make the whole registry unreadable:
+ * a server called `svc/worker` or one named in a non-Latin script would have taken it down exactly
+ * as `claude.ai Gmail` did. That is #566 again with a different character, so the class went.
+ *
+ * THE STATUS IS ANCHORED BY SHAPE, NOT BY GLYPH, and that is a deliberate second choice. The first
+ * version of this fix pinned the exact markers the CLI prints here — U+2714, U+2718, `!` — and the
+ * suite immediately caught that this file's own fixtures had been written with U+2713 instead. Two
+ * spellings of a tick, one in the fixtures and a different one in production, neither ever compared
+ * against the other. Pinning the glyph would therefore have re-created #566 on the next CLI update,
+ * silently and in the same way. So the rule is: a status is one leading character that is not a
+ * letter, a digit or a space. `✓ ✔ ✗ ✘ !` all qualify without being enumerated,
+ * and `Error: config not found - check permissions` does not, because `check` starts with a letter.
+ *
+ * A future `- OK` would fail to parse and read as INCONCLUSIVE. That is the correct direction to be
+ * wrong in, and it is the direction this whole file is built around.
  */
-const CLAUDE_ENTRY = /^([A-Za-z0-9._-]+):\s+\S.*\s-\s+\S/
+const CLAUDE_STATUS = '[^\\p{L}\\p{N}\\s]'
+const CLAUDE_NAME = '[^:]+'
+const CLAUDE_ENTRY = new RegExp(`^(${CLAUDE_NAME}):\\s+\\S.*\\s-\\s+${CLAUDE_STATUS}`, 'u')
 const CLAUDE_EMPTY = /^No MCP servers configured\b/
 // Progress chatter the CLI prints around the list. Matched exactly rather than skipped loosely:
 // "any line that is not an entry" is how the old parser got here.

--- a/tests/mcp_runtimes.mjs
+++ b/tests/mcp_runtimes.mjs
@@ -99,6 +99,47 @@ check(JSON.stringify(parseClaudeList(`Checking MCP server health...\n\n${CLAUDE_
 check(foreignServers(parseClaudeList('Error: unable to read config'), 'mc-claude') === null,
   'an unreadable list stays UNKNOWN all the way to foreignServers, and cannot print a clean tick')
 
+// ── A SPACE IN A SERVER NAME (#566) ──────────────────────────────────────────────────────────
+// The claude.ai-hosted connectors are named `claude.ai Gmail`, `claude.ai Google Drive` and so on.
+// The name class had no space in it, so one of those lines returned null for the WHOLE registry —
+// and five of them are present on the maintainer's Mac. The fixtures above never caught it because
+// every name in them is a single token, which is the same shape of miss as the space-in-a-name bug
+// that took the sealed lane down: the suite was green and production was not.
+const CLAUDE_HOSTED = [
+  'claude.ai Google Drive: https://drivemcp.googleapis.com/mcp/v1 - ✔ Connected',
+  'claude.ai Notion: https://mcp.notion.com/mcp - ! Needs authentication',
+  'nvoy-lukedog: /path/node /path/claude-channel.mjs --instance lukedog - ✘ Failed to connect',
+].join('\n')
+check(JSON.stringify(parseClaudeList(CLAUDE_HOSTED))
+  === JSON.stringify(['claude.ai Google Drive', 'claude.ai Notion', 'nvoy-lukedog']),
+  'claude: a name containing spaces parses, and keeps the space — this returned null for the whole list')
+
+// THE ASSERTION THAT WOULD HAVE FAILED IN PRODUCTION. The point of the row is finding a foreign
+// nvoy server; a discarded list finds none, and the operator is told the machine is clean of
+// everything the unread runtime held.
+check(JSON.stringify(foreignServers(parseClaudeList(CLAUDE_HOSTED), 'mc-claude'))
+  === JSON.stringify(['nvoy-lukedog']),
+  '  …and the foreign nvoy server beside it is DETECTED, not silently dropped with the list')
+
+// THE STATUS IS ANCHORED BY SHAPE, NOT BY GLYPH. Both spellings of a tick must work: production
+// prints U+2714 and this file's own fixtures above were written with U+2713, which is exactly how
+// a glyph allowlist would have re-created #566 on the next CLI update.
+check(JSON.stringify(parseClaudeList('a: /x - ✓ Connected\nb: /y - ✔ Connected'))
+  === JSON.stringify(['a', 'b']),
+  'claude: U+2713 and U+2714 are both accepted — the exact tick is deliberately not pinned')
+check(parseClaudeList('Error: config not found - check permissions') === null,
+  'claude: prose after the dash is still INCONCLUSIVE — widening the NAME did not widen the line')
+check(parseClaudeList('nvoy: node /x.js - OK') === null,
+  'claude: an unrecognised status reads as INCONCLUSIVE rather than as a short list')
+
+// THE GUARD IS THE STATUS, NOT THE NAME. Every #464 refusal above must still hold with the name
+// class gone, or widening it traded one silent failure for another. These are the same inputs, kept
+// here deliberately next to the widening that could have broken them.
+check(parseClaudeList('svc/worker: node /x.js - ✓ Connected') !== null,
+  'claude: a name this parser never anticipated still parses — a narrow class is just #566 waiting')
+check(parseClaudeList('zsh: command not found: claude') === null,
+  '  …and a shell failure is STILL refused, by the missing status rather than by the name')
+
 // ── The row itself. The line above is true of `foreignServers`, and was written as though it were
 // true of the REPORT — one frame below where the sentence is about. It is not: the tool asked only
 // the runtimes that ANSWERED, so `claude` answering clean while `codex` sat installed-and-unreadable


### PR DESCRIPTION
Found auditing the onboarding rails ahead of the Codex/Grokbot run. Closes nothing on its own — `#566` has the full write-up.

## What was wrong

`parseClaudeList` returned `null` for the real output of `claude mcp list` on the maintainer's Mac. The name class was `[A-Za-z0-9._-]+`, with no space, and the claude.ai-hosted connectors are named `claude.ai Gmail`, `claude.ai Google Drive`, `claude.ai Notion`. One unrecognised line invalidates the whole read — that part is deliberate and stays — so five connector lines took the registry down with them.

## What it cost

Not a false green. `exclusivityVerdict` fails closed: `unreadable > 0` returns UNKNOWN, never a pass. That design worked.

It under-reported instead. Foreign nvoy servers registered in **Claude Code were never detected**, because the list they would have appeared in was thrown away. Same command, same machine, before and after:

```
before:  nvoy_codex_jaf (Codex CLI)
         (Claude Code went unread, so there may be more.)

after:   nvoy (Claude Code), nvoy-mc-claude (Claude Code), nvoy-oliver (Claude Code),
         nvoy-lukedog (Claude Code), nvoy_codex_jaf (Codex CLI)
```

Four servers that carry tools which **sign, and not as the agent being onboarded**, invisible to the row whose entire job is finding them. The operator was told to remove one and told the rest of the machine was unexamined — which reads, at a glance, as examined.

This is the failure the row was built for after a LukeDog session once reported itself as MC Claude.

## The fix

The guard moved to the other end of the line. The name is now `[^:]+`; the trailing status must be a leading non-letter, non-digit character. Every refusal #464 lists still holds — `Error: unable to read config`, `zsh: command not found: claude`, a stack trace, blank output — the refusal just comes from the end of the line instead of the start.

## Two things I got wrong first, both now in the comment

**The allowlist name was the wrong instinct.** The first version kept an allowlist and merely added spaces to it. The mutation widening that name to `[^:]+` **could not be killed** — with the status anchored, the two are equivalent for any line either would ever see. Meanwhile the narrow class still gave a *legitimate* name one more way to take the registry down: a server called `svc/worker`, or one named in a non-Latin script, fails exactly as `claude.ai Gmail` did. That is this bug again with a different character, so the class went. The escaped mutation is what taught me that; it is the reason to run them.

**The status is anchored by shape, not by glyph.** I pinned the exact markers first — U+2714, U+2718, `!` — and the suite immediately caught that this file's own fixtures use U+2713. Two spellings of a tick, one in the fixtures and another in production, never compared. Pinning the glyph would have re-created #566 on the next CLI update, silently and identically.

## Verification

- `tests/mcp_runtimes.mjs` — 96 passed, 0 failed.
- Mutation, anchor-guarded: **3 of 3 killed, 0 escaped** — the space removed, the status anchor loosened, and both guards dropped at once.
- The assertion that would have failed in production is asserted at the surface, not just at the parser: a foreign `nvoy-*` server sitting beside a spaced connector name is **detected**, rather than dropped with the list.
- Both directions throughout — a parser that returned `null` for everything passes every fail-closed check while taking the feature down, so each refusal is paired with a legitimate line that still gets through.
- Full `npm test` rc=0 across the chain; `npx eslint .` 0 errors.

## Review

@My Dude — this touches a guard, so it is substantive. The part worth attacking is the widened name: I argue the status anchor subsumes the #464 protection and the mutation set says so, but that is exactly the kind of claim that has been wrong here before. The other question worth your eye is whether `[^\p{L}\p{N}\s]` is the right shape, or whether a future `- OK` reading as INCONCLUSIVE is too brittle.

Drafted with assistance from [Claude Code](https://claude.com/claude-code)
