### PR TITLE
Release inbox claim after decrypt failure

### DIFF
--- a/tests/wake_spool_lane.mjs
+++ b/tests/wake_spool_lane.mjs
@@ -61,6 +61,25 @@ const wrapFor = (senderSk, text) => {
   }, wsk)
 }
 
+// A real, signed kind:1059 addressed to `self`, but whose ciphertext cannot open. This reaches the
+// first decrypt catch, same as a transient bunker timeout opening the wrap after the id has been
+// verified and claimed.
+const unreadableWrap = () => finalizeEvent({
+  kind: 1059, created_at: Math.floor(Date.now() / 1000), tags: [['p', selfPk]], content: 'not-nip44-ciphertext',
+}, generateSecretKey())
+
+// A wrap that opens into a real signed seal whose content cannot open. This reaches the SECOND
+// decrypt catch after sealAuthor has verified the seal, proving both release sites.
+const unreadableSealWrap = () => {
+  const now = Math.floor(Date.now() / 1000)
+  const seal = finalizeEvent({ kind: 13, created_at: now, tags: [], content: 'not-nip44-ciphertext' }, courierSk)
+  const wsk = generateSecretKey()
+  return finalizeEvent({
+    kind: 1059, created_at: now, tags: [['p', selfPk]],
+    content: nip44.encrypt(JSON.stringify(seal), nip44.getConversationKey(wsk, selfPk)),
+  }, wsk)
+}
+
 // --- the scripted relay -----------------------------------------------------------------------------
 /**
  * Serves `backfill()` then EOSE on every subscription. `dropAfterEose` closes the socket once, so the
@@ -173,6 +192,70 @@ console.log('\na durable write that failed must not leave the message claimed in
     `spooled=${spoolIds(dir).length} code=${r.code}`)
   check(!/the in-memory claim is released/.test(r.errOut),
     '  …and says nothing about releasing a claim — the line above is a real failure path, not always-on prose')
+}
+
+console.log('\na transient wrap decrypt failure must not leave the message claimed in memory')
+
+// Same seam, one frame earlier: the tool claims the verified wrap id before the two NIP-44 decrypts.
+// If a bunker times out there and the claim is not released, every relay replay returns at
+// `seen.has(wrap.id)` above the decrypt, above the spool and above the hook. A second, different bad
+// wrap on the replay is the control that proves the replay reached the handler at all.
+{
+  const dir = freshDir()
+  writeFileSync(join(dir, 'seen.log'), ''); writeFileSync(join(dir, 'started'), 'seeded by the suite\n')
+  const stuck = unreadableWrap()
+  const different = unreadableWrap()
+  const before = relay.state.connections
+  relay.state.backfill = () => relay.state.connections <= before + 1 ? [stuck] : [stuck, different]
+  relay.state.dropAfterEose = true
+
+  const r = await runTool([...base, ...trust, '--spool', dir, '--watch'], {}, { killAfterMs: 2500 })
+  const couldNotOpen = (r.errOut.match(/could not open a wrap/g) || []).length
+  const released = (r.errOut.match(/could not open a wrap[^\n]*the in-memory claim is released/g) || []).length
+
+  check(relay.state.connections >= before + 2,
+    'the control: the relay served a second connection, so the unreadable wrap was replayed',
+    `connections=${relay.state.connections - before}`)
+  check(couldNotOpen >= 3,
+    'the SAME unreadable wrap is tried again after replay, not suppressed by the failed first claim',
+    `could-not-open=${couldNotOpen}`)
+  check(released >= 3,
+    'each wrap decrypt failure releases the in-memory claim, so a later replay can retry it',
+    `released=${released}`)
+  check(spoolIds(dir).length === 0,
+    'and no durable record is invented for a message the tool could not open',
+    `spooled=${spoolIds(dir).length}`)
+}
+
+console.log('\na transient seal decrypt failure must not leave the message claimed in memory either')
+
+// Same replay assertion for the SECOND decrypt catch. The wrap opens and the seal signature verifies;
+// only the rumor ciphertext is bad. Removing the seal-catch release used to survive the whole suite.
+{
+  const dir = freshDir()
+  writeFileSync(join(dir, 'seen.log'), ''); writeFileSync(join(dir, 'started'), 'seeded by the suite\n')
+  const stuck = unreadableSealWrap()
+  const different = unreadableSealWrap()
+  const before = relay.state.connections
+  relay.state.backfill = () => relay.state.connections <= before + 1 ? [stuck] : [stuck, different]
+  relay.state.dropAfterEose = true
+
+  const r = await runTool([...base, ...trust, '--spool', dir, '--watch'], {}, { killAfterMs: 2500 })
+  const couldNotOpen = (r.errOut.match(/could not open a seal/g) || []).length
+  const released = (r.errOut.match(/could not open a seal[^\n]*the in-memory claim is released/g) || []).length
+
+  check(relay.state.connections >= before + 2,
+    'the control: the relay served a second connection, so the unreadable seal was replayed',
+    `connections=${relay.state.connections - before}`)
+  check(couldNotOpen >= 3,
+    'the SAME unreadable seal is tried again after replay, not suppressed by the failed first claim',
+    `could-not-open=${couldNotOpen}`)
+  check(released >= 3,
+    'each seal decrypt failure releases the in-memory claim, so a later replay can retry it',
+    `released=${released}`)
+  check(spoolIds(dir).length === 0,
+    'and no durable record is invented for a seal the tool could not open',
+    `spooled=${spoolIds(dir).length}`)
 }
 
 // ============================================================ must-fix 2: the marker is written last

--- a/tools/agent-inbox.mjs
+++ b/tools/agent-inbox.mjs
@@ -166,8 +166,11 @@ async function open(wrap, live = true, bootstrap = false) {
   try { seal = JSON.parse(await signer.nip44Decrypt(wrap.pubkey, wrap.content)) }
   catch (e) {
     // Never counted as "no mail". This is the branch a bunker without nip44_decrypt lands in.
+    // The in-memory claim is released because no durable record was written; otherwise a transient
+    // NIP-46 timeout suppresses every relay replay for the life of this watcher.
+    seen.delete(wrap.id)
     failed++
-    console.error(`  could not open a wrap — ${String(e?.message || e).slice(0, 160)}`)
+    console.error(`  could not open a wrap — ${String(e?.message || e).slice(0, 160)}; the in-memory claim is released`)
     return
   }
   const author = sealAuthor(seal, verifyEvent)
@@ -189,7 +192,7 @@ async function open(wrap, live = true, bootstrap = false) {
   }
   let rumor
   try { rumor = JSON.parse(await signer.nip44Decrypt(seal.pubkey, seal.content)) }
-  catch (e) { failed++; console.error(`  could not open a seal from ${author.author.slice(0, 12)}… — ${String(e?.message || e).slice(0, 160)}`); return }
+  catch (e) { seen.delete(wrap.id); failed++; console.error(`  could not open a seal from ${author.author.slice(0, 12)}… — ${String(e?.message || e).slice(0, 160)}; the in-memory claim is released`); return }
   const verdict = rumorVerdict(rumor, { author: author.author, self, trusted })
 
   // THE MESSAGE CLOCK. `--since` is answered here, from the rumor, not on the wire — see WIRE_FLOOR.


### PR DESCRIPTION
## What is broken

`tools/agent-inbox.mjs` verifies and claims a wrap id in the in-memory `seen` set before opening the NIP-59 wrap and seal. If either NIP-46 `nip44_decrypt` call times out or fails, no record is written, but the in-memory claim survives. Later relay replays short-circuit at `seen.has(wrap.id)`, above decrypt, above spool, and above the hook, so the message is suppressed for the life of that watcher process.

## Fix

Release the in-memory claim in both decrypt failure paths. Do not release it for stale or not-addressed returns; those claims intentionally avoid repeated decrypt work.

## Evidence

- Added end-to-end `wake_spool_lane` cases for both decrypt catches: one signed addressed wrap whose wrap ciphertext cannot open, and one wrap that opens into a signed seal whose content cannot open. Both are replayed across reconnect.
- The tests prove the same unreadable wrap/seal is retried after replay and that a second bad event proves the replay reached the handler.
- Ran `node tests/wake_spool_lane.mjs`: 31 passed.
- Ran full `npm test`: passed locally, 117 suites.

## Review note

This is delivery-path code. Please review before merge; the fix is currently needed by Pi Dog's local watcher.

## Checkout note

The local checkout has two untracked files, `uu.CLAUDE.md.txt` and `uu.README.md.txt`. They are not added, not committed, and not part of this branch/PR.
