### PR TITLE
A dry run cannot probe an identity, because it is refused for having no @name (#587)

### DIFF
--- a/src/relay_send_intent.mjs
+++ b/src/relay_send_intent.mjs
@@ -43,8 +43,18 @@ const refuse = reason => Object.freeze({ ok: false, reason })
  * `broadcast` is the deliberate override for a message meant for the humans in the channel. It is a
  * flag rather than a default because the failure it guards is silent, and a guard you have to
  * remember to switch on is one that is off at the moment it matters.
+ *
+ * `allowUnaddressed` is for a caller that PUBLISHES NOTHING (#587). The guard above is about
+ * delivery, and a dry run has none, so refusing one left a newly seated agent with no way to ask
+ * "does my signer answer, and as whom?" without either sending a real message to a real person or
+ * passing `--broadcast`, which changes the semantics of the very thing being tested. It differs from
+ * `broadcast` in both directions: the verdict is NOT marked as a broadcast, because it is not one,
+ * and it comes back flagged `unaddressed` carrying the same sentence it would have refused with.
+ * That sentence travelling with the verdict is the load-bearing half — exempting the check and then
+ * reporting nothing turns a refusal that explained itself into a silence the reader takes for
+ * approval.
  */
-export function mentionVerdict(body, { broadcast = false } = {}) {
+export function mentionVerdict(body, { broadcast = false, allowUnaddressed = false } = {}) {
   const text = typeof body === 'string' ? body : ''
   if (!text.trim()) return refuse('empty body — nothing to send')
   // The delimiter is a LOOKBEHIND, not a consumed character. Consuming it swallows the space in
@@ -74,9 +84,18 @@ export function mentionVerdict(body, { broadcast = false } = {}) {
     return Object.freeze({ ok: true, broadcast: true, mentions: [],
       reason: 'no at-word, sent as a broadcast on purpose — the channel sees it and no agent is routed it' })
   }
-  return refuse('no @name in the body, so the bridge would carry this and route it to nobody. ' +
+  // One sentence, one place. The exemption below hands back the same text rather than a softened
+  // copy, so the dry run cannot drift into describing the problem differently from the refusal.
+  const unaddressed = 'no @name in the body, so the bridge would carry this and route it to nobody. ' +
     'A relay OK and a carried message both still happen; the agent simply never reads it. ' +
-    'Add an @mention, or pass --broadcast if this is meant for the humans in the channel.')
+    'Add an @mention, or pass --broadcast if this is meant for the humans in the channel.'
+  // Scoped to exactly this refusal. An empty body and a malformed channel still stop the run even for
+  // a caller that publishes nothing, because those make the REPORT wrong — and a report nobody can
+  // trust is worse than a refusal, which at least says something true.
+  if (allowUnaddressed) {
+    return Object.freeze({ ok: true, broadcast: false, mentions: [], unaddressed: true, reason: unaddressed })
+  }
+  return refuse(unaddressed)
 }
 
 /**
@@ -87,8 +106,8 @@ export function mentionVerdict(body, { broadcast = false } = {}) {
  * and attributes the post to that key. Getting it wrong does not fail loudly — it produces a message
  * the bridge refuses, which from the agent's side looks exactly like a message nobody replied to.
  */
-export function buildIntent({ body, channel, self, at = null, broadcast = false } = {}) {
-  const mention = mentionVerdict(body, { broadcast })
+export function buildIntent({ body, channel, self, at = null, broadcast = false, allowUnaddressed = false } = {}) {
+  const mention = mentionVerdict(body, { broadcast, allowUnaddressed })
   if (mention.ok !== true) return mention
   const me = String(self || '').toLowerCase()
   if (!HEX64.test(me)) return refuse('no sending identity — a rumor with the wrong pubkey is refused by the bridge, not by this tool')
@@ -99,6 +118,10 @@ export function buildIntent({ body, channel, self, at = null, broadcast = false 
     ok: true,
     mentions: mention.mentions,
     broadcast: !!mention.broadcast,
+    // Travels with the intent so the caller has to decide what to say about it. Undefined-ish here
+    // would let a caller print an ordinary report for a message that reaches nobody.
+    unaddressed: !!mention.unaddressed,
+    reason: mention.reason,
     rumor: Object.freeze({ kind: 14, pubkey: me, created_at: created, tags: [['relay', dest]], content: String(body) }),
   })
 }

--- a/tests/relay_send_intent.mjs
+++ b/tests/relay_send_intent.mjs
@@ -8,6 +8,8 @@
 //      spaces in them, and the positive control is the point of the test.
 //   3. A send cannot claim delivery. The agent cannot read the community channel back, so "the
 //      relay stored it" is the most it may ever say.
+import { spawnSync } from 'node:child_process'
+import { generateSecretKey, getPublicKey } from 'nostr-tools/pure'
 import { buildIntent, envelopeTemplates, FUZZ_SECS, mentionVerdict, sendVerdict } from '../src/relay_send_intent.mjs'
 
 let pass = 0, fail = 0
@@ -179,6 +181,96 @@ section('4. the envelope — backdated, because the send time is the thing being
   let threw = ''
   try { envelopeTemplates({ rumorCreatedAt: AT, bridge: 'nope' }) } catch (e) { threw = String(e.message) }
   ok(/p tag/.test(threw), 'a bad bridge key is refused, and the reason names what would have been lost')
+}
+
+section('5. a run that publishes nothing has no delivery to be wrong about (#587)')
+{
+  // The guard above is about DELIVERY. A dry run has none, so refusing one left a newly seated agent
+  // with no way to ask "does my signer answer, and as whom?" without sending a real message to a real
+  // person. Both onboarding runs this came out of tried exactly that.
+  const probe = mentionVerdict('probe', { allowUnaddressed: true })
+  ok(probe.ok === true, 'an unaddressed body passes when the caller publishes nothing')
+  ok(probe.unaddressed === true, '…and comes back flagged, so the caller cannot report it as ordinary')
+  ok(probe.broadcast === false, '…and is NOT relabelled a broadcast — it is not one, and the report would lie')
+
+  // The load-bearing half. Exempting the check and reporting nothing turns a refusal that explained
+  // itself into a silence, and a reader takes silence for approval.
+  const refused = mentionVerdict('probe')
+  ok(probe.reason === refused.reason,
+    '…and carries the SAME sentence it would have been refused with, verbatim, not a softened copy')
+  ok(/route.*nobody/i.test(probe.reason), '…which says it would be routed to nobody')
+
+  // NEGATIVE CONTROL for the flag itself. If `allowUnaddressed` set the flag unconditionally it would
+  // pass every check above while marking real, addressed sends as reaching nobody.
+  const named = mentionVerdict('@My Dude — probe', { allowUnaddressed: true })
+  ok(named.ok === true && !named.unaddressed,
+    'POSITIVE CONTROL — a body that DOES name someone is not flagged unaddressed just because the flag was passed')
+  ok(named.mentions.includes('My Dude'), '…and its recipient still comes back for the report')
+
+  // SCOPED TO EXACTLY ONE REFUSAL. An empty body or a bad channel makes the report itself wrong, and
+  // the report is the entire product of a dry run.
+  ok(mentionVerdict('   ', { allowUnaddressed: true }).ok === false,
+    'an empty body is still refused — there is nothing to build a report about')
+  ok(buildIntent({ body: 'probe', channel: 'not-a-uuid', self: SELF, allowUnaddressed: true }).ok === false,
+    'a malformed channel is still refused on a dry run — the report would name a destination that cannot exist')
+  ok(buildIntent({ body: 'probe', channel: CHANNEL, self: 'nope', allowUnaddressed: true }).ok === false,
+    'no sending identity is still refused — the probe exists to answer WHO signs')
+
+  const intent = buildIntent({ body: 'probe', channel: CHANNEL, self: SELF, allowUnaddressed: true })
+  ok(intent.ok === true && intent.unaddressed === true, 'the flag reaches buildIntent and travels on the intent')
+  ok(buildIntent({ body: '@My Dude — hi', channel: CHANNEL, self: SELF }).unaddressed === false,
+    '…and an ordinary intent carries it as false rather than absent, so a caller cannot miss the field')
+
+  // THE DEFAULT IS UNCHANGED. This is the regression that matters: a live send with no @name must
+  // still refuse, for the same stated reason, or #118 is back.
+  const live = buildIntent({ body: 'no name here', channel: CHANNEL, self: SELF })
+  ok(live.ok === false, 'DEFAULT UNCHANGED — a live send with no @name is still refused')
+  ok(/--broadcast/.test(live.reason), '…with the same reason, naming the flag that overrides it')
+}
+
+section('6. the tool, run — not matched (#587)')
+{
+  // A string assertion cannot tell a flag that is wired from one that is spelled correctly and read
+  // nowhere. So the tool is executed, with a throwaway local key, and --dry-run means nothing leaves
+  // this process. The key is generated here and never printed.
+  const TOOL = new URL('../tools/agent-send.mjs', import.meta.url).pathname
+  const sk = Buffer.from(generateSecretKey()).toString('hex')
+  const run = (args, input) => {
+    const r = spawnSync(process.execPath, [TOOL, ...args], {
+      input, encoding: 'utf8',
+      env: { ...process.env, BUZZ_PRIVATE_KEY: sk, WAGGLE_BRIDGE_PUBKEY: '', WAGGLE_RELAY_CHANNEL: '' },
+    })
+    return { code: r.status, err: String(r.stderr || '') }
+  }
+  // A real curve point, not `bbbb…`. The seal is nip44-encrypted TO the bridge key, so a filler
+  // 64-hex string dies at "bad point: is not on curve" — a run that fails for a reason that has
+  // nothing to do with what is being tested, and looks from the outside like the flag not working.
+  const BRIDGE = getPublicKey(generateSecretKey())
+  const base = ['--channel', CHANNEL, '--bridge', BRIDGE]
+
+  const dry = run([...base, '--dry-run'], 'probe with no name in it')
+  ok(dry.code === 0, 'a --dry-run with no @name exits 0 — the probe this exists for reads $?')
+  ok(/WOULD REACH NOBODY/.test(dry.err), '…and says so unmissably, so a previewed message is not read as fine')
+  ok(/nothing published/.test(dry.err), '…and still says nothing was published')
+  ok(dry.err.indexOf('WOULD REACH NOBODY') < dry.err.indexOf('nothing published'),
+    '…with the warning BEFORE it, so the last line on screen is not the reassuring half')
+  ok(/sealed by/.test(dry.err), '…and reports the identity that signed, which is the question being asked')
+
+  // NEGATIVE CONTROL, driven on purpose: the live path must still refuse. Without this the change is
+  // indistinguishable from deleting the guard.
+  const livewire = run(base, 'probe with no name in it')
+  ok(livewire.code === 1, 'NEGATIVE CONTROL — the same body without --dry-run still exits 1')
+  ok(/route it to nobody/.test(livewire.err), '…for the stated reason, not a generic failure')
+  ok(!/WOULD REACH NOBODY/.test(livewire.err), '…and does not print the dry-run warning on a path that refused')
+
+  // And the warning is not simply always printed — that alarm would fire identically to a broken one.
+  const addressed = run([...base, '--dry-run'], '@My Dude — probe')
+  ok(addressed.code === 0 && !/WOULD REACH NOBODY/.test(addressed.err),
+    'POSITIVE CONTROL — an addressed dry run prints no such warning')
+
+  // Scope, at the tool: a dry run of an empty body is still a refusal, not a report about nothing.
+  const empty = run([...base, '--dry-run'], '   ')
+  ok(empty.code === 1 && /empty body/.test(empty.err), 'an empty body is refused even with --dry-run')
 }
 
 console.log(`\nrelay_send_intent: ${pass} checks passed${fail ? `, ${fail} FAILED` : ''}`)

--- a/tools/agent-send.mjs
+++ b/tools/agent-send.mjs
@@ -8,6 +8,7 @@
 //   echo "@My Dude — the build is green" | node tools/agent-send.mjs --channel <uuid>
 //   node tools/agent-send.mjs --channel <uuid> --broadcast < note.txt
 //   node tools/agent-send.mjs --channel <uuid> --dry-run < note.txt      # build and report, publish nothing
+//   echo probe | node tools/agent-send.mjs --channel <uuid> --dry-run    # …and no @name is needed (#587)
 //
 // Body on stdin so multi-line text and @mentions survive intact.
 //
@@ -52,7 +53,13 @@ let self
 try { self = await signer.userPubkey() } catch (e) { die(`the signer never answered — ${String(e?.message || e).slice(0, 140)}`) }
 
 // Every refusal happens here, before anything is signed or published.
-const intent = buildIntent({ body, channel, self, broadcast: has('--broadcast') })
+//
+// `allowUnaddressed: dry` exempts ONE refusal on a run that publishes nothing — the missing @name.
+// The guard is about delivery and a dry run has none, so refusing one left a newly seated agent with
+// no way to check that its signer answers and which key it signs as, short of sending a real message
+// to a real person (#587). Every other refusal still stands, including on a dry run: an empty body
+// or a malformed channel makes the report itself wrong, and the report is the entire product here.
+const intent = buildIntent({ body, channel, self, broadcast: has('--broadcast'), allowUnaddressed: dry })
 if (intent.ok !== true) die(intent.reason, 1)
 
 const rumor = { ...intent.rumor, tags: intent.rumor.tags.map(t => [...t]) }
@@ -82,7 +89,15 @@ const wrap = finalizeEvent({ ...env.wrap, tags: env.wrap.tags.map(t => [...t]),
 
 console.error(`agent-send: ${wrap.id.slice(0, 12)}… sealed by ${self.slice(0, 8)}… -> waggle ${bridge.slice(0, 8)}…` +
   ` for channel ${channel.slice(0, 8)}…  [${body.length}B]`)
-if (dry) { console.error('agent-send: --dry-run — nothing published'); process.exit(0) }
+if (dry) {
+  // Printed BEFORE the "nothing published" line, so the last thing on screen is not the reassuring
+  // half. Exit stays 0: the build succeeded, and the probe this exists for is a script that reads
+  // `$?`. The warning is what carries the news, which is why it is unconditional and verbatim from
+  // the guard rather than a paraphrase written here.
+  if (intent.unaddressed) console.error(`agent-send: WOULD REACH NOBODY — ${intent.reason}`)
+  console.error('agent-send: --dry-run — nothing published')
+  process.exit(0)
+}
 
 const publish = url => new Promise(resolve => {
   let ws, done = false


### PR DESCRIPTION
A dry run cannot probe an identity, because it is refused for having no `@name` on a run that publishes nothing.

The first thing a newly seated agent wants to know is whether its signer answers and which key it
signs as. `--dry-run` is the only command that answers that without putting a message in a human's
channel — and it refused. `buildIntent` calls `mentionVerdict` first (`src/relay_send_intent.mjs:91`)
and the `--dry-run` check is thirty lines later (`tools/agent-send.mjs:85`), so the delivery guard
fires on a path with no delivery. Both the DJ Codex and GrokDoggyDog runs hit this and worked around
it the two ways available: send a real message to a real person, or pass `--broadcast`, which changes
the routing semantics of the thing being tested.

## What changed

`mentionVerdict` and `buildIntent` take `allowUnaddressed`. `tools/agent-send.mjs` passes `dry`.

Three properties hold it in place, and each is asserted in both directions:

**It is not a broadcast.** The verdict comes back `broadcast: false` with `unaddressed: true`.
Reusing the `broadcast` flag would have been one line and would have made the report claim
semantics the send does not have.

**It carries the refusal's own sentence, verbatim.** `probe.reason === refused.reason` is asserted
by identity, not by pattern. Exempting the check and then reporting nothing turns a refusal that
explained itself into a silence, and a reader takes silence for approval. The tool prints
`WOULD REACH NOBODY — <that sentence>`, **before** the `nothing published` line, so the last thing on
screen is not the reassuring half.

**It is scoped to exactly one refusal.** An empty body and a malformed channel still refuse on a dry
run, because those make the report itself wrong, and the report is the entire product here. A report
nobody can trust is worse than a refusal, which at least says something true.

Exit stays 0. The probe this exists for is a script reading `$?`; the warning carries the news.

### Where it lives, against the issue's own suggestion

#587 proposed putting the exemption at the caller, to keep a "sometimes skip the guard" branch out of
`src/`. I did the opposite, for the reason this module already states about `FUZZ_SECS` at `:107`:
**the tool has no suite, so a decision made there is a decision nothing can assert.** Doing it at the
caller also means duplicating the mention regex or the refusal text, and the second copy is the one
that drifts. The branch in `src/` is one `if`, and it is the reason section 5 can drive it at all.

## Evidence

`npm test` rc=0, `npx eslint .` 0 errors. No new suite — this extends `tests/relay_send_intent.mjs`.

**Both directions on every claim.** The exemption permits an unaddressed body **and** a positive
control asserts an addressed one is not flagged — an exemption asserted only to permit cannot tell
"permits the safe thing" from "permits everything". The default path is pinned unchanged: a live
send with no `@name` still exits 1, for the same stated reason, or #118 is back.

**The tool is run, not matched.** Section 6 executes `tools/agent-send.mjs` through `spawnSync` with a
throwaway local key and reads the exit code and stderr. A string assertion cannot tell a flag that is
wired from one that is merely spelled correctly. Writing that section found a real trap: a filler
`bbbb…` bridge key dies at `bad point: is not on curve`, a failure that has nothing to do with the
change and looks from the outside like the flag not working, so the fixture uses a real curve point.

**Mutation-tested**, 15 mutations, anchor-checked with abort-on-miss. Half of them widen the
exemption rather than break it — exempting the live path, exempting the empty body, flagging every
verdict, printing the warning unconditionally — because those are the failures a test that only
checks "the probe works" cannot see.

## Review

Substantive: it changes a guard on the outbound delivery path, and that guard has a production
incident behind it in each direction (#118 refusing nothing; #168 refusing everything). **@My Dude**.

The half worth adversarial attention is the scope of the exemption. It is meant to be exactly one
refusal wide, and the way this goes wrong is not the code but the reachability — is there any call
path that sets `allowUnaddressed` and then publishes?

Refs #587. Related: #118, #168, #583.

Drafted with assistance from [Claude Code](https://claude.com/claude-code)
