### PR TITLE
The handoff document told an agent to run two commands that could not run (#583)

### DIFF
--- a/console/VERSION.json
+++ b/console/VERSION.json
@@ -1,3 +1,3 @@
 {
-  "build": "948ba6a1c4c9d0f91a2057ed150a33dc"
+  "build": "c7372bdf0629e8b90f9f6574d5900bbc"
 }

--- a/console/agent-startup.mjs
+++ b/console/agent-startup.mjs
@@ -98,7 +98,8 @@ const SAYS = {
  * works. `facts` carries the public identifiers. Everything else here is invariant role text, and
  * every line of it is a rule an agent has broken confidently at least once.
  */
-export function startupDoc({ agent, pubkey, channel, bridge, runtimeLabel, runtimeId, repo, briefPath = 'docs/AGENT_BRIEF.md', report,
+export function startupDoc({ agent, pubkey, channel, bridge, runtimeLabel, runtimeId, repo, instanceRoot,
+  briefPath = 'docs/AGENT_BRIEF.md', report,
   writtenBy = '`tools/connect-agent.mjs --startup`' }) {
   if (!agent) throw new Error('startupDoc needs the agent name')
   const rows = report?.rows || []
@@ -156,6 +157,27 @@ export function startupDoc({ agent, pubkey, channel, bridge, runtimeLabel, runti
   // paths are not: a quoted `docs/…` reference reads as a defect, and nobody pastes it to a shell.
   const shq = s => (/^[A-Za-z0-9_@%+=:,./-]+$/.test(s) ? s : `'${String(s).replace(/'/g, `'\\''`)}'`)
   const cmd = p => shq(at(p))
+  // The agent's INSTANCE directory, which is a different directory from the checkout and is where
+  // the reader is actually standing. `tools/connect-agent.mjs` knows it as `HERE` — `<root>/<name>`;
+  // `tools/pair-agent.mjs` writes the two credential files under it, and `connect-agent` creates
+  // `spool/` at 0o700 inside it. Every one of those paths already exists on disk and nothing printed
+  // them, so the commands below named neither the credentials they need nor the spool they should
+  // keep. Placeholder when the caller has not seen the machine, same contract as `base` above.
+  const home = instanceRoot ? String(instanceRoot).replace(/\/+$/, '') : '<your agent dir>'
+  const inHome = p => shq(`${home}/${p}`)
+  // THE SIGNER IS AN ENVIRONMENT PAIR, and leaving it off the printed commands is why a correctly
+  // paired agent reported its lane as down. `loadNostrSigner` reads only the environment
+  // (`src/nostr_signer.mjs:204`) — it does no path discovery — so with the pair unset
+  // `agent-inbox.mjs:90` exits **3** with "no signer configured" and `agent-send.mjs:40` exits 1.
+  // Neither failure names the instance directory the files are already sitting in, and an agent that
+  // has just been told its pairing is PRESENT reads that refusal as the bunker being unreachable.
+  // That is exactly how one onboarding run ended INCONCLUSIVE with every credential seated.
+  //
+  // Printed always, filled in when the directory is known and flagged when it is not — the same rule
+  // `--bridge` follows below, and for the same reason: an omitted argument is what makes an
+  // incomplete command look complete. These are PATHS, not values; nothing secret renders here.
+  const signerEnv = `WAGGLE_BUNKER_URI_FILE=${inHome('credentials/bunker-uri')}` +
+    ` WAGGLE_NIP46_CLIENT_NSEC_FILE=${inHome('credentials/bunker-client')}`
   // `--runtime` for the same reason as `--lane`, and it is not cosmetic either: the MCP rows are
   // scoped by whether the runtime HAS an MCP client, and absent means they apply (#526). So a Pi
   // whose document omits the flag runs a check that blocks it on a hazard its runtime cannot have.
@@ -307,7 +329,28 @@ export function startupDoc({ agent, pubkey, channel, bridge, runtimeLabel, runti
     out.push(`machine at all, you cannot run these — report THAT, not an unseated credential.`)
     out.push('')
   }
-  out.push(`**To listen:** \`node ${cmd('tools/agent-inbox.mjs')} --pubkey ${arg(pubkey, '<your 64-hex>')} --watch\``)
+  if (!instanceRoot) {
+    // Its own caveat, not folded into the checkout one, because they are two different directories
+    // and an agent that substitutes one for the other gets a signer that reads nothing from a path
+    // that exists. The checkout holds `tools/`; the instance directory holds this file, your
+    // credentials and your spool, and it is your working directory.
+    out.push(`⚠ **\`<your agent dir>\` in the commands below is a placeholder** — substitute the directory`)
+    out.push(`holding this file, which is where your credentials and spool live. It is **not** the waggle`)
+    out.push(`checkout; the two are different directories and substituting one for the other gives a`)
+    out.push(`signer that reads nothing from a path that exists.`)
+    out.push('')
+  }
+  out.push(`**To listen:** \`${signerEnv} node ${cmd('tools/agent-inbox.mjs')} --pubkey ${arg(pubkey, '<your 64-hex>')}` +
+    ` --watch --spool ${inHome('spool')}\``)
+  // The env pair and the spool are both parts of the command, so both are explained where they are
+  // printed rather than left as noise the reader trims out to make the line shorter.
+  out.push(`The two \`WAGGLE_…\` variables are the signer: they are **paths to files**, not the`)
+  out.push(`credentials themselves, and nothing here needs a key in the environment. Without them the`)
+  out.push(`tool exits **3** saying no signer is configured — which is a command handed over`)
+  out.push(`incomplete, not a lane that is down. \`--spool\` makes the first-seen index durable: in`)
+  out.push(`memory it dies with the process, so every restart is a first-ever start, the whole relay`)
+  out.push(`backfill reads as unseen, and it is seeded without waking anyone (#557). The directory is`)
+  out.push(`created if it is not there.`)
   out.push(`Opens the return lane and holds it. A \`kind:14\` rumor is unsigned by construction, so its`)
   out.push(`\`pubkey\` field is a **claim** — the tool attributes a message only to the key whose seal`)
   out.push(`carried it, and refuses one where the two disagree. A sender not on your trust list is`)
@@ -322,8 +365,8 @@ export function startupDoc({ agent, pubkey, channel, bridge, runtimeLabel, runti
   // does not write it. So it is printed as a flag always, filled in when the caller knew the value,
   // and flagged as an open piece when it did not — never silently omitted.
   const bridgeKey = HEX64.test(String(bridge || '').toLowerCase()) ? String(bridge).toLowerCase() : null
-  out.push(`**To speak:** \`echo "@Name — your message" | node ${cmd('tools/agent-send.mjs')} --channel ${arg(channel, '<uuid>')}` +
-    ` --bridge ${bridgeKey || "<waggle's 64-hex>"}\``)
+  out.push(`**To speak:** \`echo "@Name — your message" | ${signerEnv} node ${cmd('tools/agent-send.mjs')}` +
+    ` --channel ${arg(channel, '<uuid>')} --bridge ${bridgeKey || "<waggle's 64-hex>"}\``)
   if (!bridgeKey) {
     // Stated on its own line rather than folded into the paragraph, because it is the one argument
     // above that this document could not resolve and an agent reading past it gets exit 3.
@@ -364,17 +407,37 @@ export function startupDoc({ agent, pubkey, channel, bridge, runtimeLabel, runti
     // Nothing absent, only unproven: the commands are expected to work, and running them is what
     // settles the rest. A blocked heading here would be the same false statement in the other
     // direction — and an agent that reads "this does not work" does not try.
-    const blocked = laneOpen.some(k => laneState(k) === MISSING || laneState(k) === UNKNOWN)
+    // THREE HEADINGS, NOT TWO, and the third one is the change (#583). `Neither command works yet`
+    // was reached by UNKNOWN as well as MISSING, so a document written by something that could not
+    // observe the credentials — the console has never seen the machine, and `--remote` says so out
+    // loud — opened by telling a correctly-seated agent that its lane was down. That is the same
+    // overclaim the UNVERIFIED split fixed one state along (#541), in the one state left: the
+    // per-piece text says "was never checked, which is not the same as absent" directly under a
+    // heading asserting it is absent. An agent that reads "this does not work" does not try.
+    const absent = laneOpen.some(k => laneState(k) === MISSING)
+    const unlooked = !absent && laneOpen.some(k => laneState(k) === UNKNOWN)
     out.push('')
-    out.push(blocked
+    out.push(absent
       ? `⚠ **Neither command works yet.** ${laneOpen.map(laneSays).join('; ')}.`
-      : `⚠ **Not everything here was proven from this machine.** ${laneOpen.map(laneSays).join('; ')}.`)
-    if (blocked && checkCmd) {
+      : unlooked
+        ? `⚠ **Nothing has checked whether these commands can run.** ${laneOpen.map(laneSays).join('; ')}.`
+        : `⚠ **Not everything here was proven from this machine.** ${laneOpen.map(laneSays).join('; ')}.`)
+    if (absent && checkCmd) {
       out.push(`Settle that first with \`${checkCmd}\`; running either tool before then fails in a`)
       out.push(`way that looks like the lane being down.`)
-    } else if (blocked) {
+    } else if (absent) {
       out.push(`Running either tool before that is settled fails in a way that looks like the lane`)
       out.push(`being down. ${nameRule}`)
+    } else if (unlooked) {
+      // Not "settle it first" — nothing here says it is broken, so waiting is the wrong advice as
+      // surely as confidence would be. Run the check on the machine that can see the files, and
+      // read a failure as what it is rather than as the lane.
+      out.push(checkCmd
+        ? `Run \`${checkCmd}\` **on the agent's own machine** to settle it — whatever wrote this could`
+        : `Settle it on the agent's own machine — whatever wrote this could`)
+      out.push(`not look. Both commands may well work; if one fails, read the message before concluding`)
+      out.push(`the lane is down, because an unset signer and an unreachable relay do not fail alike.`)
+      if (!checkCmd) out.push(nameRule)
     } else {
       // The instruments are the ones the document already names, so this points at them rather than
       // inventing a ceremony: a signature pinned with --expect, and mail that actually opens.

--- a/console/build-id.mjs
+++ b/console/build-id.mjs
@@ -2,4 +2,4 @@
 //
 // The id of the console build this module graph belongs to. A page compares it against
 // console/VERSION.json, fetched with no-store, to detect a stale cached graph (#418).
-export const CONSOLE_BUILD_ID = '948ba6a1c4c9d0f91a2057ed150a33dc'
+export const CONSOLE_BUILD_ID = 'c7372bdf0629e8b90f9f6574d5900bbc'

--- a/src/agent_startup.mjs
+++ b/src/agent_startup.mjs
@@ -87,7 +87,8 @@ const SAYS = {
  * works. `facts` carries the public identifiers. Everything else here is invariant role text, and
  * every line of it is a rule an agent has broken confidently at least once.
  */
-export function startupDoc({ agent, pubkey, channel, bridge, runtimeLabel, runtimeId, repo, briefPath = 'docs/AGENT_BRIEF.md', report,
+export function startupDoc({ agent, pubkey, channel, bridge, runtimeLabel, runtimeId, repo, instanceRoot,
+  briefPath = 'docs/AGENT_BRIEF.md', report,
   writtenBy = '`tools/connect-agent.mjs --startup`' }) {
   if (!agent) throw new Error('startupDoc needs the agent name')
   const rows = report?.rows || []
@@ -155,6 +156,27 @@ export function startupDoc({ agent, pubkey, channel, bridge, runtimeLabel, runti
   // paths are not: a quoted `docs/…` reference reads as a defect, and nobody pastes it to a shell.
   const shq = s => (/^[A-Za-z0-9_@%+=:,./-]+$/.test(s) ? s : `'${String(s).replace(/'/g, `'\\''`)}'`)
   const cmd = p => shq(at(p))
+  // The agent's INSTANCE directory, which is a different directory from the checkout and is where
+  // the reader is actually standing. `tools/connect-agent.mjs` knows it as `HERE` — `<root>/<name>`;
+  // `tools/pair-agent.mjs` writes the two credential files under it, and `connect-agent` creates
+  // `spool/` at 0o700 inside it. Every one of those paths already exists on disk and nothing printed
+  // them, so the commands below named neither the credentials they need nor the spool they should
+  // keep. Placeholder when the caller has not seen the machine, same contract as `base` above.
+  const home = instanceRoot ? String(instanceRoot).replace(/\/+$/, '') : '<your agent dir>'
+  const inHome = p => shq(`${home}/${p}`)
+  // THE SIGNER IS AN ENVIRONMENT PAIR, and leaving it off the printed commands is why a correctly
+  // paired agent reported its lane as down. `loadNostrSigner` reads only the environment
+  // (`src/nostr_signer.mjs:204`) — it does no path discovery — so with the pair unset
+  // `agent-inbox.mjs:90` exits **3** with "no signer configured" and `agent-send.mjs:40` exits 1.
+  // Neither failure names the instance directory the files are already sitting in, and an agent that
+  // has just been told its pairing is PRESENT reads that refusal as the bunker being unreachable.
+  // That is exactly how one onboarding run ended INCONCLUSIVE with every credential seated.
+  //
+  // Printed always, filled in when the directory is known and flagged when it is not — the same rule
+  // `--bridge` follows below, and for the same reason: an omitted argument is what makes an
+  // incomplete command look complete. These are PATHS, not values; nothing secret renders here.
+  const signerEnv = `WAGGLE_BUNKER_URI_FILE=${inHome('credentials/bunker-uri')}` +
+    ` WAGGLE_NIP46_CLIENT_NSEC_FILE=${inHome('credentials/bunker-client')}`
   // `--runtime` for the same reason as `--lane`, and it is not cosmetic either: the MCP rows are
   // scoped by whether the runtime HAS an MCP client, and absent means they apply (#526). So a Pi
   // whose document omits the flag runs a check that blocks it on a hazard its runtime cannot have.
@@ -309,7 +331,28 @@ export function startupDoc({ agent, pubkey, channel, bridge, runtimeLabel, runti
     out.push(`machine at all, you cannot run these — report THAT, not an unseated credential.`)
     out.push('')
   }
-  out.push(`**To listen:** \`node ${cmd('tools/agent-inbox.mjs')} --pubkey ${arg(pubkey, '<your 64-hex>')} --watch\``)
+  if (!instanceRoot) {
+    // Its own caveat, not folded into the checkout one, because they are two different directories
+    // and an agent that substitutes one for the other gets a signer that reads nothing from a path
+    // that exists. The checkout holds `tools/`; the instance directory holds this file, your
+    // credentials and your spool, and it is your working directory.
+    out.push(`⚠ **\`<your agent dir>\` in the commands below is a placeholder** — substitute the directory`)
+    out.push(`holding this file, which is where your credentials and spool live. It is **not** the waggle`)
+    out.push(`checkout; the two are different directories and substituting one for the other gives a`)
+    out.push(`signer that reads nothing from a path that exists.`)
+    out.push('')
+  }
+  out.push(`**To listen:** \`${signerEnv} node ${cmd('tools/agent-inbox.mjs')} --pubkey ${arg(pubkey, '<your 64-hex>')}` +
+    ` --watch --spool ${inHome('spool')}\``)
+  // The env pair and the spool are both parts of the command, so both are explained where they are
+  // printed rather than left as noise the reader trims out to make the line shorter.
+  out.push(`The two \`WAGGLE_…\` variables are the signer: they are **paths to files**, not the`)
+  out.push(`credentials themselves, and nothing here needs a key in the environment. Without them the`)
+  out.push(`tool exits **3** saying no signer is configured — which is a command handed over`)
+  out.push(`incomplete, not a lane that is down. \`--spool\` makes the first-seen index durable: in`)
+  out.push(`memory it dies with the process, so every restart is a first-ever start, the whole relay`)
+  out.push(`backfill reads as unseen, and it is seeded without waking anyone (#557). The directory is`)
+  out.push(`created if it is not there.`)
   out.push(`Opens the return lane and holds it. A \`kind:14\` rumor is unsigned by construction, so its`)
   out.push(`\`pubkey\` field is a **claim** — the tool attributes a message only to the key whose seal`)
   out.push(`carried it, and refuses one where the two disagree. A sender not on your trust list is`)
@@ -324,8 +367,8 @@ export function startupDoc({ agent, pubkey, channel, bridge, runtimeLabel, runti
   // does not write it. So it is printed as a flag always, filled in when the caller knew the value,
   // and flagged as an open piece when it did not — never silently omitted.
   const bridgeKey = HEX64.test(String(bridge || '').toLowerCase()) ? String(bridge).toLowerCase() : null
-  out.push(`**To speak:** \`echo "@Name — your message" | node ${cmd('tools/agent-send.mjs')} --channel ${arg(channel, '<uuid>')}` +
-    ` --bridge ${bridgeKey || "<waggle's 64-hex>"}\``)
+  out.push(`**To speak:** \`echo "@Name — your message" | ${signerEnv} node ${cmd('tools/agent-send.mjs')}` +
+    ` --channel ${arg(channel, '<uuid>')} --bridge ${bridgeKey || "<waggle's 64-hex>"}\``)
   if (!bridgeKey) {
     // Stated on its own line rather than folded into the paragraph, because it is the one argument
     // above that this document could not resolve and an agent reading past it gets exit 3.
@@ -366,17 +409,37 @@ export function startupDoc({ agent, pubkey, channel, bridge, runtimeLabel, runti
     // Nothing absent, only unproven: the commands are expected to work, and running them is what
     // settles the rest. A blocked heading here would be the same false statement in the other
     // direction — and an agent that reads "this does not work" does not try.
-    const blocked = laneOpen.some(k => laneState(k) === MISSING || laneState(k) === UNKNOWN)
+    // THREE HEADINGS, NOT TWO, and the third one is the change (#583). `Neither command works yet`
+    // was reached by UNKNOWN as well as MISSING, so a document written by something that could not
+    // observe the credentials — the console has never seen the machine, and `--remote` says so out
+    // loud — opened by telling a correctly-seated agent that its lane was down. That is the same
+    // overclaim the UNVERIFIED split fixed one state along (#541), in the one state left: the
+    // per-piece text says "was never checked, which is not the same as absent" directly under a
+    // heading asserting it is absent. An agent that reads "this does not work" does not try.
+    const absent = laneOpen.some(k => laneState(k) === MISSING)
+    const unlooked = !absent && laneOpen.some(k => laneState(k) === UNKNOWN)
     out.push('')
-    out.push(blocked
+    out.push(absent
       ? `⚠ **Neither command works yet.** ${laneOpen.map(laneSays).join('; ')}.`
-      : `⚠ **Not everything here was proven from this machine.** ${laneOpen.map(laneSays).join('; ')}.`)
-    if (blocked && checkCmd) {
+      : unlooked
+        ? `⚠ **Nothing has checked whether these commands can run.** ${laneOpen.map(laneSays).join('; ')}.`
+        : `⚠ **Not everything here was proven from this machine.** ${laneOpen.map(laneSays).join('; ')}.`)
+    if (absent && checkCmd) {
       out.push(`Settle that first with \`${checkCmd}\`; running either tool before then fails in a`)
       out.push(`way that looks like the lane being down.`)
-    } else if (blocked) {
+    } else if (absent) {
       out.push(`Running either tool before that is settled fails in a way that looks like the lane`)
       out.push(`being down. ${nameRule}`)
+    } else if (unlooked) {
+      // Not "settle it first" — nothing here says it is broken, so waiting is the wrong advice as
+      // surely as confidence would be. Run the check on the machine that can see the files, and
+      // read a failure as what it is rather than as the lane.
+      out.push(checkCmd
+        ? `Run \`${checkCmd}\` **on the agent's own machine** to settle it — whatever wrote this could`
+        : `Settle it on the agent's own machine — whatever wrote this could`)
+      out.push(`not look. Both commands may well work; if one fails, read the message before concluding`)
+      out.push(`the lane is down, because an unset signer and an unreachable relay do not fail alike.`)
+      if (!checkCmd) out.push(nameRule)
     } else {
       // The instruments are the ones the document already names, so this points at them rather than
       // inventing a ceremony: a signature pinned with --expect, and mail that actually opens.

--- a/src/connect_flags.mjs
+++ b/src/connect_flags.mjs
@@ -30,6 +30,8 @@ export const FLAGS = Object.freeze([
   { flag: '--print', value: null, what: 'print to stdout rather than writing a file' },
   { flag: '--startup', value: null, what: "render the runtime's startup document" },
   { flag: '--runtime', value: 'id', what: 'which runtime the startup file and stanza are for' },
+  { flag: '--remote', value: null, what: 'the startup document describes an agent on ANOTHER machine — render placeholders, claim nothing observed here' },
+  { flag: '--repo-root', value: 'path', what: 'the waggle checkout on the agent’s machine, when it is not this one' },
   { flag: '--stanza', value: null, what: 'print the channel registration for each runtime' },
   { flag: '--bridge', value: '64-hex', what: "waggle's own key, for the speak command in the startup document" },
   { flag: '--channel', value: 'uuid', what: 'the destination channel, for the same' },

--- a/tests/agent_startup.mjs
+++ b/tests/agent_startup.mjs
@@ -45,6 +45,9 @@ check(secretInText("connect to nostrconnect and see") === null,
 
 const PUB = 'a'.repeat(64)
 const CHAN = 'a8186b53-537d-46ad-a7e7-b6486c58970e'
+// The agent's instance directory — where its credentials and spool live. A DIFFERENT directory from
+// the checkout, and the reader's actual working directory (#583).
+const INST = '/opt/agents/oliver'
 // Everything verified — the state an agent is MOST likely to be handed after a clean install, and
 // the one where an overclaim does the most damage.
 const allGood = installState(Object.fromEntries(
@@ -223,8 +226,17 @@ check(!/Neither command works yet/.test(good),
   'NEGATIVE CONTROL — a working agent is NOT warned; the warning tracks the state, it is not decoration')
 // The bug this commit fixed: a piece with NO row read as satisfied, so a document built from no
 // install state at all handed over both commands with no warning at all.
-check(/Neither command works yet/.test(noReport),
+check(/Nothing has checked whether these commands can run/.test(noReport),
   'a document built from NO install state warns too — an unsupplied row is unknown, not satisfied')
+// …and warns in the never-checked words rather than the absent ones (#583). This used to reach
+// `Neither command works yet`, which is a flat claim about a lane nothing looked at — the same
+// overclaim the UNVERIFIED split removed one state along, in the one state left. It matters because
+// the console renders this document for a machine it has never seen, so ALL of its lane rows are
+// unknown and every prompt it emitted opened by telling the agent its lane was down.
+check(!/Neither command works yet/.test(noReport),
+  '  …and NOT in the words for a credential that is genuinely absent — nobody looked, which is a different fact')
+check(/on the agent's own machine/.test(noReport),
+  '  …and points the check at the machine that can see the files, rather than telling the reader to wait')
 // The third state matters separately: never-checked is not absent, and telling an agent its lane is
 // broken when nobody looked sends it to fix a thing that may be fine.
 const laneUnchecked = startupDoc({ agent: 'oliver', pubkey: PUB, report: { rows: [
@@ -232,6 +244,15 @@ const laneUnchecked = startupDoc({ agent: 'oliver', pubkey: PUB, report: { rows:
 ] } })
 check(/was never checked, which is not the same as absent/.test(laneUnchecked),
   'an unchecked pairing is reported as unchecked, not as missing')
+check(/Both commands may well work/.test(laneUnchecked),
+  '  …and the agent is told to try them, because one that reads "this does not work" does not')
+// NEGATIVE CONTROL for the split, and it is the one that matters: a single genuinely MISSING piece
+// beside unchecked ones must still produce the hard heading, or this has just deleted the warning.
+check(/Neither command works yet/.test(startupDoc({ agent: 'oliver', pubkey: PUB, report: { rows: [
+  { key: 'bunker-uri', title: 'Bunker pairing', state: UNKNOWN },
+  { key: 'bunker-client', title: 'Client transport key', state: MISSING },
+] } })),
+  'NEGATIVE CONTROL — one MISSING piece among unchecked ones still says neither command works')
 
 // The must-fix from the #514 review: the documented speak command could not run. `--bridge` is the
 // FIRST check in tools/agent-send.mjs — ahead of the signer, ahead of the body — and nothing in the
@@ -451,7 +472,10 @@ console.log('\n5g. every path the document names resolves from the agent, or say
 // it names the command that WROTE this file, on the machine that wrote it, which is not a path the
 // reader resolves. A filter that swept it in would demand an absolute path for a line nobody runs —
 // the same shape of mistake as the remedy filter in 5d, which caught it for the opposite reason.
-const withRepo = laneDoc('sealed', { repo: ROOT, writtenBy: 'PROVENANCE-SENTINEL tools/connect-agent.mjs' })
+// `instanceRoot` as well as `repo`: this block asserts that NO placeholder survives when the caller
+// knew the paths, and there are two of them. Supplying one and not the other would leave the other's
+// caveat standing and turn the assertion below into a test of which placeholder was checked.
+const withRepo = laneDoc('sealed', { repo: ROOT, instanceRoot: INST, writtenBy: 'PROVENANCE-SENTINEL tools/connect-agent.mjs' })
 check(withRepo.includes('PROVENANCE-SENTINEL'), 'ANCHOR — the provenance line is present, so excluding it excludes something')
 const bareRefs = withRepo.split('\n')
   .filter(l => !l.includes('PROVENANCE-SENTINEL'))
@@ -490,24 +514,43 @@ const spaceRoot = mkdtempSync(join(tmpdir(), 'wb-space-'))
 const spacedRepo = join(spaceRoot, 'My Repos', "it's waggle")
 mkdirSync(join(spacedRepo, 'tools'), { recursive: true })
 writeFileSync(join(spacedRepo, 'tools', 'agent-inbox.mjs'), 'process.exit(0)\n')
-const spacedDoc = laneDoc('sealed', { repo: spacedRepo })
+// The instance directory gets a space and an apostrophe too, and for the same reason: it is now
+// interpolated into the same command, as three paths (#583). `~/Library/Application Support/…` is
+// where a Mac agent's directory ordinarily lands, so this is not a contrived name.
+const spacedInst = join(spaceRoot, 'Application Support', "oliver's agent")
+const spacedDoc = laneDoc('sealed', { repo: spacedRepo, instanceRoot: spacedInst })
 const spacedListenLine = spacedDoc.split('\n').find(l => l.startsWith('**To listen:**'))
 const spacedListenCmd = (spacedListenLine || '').match(/`([^`]+)`/)?.[1] || ''
 check(/agent-inbox\.mjs/.test(spacedListenCmd), `ANCHOR — a listen command was extracted from the document (${spacedListenCmd.slice(0, 60)}…)`)
+check(/WAGGLE_BUNKER_URI_FILE=/.test(spacedListenCmd) && /--spool /.test(spacedListenCmd),
+  '  ANCHOR — and it carries the signer pair and the spool, so the quoting under test covers all three')
 const runsInShell = c => { try { execFileSync('/bin/sh', ['-c', c], { stdio: 'pipe' }); return 0 } catch (e) { return e.status ?? -1 } }
 check(runsInShell(spacedListenCmd) === 0,
   'the rendered command RUNS in a real shell when the checkout path holds a space and an apostrophe')
-// NEGATIVE CONTROL. Strip the quoting the fix adds and the same command must fail the same way it
-// failed before — otherwise this proves the temp tree exists, not that the quoting is what fixed it.
-const unquoted = spacedListenCmd.replace(/'/g, '')
+// NEGATIVE CONTROL, in two halves, because the command now has two kinds of quoted path in it and
+// they fail differently when the quotes come off.
+//
+// The `node …` half first, unchanged: strip the quoting and it must be `Cannot find module` at
+// exit 1 — the exact failure #525 removed. It is isolated from the leading assignments because an
+// unquoted assignment fails EARLIER and with a different shape, which would mask this one.
+const nodePart = spacedListenCmd.slice(spacedListenCmd.indexOf('node '))
+check(nodePart.startsWith('node ') && nodePart.includes('agent-inbox.mjs') && !/WAGGLE_/.test(nodePart),
+  'ANCHOR — the node half was isolated from the env prefix')
+const unquoted = nodePart.replace(/'/g, '')
 let bareErr = ''
 try { execFileSync('/bin/sh', ['-c', unquoted], { stdio: 'pipe' }) } catch (e) { bareErr = `${e.stderr || ''}` }
 check(runsInShell(unquoted) === 1 && /Cannot find module/.test(bareErr),
   '  NEGATIVE CONTROL — with the quotes removed it is `Cannot find module` at exit 1, the failure this PR exists to remove')
+// The env half. Unquoted, `WAGGLE_BUNKER_URI_FILE=/…/Application Support/…` splits at the space and
+// the shell runs the remainder as a command, so the whole line fails before node is reached. Its
+// exit code is not the point and is not asserted — what is asserted is that the quoting is
+// load-bearing here too, rather than decoration around a path that would have worked anyway.
+check(runsInShell(spacedListenCmd.replace(/'/g, '')) !== 0,
+  '  NEGATIVE CONTROL — and unquoted, the signer paths break the line before node runs at all')
 // And the quoting is not applied to everything: an ordinary path stays bare, or the document would
 // print quotes nobody needs and the reader would learn to ignore them.
-check(!/'/.test(laneDoc('sealed', { repo: ROOT }).split('\n').find(l => l.startsWith('**To listen:**')) || "'"),
-  '  BOTH DIRECTIONS — a checkout path that needs no quoting does not get any')
+check(!/'/.test(laneDoc('sealed', { repo: ROOT, instanceRoot: INST }).split('\n').find(l => l.startsWith('**To listen:**')) || "'"),
+  '  BOTH DIRECTIONS — paths that need no quoting do not get any')
 
 // ── 5i. the seating command is a command too ────────────────────────────────────────────────
 console.log('\n5i. the pairing remedy runs in a shell, and is withheld once the pairing is seated')
@@ -536,6 +579,77 @@ check(unpinnedSeat && !/--expect/.test(unpinnedSeat) && runsInShell(unpinnedSeat
 check(!seatOf(startupDoc({ agent: 'oliver', pubkey: PUB, repo: spacedRepo,
   report: { rows: [{ key: 'bunker-uri', title: 'Bunker pairing', state: PRESENT }] } })),
   '  BOTH DIRECTIONS — a SEATED pairing renders no seating command at all')
+
+// ── 5j. the commands carry the signer and the spool ─────────────────────────────────────────
+console.log('\n5j. the printed commands carry a signer and a durable index, or say they could not')
+// #583. Both commands were printed without the two environment variables that ARE the signer, and
+// the listen command without `--spool`. Neither omission looks like an omission from the reader's
+// side: `loadNostrSigner` reads only the environment, so an agent whose pairing this same document
+// reports as PRESENT runs the command, gets exit 3, and reports its lane as down. That is how one
+// onboarding run ended INCONCLUSIVE with every credential correctly seated.
+const withPaths = laneDoc('sealed', { repo: ROOT, instanceRoot: INST, bridge: BRIDGE, channel: CHAN })
+const listenOf = d => (d.split('\n').find(l => l.startsWith('**To listen:**')) || '').match(/`([^`]+)`/)?.[1] || ''
+const speakOf = d => (d.split('\n').find(l => l.startsWith('**To speak:**')) || '').match(/`([^`]+)`/)?.[1] || ''
+check(/agent-inbox\.mjs/.test(listenOf(withPaths)) && /agent-send\.mjs/.test(speakOf(withPaths)),
+  'ANCHOR — both commands were extracted, so asserting about them asserts about something')
+// The NAMES come from the reader, not from here. `loadNostrSigner` is the only thing that reads
+// them, and a document naming a variable it does not read is a document that cannot work — so this
+// asserts the two files agree rather than re-checking a literal, the same rule `connect_flags.mjs`
+// exists for. A rename in the signer that missed this renderer would fail here rather than in a
+// pasted command on somebody else's machine.
+const signerSrc = readFileSync(join(ROOT, 'src', 'nostr_signer.mjs'), 'utf8')
+const envNames = [...signerSrc.matchAll(/env\.(WAGGLE_[A-Z0-9_]+)/g)].map(m => m[1])
+check(envNames.length === 2, `ANCHOR — the signer reads two WAGGLE_ variables from the environment (${envNames.join(', ')})`)
+for (const v of envNames) {
+  check(listenOf(withPaths).includes(`${v}=`), `the listen command sets ${v}, which is what the signer actually reads`)
+  check(speakOf(withPaths).includes(`${v}=`), `  …and so does the speak command — it signs too`)
+}
+// And the PATHS come from the tool that writes them. `pair-agent` puts both files under
+// `credentials/`, and `connect-agent` creates `spool/` at 0o700; a renderer that invented its own
+// layout would point at files nothing creates, which is exactly the defect #474 was.
+const pairSrc = readFileSync(join(ROOT, 'tools', 'pair-agent.mjs'), 'utf8')
+check(/join\(here, 'credentials'\)/.test(pairSrc) && /'bunker-uri'/.test(pairSrc) && /'bunker-client'/.test(pairSrc),
+  'ANCHOR — pair-agent still writes credentials/bunker-uri and credentials/bunker-client')
+check(listenOf(withPaths).includes(`${INST}/credentials/bunker-uri`)
+  && listenOf(withPaths).includes(`${INST}/credentials/bunker-client`),
+  '  …and the command names those two paths under the agent\'s own instance directory')
+const connectSrc = readFileSync(join(ROOT, 'tools', 'connect-agent.mjs'), 'utf8')
+check(/\['spool', 0o700\]/.test(connectSrc), "ANCHOR — connect-agent still creates spool/ at 0700 under the instance directory")
+check(listenOf(withPaths).includes(`--spool ${INST}/spool`),
+  'the listen command points --spool at that directory, so the first-seen index survives a restart')
+check(/#557/.test(withPaths) && /every restart is a first-ever start/.test(flat(withPaths)),
+  '  …and says what it buys, because a flag with no reason attached is the first thing trimmed')
+// NEGATIVE CONTROL for the whole block: none of this is decoration that renders unconditionally.
+check(!/<your agent dir>/.test(withPaths),
+  'NEGATIVE CONTROL — with the directory known, no placeholder survives anywhere in the document')
+check(!/in the commands below is a placeholder/.test(withPaths.split('agent dir')[0] || ''),
+  '  …nor the caveat that explains one')
+
+// The other direction — the console renders this for a machine it has never seen. The commands must
+// STILL carry the pair, filled in with a placeholder and flagged, never silently dropped: an omitted
+// argument is what made an incomplete command look complete, which is the rule `--bridge` follows.
+const noInst = laneDoc('sealed', { repo: ROOT, bridge: BRIDGE, channel: CHAN })
+for (const v of envNames) check(listenOf(noInst).includes(`${v}=`),
+  `BOTH DIRECTIONS — ${v} is printed even when the directory is unknown, rather than dropped`)
+check(listenOf(noInst).includes('--spool'), '  …and so is --spool')
+check(/<your agent dir>/.test(listenOf(noInst)), '  …with a placeholder standing in for the path')
+check(/`<your agent dir>` in the commands below is a placeholder/.test(noInst),
+  '  …and the document says it is one, rather than leaving the reader to guess it is a substitution')
+check(/not\*\* the waggle checkout/.test(flat(noInst)),
+  '  …and says it is NOT the checkout — two placeholders in one document that resolve to different directories')
+// A trailing slash must not render `//` into a path, the same way it must not for the checkout.
+check(laneDoc('sealed', { instanceRoot: `${INST}/` }).includes(`${INST}/spool`)
+  && !laneDoc('sealed', { instanceRoot: `${INST}/` }).includes(`${INST}//`),
+  'a trailing slash on the instance directory does not render `//` into the command')
+
+// It RUNS — the whole pipeline, not just the node half. `echo … | VAR=… node …` is a shape a string
+// assertion cannot judge, and the memory of what a lost backslash costs is that it passes every
+// string assertion and dies in a real shell.
+writeFileSync(join(spacedRepo, 'tools', 'agent-send.mjs'), 'process.exit(0)\n')
+const spacedSpeak = speakOf(laneDoc('sealed', { repo: spacedRepo, instanceRoot: spacedInst, bridge: BRIDGE, channel: CHAN }))
+check(/agent-send\.mjs/.test(spacedSpeak) && /WAGGLE_/.test(spacedSpeak), 'ANCHOR — a speak pipeline with an env prefix was extracted')
+check(runsInShell(spacedSpeak) === 0,
+  'the speak command runs as a PIPELINE with the env pair in front of node, under spaced paths')
 rmSync(spaceRoot, { recursive: true, force: true })
 
 // The usage line is the message an agent acts on when it gets the call wrong, and it had drifted to
@@ -704,6 +818,102 @@ const remedy = (again.stdout.split('\n').find(l => l.includes('compare it agains
 check(remedy.includes(`--root ${probeRoot}`),
   `the remedy command carries --root — ${remedy.trim().slice(0, 90)}`)
 check(remedy.includes(`--channel ${CHAN}`), 'and carries --channel, so the fresh file is comparable to the one on disk')
+
+// ── 8. Whose machine the document is about ──────────────────────────────────────────────────
+console.log('\n8. the tool names the agent\'s own directory, or says it is not this machine')
+// The instance directory is `--root/--name`, and the tool has always known it — it creates `spool/`
+// there and `pair-agent` writes both credential files there. It just never printed any of it, so
+// the commands the tool wrote named neither (#583).
+const localDoc = runStartup('seated')
+check(localDoc !== null && localDoc.includes(`${join(probeRoot, 'seated')}/credentials/bunker-uri`),
+  'the written document names the credential files under THIS agent\'s instance directory')
+check(localDoc !== null && localDoc.includes(`--spool ${join(probeRoot, 'seated')}/spool`),
+  '  …and points --spool at the directory the tool itself creates at 0700')
+check(localDoc !== null && !/<your agent dir>/.test(localDoc),
+  '  NEGATIVE CONTROL — and prints no placeholder, because the tool knows the path')
+
+// `--remote`. The tool's paths and its install rows are both about THIS machine, and neither is a
+// fact about an agent somewhere else. Without this the operator writing a handoff for a third
+// machine got a document naming a checkout that does not exist there, over install rows read off
+// the wrong disk — which is how three onboarding runs got hand-written essays instead.
+const remoteDoc = runStartup('seated', ['--remote'])
+check(remoteDoc !== null && /<your agent dir>/.test(remoteDoc) && /<your waggle checkout>/.test(remoteDoc),
+  '--remote renders BOTH paths as placeholders, because neither of this machine\'s is the reader\'s')
+// Scoped to the DOCUMENT, which `--print` emits behind a `| ` gutter, not to the whole run. The
+// tool also prints its own local install report above it, and that report is entitled to name this
+// machine's paths — the operator is standing on it. What must not carry them is the file that gets
+// handed to somebody else.
+const gutter = out => (out || '').split('\n').filter(l => l.startsWith('  | ')).join('\n')
+check(gutter(remoteDoc).length > 500, 'ANCHOR — a document was extracted from behind the print gutter')
+check(!gutter(remoteDoc).includes(join(probeRoot, 'seated', 'credentials')),
+  '  …and no path off this machine leaks into the commands')
+// The load-bearing half. A row read off this disk is not an observation of that agent, and reporting
+// one as MISSING sends a reader to re-create a credential they already hold.
+check(remoteDoc !== null && /Nothing has checked whether these commands can run/.test(remoteDoc),
+  '  …and the lane reads never-checked rather than broken — nobody looked at that machine')
+check(remoteDoc !== null && !/Neither command works yet/.test(remoteDoc),
+  '  …never the words for a credential that is genuinely absent, which is what this disk would have said')
+check(remoteDoc !== null && /on the agent's own machine/.test(remoteDoc),
+  '  …and the check it names is to be run there, not here')
+// NEGATIVE CONTROL for the whole flag: the local document still reports the local state. A tool that
+// blanked every row unconditionally would pass every assertion above.
+check(localDoc !== null && localDoc.includes(TOOL_PUB) && !/<your waggle checkout>/.test(localDoc),
+  'NEGATIVE CONTROL — without --remote the document still names this machine\'s checkout and this manifest\'s key')
+
+// `--repo-root` on its own: the operator knows the checkout on the agent's machine and says so.
+const rooted = runStartup('seated', ['--remote', '--repo-root', '/srv/waggle'])
+check(rooted !== null && rooted.includes('/srv/waggle/tools/agent-inbox.mjs'),
+  '--repo-root names the checkout on the agent\'s machine, in the commands')
+check(rooted !== null && !/<your waggle checkout>/.test(rooted) && /<your agent dir>/.test(rooted),
+  '  …and resolves only that placeholder — the instance directory is still unknown and still says so')
+
+// Both flags refuse outside --startup, because that is the only thing either changes and a flag that
+// silently does nothing is one the operator believes worked.
+const strayRun = (extra) => {
+  const args = [join(ROOT, 'tools', 'connect-agent.mjs'), '--name', 'seated', '--root', probeRoot, '--check', ...extra]
+  try { execFileSync(process.execPath, args, { encoding: 'utf8', timeout: 60000, stdio: ['ignore', 'pipe', 'pipe'] }); return { code: 0, stderr: '' } }
+  catch (e) { return { code: typeof e?.status === 'number' ? e.status : -1, stderr: String(e?.stderr ?? '') } }
+}
+for (const [f, extra] of [['--remote', ['--remote']], ['--repo-root', ['--repo-root', '/srv/waggle']]]) {
+  const r = strayRun(extra)
+  // The REASON, not only the refusal: `!ok` cannot tell a correct refusal from one whose message
+  // sends the operator somewhere else, and `--check` exits non-zero on its own by design.
+  check(r.code === 1 && new RegExp(`${f} only changes the startup document`).test(r.stderr),
+    `${f} outside --startup is refused, and says why — ${r.stderr.trim().slice(0, 60)}`)
+}
+check(strayRun([]).stderr === '' || !/only changes the startup document/.test(strayRun([]).stderr),
+  'NEGATIVE CONTROL — an ordinary --check with neither flag is not refused for either of them')
+
+// ── 8b. A manifest key that is not the key on the command line ──────────────────────────────
+console.log('\n8b. two accounts of the agent\'s identity, disagreeing')
+// The row asked only whether the field was 64 hex, so a stub — `1111…` shipped — rendered `ok` while
+// `--pubkey` on the same line said otherwise. Both halves are believable alone; this line is the
+// only place they meet.
+const STUB = '1'.repeat(64)
+mkdirSync(join(probeRoot, 'stubkey', 'instances'), { recursive: true })
+writeFileSync(join(probeRoot, 'stubkey', 'instances', 'stubkey.json'), JSON.stringify({
+  version: 1, id: 'stubkey', pubkey: STUB, grantors: [], task_carriers: [],
+  relays: ['wss://nos.lol'], broker_mode: 'local', delivery_mode: 'notify_only',
+}) + '\n')
+const mismatch = runRaw(['--print', '--pubkey', TOOL_PUB], 'stubkey')
+check(/Runtime manifest/.test(mismatch.stdout), 'ANCHOR — the manifest row rendered at all')
+const manifestRow = mismatch.stdout.split('\n').find(l => /Runtime manifest/.test(l)) || ''
+check(/missing/i.test(manifestRow) || /✗|x /.test(manifestRow),
+  `a manifest naming a different key than --pubkey is MISSING, not ok — ${manifestRow.trim().slice(0, 90)}`)
+check(manifestRow.includes(STUB.slice(0, 12)) && manifestRow.includes(TOOL_PUB.slice(0, 12)),
+  '  …and the row names BOTH keys, because "does not match" without them is a refusal nobody can act on')
+check(!mismatch.stdout.includes(STUB),
+  '  …and the document does not fall back to the key the row just refused')
+// BOTH DIRECTIONS, and this is the one that matters: a check that fires on every manifest cannot
+// tell a stub from a real one, and would refuse every correctly-seated agent.
+const agreeing = runRaw(['--print', '--pubkey', TOOL_PUB], 'seated')
+const agreeRow = agreeing.stdout.split('\n').find(l => /Runtime manifest/.test(l)) || ''
+check(!/missing/i.test(agreeRow) && agreeing.stdout.includes(TOOL_PUB),
+  `NEGATIVE CONTROL — a manifest that AGREES with --pubkey is not refused — ${agreeRow.trim().slice(0, 80)}`)
+// And with no --pubkey there is nothing to compare against, so the manifest still supplies the key.
+const noCompare = runRaw(['--print'], 'stubkey')
+check(noCompare.stdout.includes(STUB),
+  '  …and with no --pubkey the manifest key is still used: the check is a comparison, not a stub detector')
 
 rmSync(probeRoot, { recursive: true, force: true })
 

--- a/tests/console_first_prompt.mjs
+++ b/tests/console_first_prompt.mjs
@@ -105,7 +105,12 @@ const MATRIX = [
   // ignored `briefPath`, and one with the `!agent` guard removed — and both survived for the same
   // reason: no fixture passed the parameter, so no assertion could see it drop. This closes the
   // class rather than those two instances. `writtenBy` is the third defect of this shape.
+  // `repo` and `instanceRoot` join it for exactly that reason: a twin ignoring either would agree
+  // byte for byte with one that honoured it, because no fixture passed the parameter. `instanceRoot`
+  // is the newer of the two (#583) and is the one the console never supplies in production, so
+  // nothing else on this axis would exercise it at all.
   ['every non-default parameter supplied at once', { briefPath: 'docs/OTHER_BRIEF.md',
+    repo: '/opt/waggle', instanceRoot: '/opt/agents/pi-agent',
     writtenBy: 'a fixture, deliberately,', report: { rows: rows({ 'admit-grant': PRESENT }) } }],
   // `report.lane` renders the `--lane` flag on the remedy command (#515). It is a field on `report`
   // rather than a parameter, so nothing above walks it, and the two copies inline their own lane
@@ -214,6 +219,32 @@ for (const copy of [['node', node], ['browser', web]]) {
   let threw = null
   try { mod.startupDoc({ report: { rows: [] } }) } catch (e) { threw = e.message }
   check(threw !== null, `  …and the ${label} copy refuses to render a document with no agent name`)
+}
+
+// `instanceRoot`, per copy and in both directions (#583). It is the parameter this suite is most
+// exposed on: the console NEVER supplies it — it has not seen the agent's machine — so production
+// only ever exercises the placeholder half, and a twin that dropped the parameter entirely would
+// render identically to a correct one on every console-shaped fixture. The signer pair and the
+// spool are the two things the commands were shipped without, so this asserts they arrive.
+for (const [label, mod] of [['node', node], ['browser', web]]) {
+  const listen = d => (d.split('\n').find(l => l.startsWith('**To listen:**')) || '').match(/`([^`]+)`/)?.[1] || ''
+  const known = mod.startupDoc({ agent: 'pi-agent', pubkey: PUB, repo: '/opt/waggle',
+    instanceRoot: '/opt/agents/pi-agent', report: { rows: rows({ 'admit-grant': PRESENT }) } })
+  check(listen(known).includes('WAGGLE_BUNKER_URI_FILE=/opt/agents/pi-agent/credentials/bunker-uri')
+    && listen(known).includes('WAGGLE_NIP46_CLIENT_NSEC_FILE=/opt/agents/pi-agent/credentials/bunker-client'),
+    `the ${label} copy renders the signer pair from the instance directory it was given`)
+  check(listen(known).includes('--spool /opt/agents/pi-agent/spool'),
+    `  …and points --spool at that directory, so the first-seen index survives a restart`)
+  check(!known.includes('<your agent dir>'),
+    `  NEGATIVE CONTROL — and no placeholder survives in the ${label} copy when the path was supplied`)
+  // The other direction, which is the ONLY one the console produces.
+  const unknown = mod.startupDoc({ agent: 'pi-agent', pubkey: PUB, repo: '/opt/waggle',
+    report: { rows: rows({ 'admit-grant': PRESENT }) } })
+  check(listen(unknown).includes('WAGGLE_BUNKER_URI_FILE=') && listen(unknown).includes('--spool')
+    && listen(unknown).includes('<your agent dir>'),
+    `  BOTH DIRECTIONS — with no directory known the ${label} copy still prints both, against a placeholder`)
+  check(/`<your agent dir>` in the commands below is a placeholder/.test(unknown),
+    `  …and says it IS a placeholder, which is the only account the console can honestly give`)
 }
 
 // A property the byte-comparison alone cannot state: that the comparison is comparing something.

--- a/tools/connect-agent.mjs
+++ b/tools/connect-agent.mjs
@@ -121,6 +121,29 @@ if (has('--runtime') && !runtime(runtimeId)) {
 }
 const HAS_MCP = runtimeId ? runtime(runtimeId).kind !== 'none' : null
 
+// ── Whose machine is the startup document about? ────────────────────────────────────────────
+// It has always been about this one, because every path in it is derived from this one: `REPO` from
+// `import.meta.url`, `HERE` from `--root`/`--name`, and the install rows from this filesystem. That
+// is right when the agent runs here and wrong in every other case — and the operator writing a
+// document for a third machine had no way to say so, so the file handed over named a checkout that
+// does not exist there and reported an install state that was never observed (#583).
+//
+// `--remote` says the reader is elsewhere. Under it the paths render as placeholders, and — this is
+// the load-bearing half — every locally-observed row is dropped to never-checked, because a row
+// derived from this disk is not a fact about that agent. Reporting one as MISSING would send a
+// reader to re-create a credential they already hold, which is the exact failure the fourth state
+// exists to stop.
+//
+// `--repo-root` is orthogonal and usable on its own: it names the checkout on the agent's machine
+// when the operator knows it. Both refuse outside `--startup`, because that is the only thing either
+// changes, and a flag that silently does nothing is one the operator believes worked.
+const REMOTE = has('--remote')
+const REPO_ROOT = flag('--repo-root')
+if (has('--repo-root') && !REPO_ROOT) die('--repo-root needs a path')
+if ((REMOTE || has('--repo-root')) && !has('--startup')) {
+  die(`${REMOTE ? '--remote' : '--repo-root'} only changes the startup document; pass --startup, or drop it`)
+}
+
 // Shape-check the two operator-pasted values HERE, at the boundary, before anything renders them
 // (#466 review §3). Both have a known shape, so an allowlist is available and an allowlist is
 // bounded: it makes `bunker://…` in `--channel` unreachable by construction rather than caught by
@@ -276,19 +299,43 @@ let manifestOk = false, manifestNote = `absent: ${manifestPath}`
 // key is a file that cannot be checked against anything. Read it from the artifact rather than
 // demanding the operator retype it.
 let manifestPubkey = null
+// A manifest whose key is not the key on the command line. `manifestOk` asked only whether the field
+// was 64 hex, so a stub — `1111…` is the one that shipped — passed, the row rendered `ok`, and the
+// startup document then took `pubkey || manifestPubkey` and printed commands for an identity nobody
+// on that box holds. Both halves are believable on their own: the operator typed the real key, the
+// file holds a placeholder, and the only place they meet is this line. A mismatch is MISSING rather
+// than unverified — the manifest for THIS agent is not there, whatever else is — and the note names
+// both keys, because "does not match" without the two values is a refusal the reader cannot act on.
+let manifestMismatch = false
 if (existsSync(manifestPath)) {
   try {
     const m = JSON.parse(readFileSync(manifestPath, 'utf8'))
     manifestOk = m.id === name && HEX64.test(String(m.pubkey || ''))
-    if (HEX64.test(String(m.pubkey || ''))) manifestPubkey = String(m.pubkey)
-    manifestNote = manifestOk
-      ? `${m.pubkey.slice(0, 12)}… · ${m.delivery_mode} · relays ${(m.relays || []).length}`
-      : 'present but its id or pubkey does not match this agent'
+    if (HEX64.test(String(m.pubkey || ''))) manifestPubkey = String(m.pubkey).toLowerCase()
+    manifestMismatch = Boolean(pubkey && manifestPubkey && manifestPubkey !== pubkey)
+    // `manifestOk` is deliberately NOT forced false here. `see()` below is handed `found: false` on a
+    // mismatch, and installState maps a false `found` to MISSING whatever `verified` says, so the
+    // extra line could not change the row. Mutation testing is what said so — it survived being
+    // turned into `if (false)`. A guard that cannot fire reads as protection and provides none.
+    manifestNote = manifestMismatch
+      ? `holds ${manifestPubkey.slice(0, 12)}…, but --pubkey says ${pubkey.slice(0, 12)}… — one of the two is wrong and this tool cannot tell which`
+      : manifestOk
+        ? `${m.pubkey.slice(0, 12)}… · ${m.delivery_mode} · relays ${(m.relays || []).length}`
+        : 'present but its id or pubkey does not match this agent'
   } catch (e) { manifestNote = `present but not valid JSON: ${e.message}` }
 }
 // Validated against the runtime's OWN validator when it can be reached — a copy of its rules here
 // would drift from it, and a manifest this tool blesses and the runtime rejects is worse than none.
-see('manifest', existsSync(manifestPath), manifestOk, manifestNote)
+see('manifest', existsSync(manifestPath) && !manifestMismatch, manifestOk, manifestNote)
+// The startup document must not fall back to a key this row has just refused — and it structurally
+// cannot: a mismatch requires `--pubkey` to be set (see the Boolean above), and the render below
+// takes `pubkey || manifestPubkey`, which never reaches the manifest key while `--pubkey` holds one.
+// Nulling `manifestPubkey` here was written as belt-and-braces and mutation testing proved it
+// unreachable, so it is gone. The property itself is asserted at the level that can observe it —
+// tests/agent_startup.mjs §8b checks the rendered document for the refused key.
+if (manifestMismatch) {
+  warn.push(`${manifestPath} names a different key than --pubkey; nothing here can say which is the agent's`)
+}
 
 // ── Runtime directories. Five, two with non-default modes. ──────────────────────────────────
 const DIRS = [
@@ -591,7 +638,18 @@ if (has('--startup')) {
   if (!rt) die(`--runtime ${target} is not one of: ${RUNTIMES.map(r => r.id).join(', ')}`)
   const dest = join(HERE, rt.startupFile)
   const exists = existsSync(dest)
-  console.log(`\nstartup file — ${rt.label}`)
+  console.log(`\nstartup file — ${rt.label}${REMOTE ? ' (for an agent on another machine)' : ''}`)
+  // Never-checked, row by row, and NOT by handing `startupDoc` an empty report: the rows still
+  // exist and still say which artifacts matter, they just no longer claim this disk answered for
+  // them. `found: null` is the same shape `see()` already uses for the two relay-side rows nothing
+  // local can observe, so this reuses the tool's own vocabulary for "did not look" rather than
+  // inventing a second one. `lane` is kept because it is the operator's declaration, not an
+  // observation — it was never read off this filesystem and is as true there as here.
+  const remoteObs = Object.fromEntries(Object.entries(obs).map(([k, v]) => (k === 'lane' ? [k, v] : [k, {
+    found: null, verified: false, note: 'not observed — this document is for an agent on another machine',
+  }])))
+  const docReport = REMOTE ? installState(remoteObs, { lane, mcp: HAS_MCP }) : report
+  if (REMOTE) console.log(`  --remote: every install row reads never-checked, because this machine is not the agent's.`)
   const render = () => {
     try {
       return startupDoc({
@@ -600,7 +658,16 @@ if (has('--startup')) {
         // Passed through when the operator supplies it, and left undefined otherwise so the
         // document prints the caveat rather than a command that exits 3 (#514 review).
         bridge: flag('--bridge') || process.env.WAGGLE_BRIDGE_PUBKEY || undefined,
-        runtimeLabel: rt.label, runtimeId: rt.id, repo: REPO, report,
+        runtimeLabel: rt.label, runtimeId: rt.id, report: docReport,
+        // `--repo-root` wins wherever it is given, including locally: an operator who names a
+        // checkout has named the one they mean. Absent it, this machine's checkout is right only
+        // when the agent runs here — under `--remote` there is nothing to give, and the document
+        // prints the placeholder it already prints for the console, which has never seen a machine.
+        repo: REPO_ROOT || (REMOTE ? undefined : REPO),
+        // The instance directory is where the credentials and the spool are, so the commands can
+        // name them (#583). There is no `--instance-root`: `HERE` is derived from `--root` and
+        // `--name`, which already exist, and under `--remote` it is not this path.
+        instanceRoot: REMOTE ? undefined : HERE,
       })
     } catch (e) { die(e.message) }
   }


### PR DESCRIPTION
The handoff document told an agent to run two commands that could not run, and described a machine it had never seen.

Three defects, all found live during the DJ Codex and GrokDoggyDog onboarding runs.

**The printed commands carried no signer.** `loadNostrSigner` reads only the environment — `WAGGLE_BUNKER_URI_FILE` and `WAGGLE_NIP46_CLIENT_NSEC_FILE`, no path discovery (`src/nostr_signer.mjs:204`). Neither variable appeared in either command, so `agent-inbox` exits 3 with "no signer configured" and `agent-send` exits 1, on an install where both credential files are seated at the paths the document does not name. The agent has just been told its pairing is PRESENT, so it reads that refusal as the bunker being unreachable. One onboarding run ended INCONCLUSIVE for exactly this reason, with every credential correct.

**`--watch` carried no `--spool`.** `connect-agent` creates `spool/` at 0700 under the instance directory and nothing ever pointed at it. Without it the first-seen index dies with the process, so every restart is a first-ever start and the backfill is seeded without waking anyone — #557, taught to every new agent.

**The document assumed the agent runs on this machine.** Every path came from here: the checkout from `import.meta.url`, the instance directory from `--root`/`--name`, and the install rows from this filesystem. An operator writing a handoff for a third machine got a file naming a checkout that does not exist there, over rows read off the wrong disk (#583).

## What changed

`startupDoc` takes `instanceRoot` and renders the two credential paths and the spool from it — the same paths `tools/pair-agent.mjs:53` writes and `tools/connect-agent.mjs:295` creates, so nothing here invents a layout. The signer pair is printed **always**: filled in when the directory is known, and against a flagged `<your agent dir>` placeholder when it is not. That is the rule `--bridge` already follows, and for the same reason — an omitted argument is what makes an incomplete command look complete.

`--remote` says the reader is elsewhere. Both paths render as placeholders, and every locally-observed row drops to never-checked. That second half is the load-bearing one: a row read off this disk is not a fact about that agent, and reporting one as MISSING sends a reader to re-create a credential they already hold. `--repo-root <path>` is orthogonal and usable alone — it names the checkout on the agent's machine. Both refuse outside `--startup`, with the reason, because a flag that silently does nothing is one the operator believes worked.

**A third heading, and this is a behaviour change worth reading.** `Neither command works yet` was reached by UNKNOWN as well as MISSING, so a document written by something that could not observe the credentials — the console has never seen the machine — opened by telling a correctly-seated agent that its lane was down, with per-piece text underneath saying "was never checked, which is not the same as absent". Never-checked now gets its own heading and its own remedy: run the check **on the agent's own machine**, and both commands may well work. Same split as #541 one state along, in the state that was left.

`--pubkey` and the manifest key are now compared. The row asked only whether the field was 64 hex, so a stub — `1111…` is the one that shipped — rendered `ok` while the command line said otherwise. A mismatch is MISSING, the row names both keys, and the document no longer falls back to the key the row just refused.

## Evidence

`npm test` rc=0 (117 suites), `npx eslint .` 0 errors.

Both directions on every guard. The heading split is pinned by a negative control that one genuinely MISSING piece among unchecked ones still produces the hard warning — otherwise the change has just deleted the alarm. The manifest comparison is pinned by an agreeing manifest that is *not* refused, because a check that fires on every manifest cannot tell a stub from a real key and would refuse every seated agent at once.

The commands are **run**, not matched. §5h drives the listen command through `/bin/sh` under a checkout path holding a space and an apostrophe, and now under an instance directory holding both as well — `~/Library/Application Support/…` is where a Mac agent's directory ordinarily lands. The speak command is run as a full pipeline, because `echo … | VAR=… node …` is a shape no string assertion can judge. Two negative controls: strip the quoting off the node half and it is `Cannot find module` at exit 1, the failure #525 removed; strip it off the whole line and the signer paths break it before node runs.

`console/agent-startup.mjs` carries every body change, and `tests/console_first_prompt.mjs` pins the two renderers byte-identical over the matrix. `instanceRoot` was added to that matrix deliberately: the console never supplies it in production, so a twin that dropped the parameter would have rendered identically to a correct one on every console-shaped fixture.

Mutation-tested, anchor-checked with abort-on-miss; every body mutation applied to **both** renderers, so a kill is the document assertion firing rather than the twin-drift check noticing they diverged. 20 mutations, 18 killed.

**The two that escaped were the useful result.** Both were lines I had written as belt-and-braces on the manifest comparison, and both are unreachable:

- `if (manifestMismatch) manifestOk = false` — `see()` is already handed `found: false` on a mismatch, and `installState` maps a false `found` to MISSING whatever `verified` says. The line could not change the row.
- `manifestPubkey = null` — a mismatch requires `--pubkey` to be set, and the render takes `pubkey || manifestPubkey`, which never reaches the manifest key while `--pubkey` holds one.

Neither is now in the diff. The property they were meant to protect is asserted where it can be observed — §8b reads the rendered document for the refused key — so deleting them costs nothing, and keeping them would have left two guards that read as protection and cannot fire. Both sites carry a comment saying so, because the next reader's instinct will be to add them back.

## Review

Substantive — it changes what a new agent is told to run. Not a delivery path or a gate, but the first thing an agent reads. **@My Dude** to coordinate; the half worth adversarial attention is the heading split, because it moves a warning that used to fire in a case it will no longer fire in.

Refs #583. Related: #557, #541, #525.

Drafted with assistance from [Claude Code](https://claude.com/claude-code)
