### PR TITLE
Nothing wrote down the onboarding steps, so work aimed at symptoms

### DIFF
--- a/docs/DESIGN_CONNECT_REMOTE_AGENT.md
+++ b/docs/DESIGN_CONNECT_REMOTE_AGENT.md
@@ -210,7 +210,7 @@ the source. Recorded here so the wizard's authors know which values are *decisio
 |---|---|---|
 | `grantors` | the maintainer's key | The bridge's `config.public.grantors`; correct and understood. |
 | `task_carriers` | the bridge key + one channel | The carrier that relays signed instructions. Understood. |
-| `broker_mode` | `local` | The desktop path; `remote` requires a keyless manifest. |
+| `broker_mode` | `local` | **This row was backwards; corrected 2026-08-18.** `local` means local to the *runtime host* and **requires** a credential reference. `remote` is the keyless desktop shape — `runtime_manifest.mjs` refuses a credential under it (*"a remote-broker Desktop manifest must be keyless"*). See `docs/FLOW_ONBOARDING.md`. |
 | `delivery_mode` | `notify_only` | Required by `claude-channel.mjs`, which refuses anything else. Established against the **local** server; not re-verified against the broker. |
 | `worker_enabled` | `false` | `true` demands a digest-pinned worker image; out of scope. |
 
@@ -225,18 +225,20 @@ the source. Recorded here so the wizard's authors know which values are *decisio
 - **`watcher_uid: 502`, `broker_uid: 503`, `adapter_uid: 504`.** These declare a four-account
   privilege separation between the watcher, broker, adapter and worker. **On this machine, uids
   502, 503 and 504 do not exist.** Only `worker_uid: 501` resolves, to the human operator, and the
-  running channel process is owned by that account. The manifest describes a security model that is
-  not in force on the desktop path; `instance-runtime-init.mjs` (which would provision it) demands
-  root and has evidently never been run here. *We do not know whether the desktop path is intended
-  to be single-account, or whether this is unfinished provisioning.* A wizard must not copy these
-  numbers forward as though they mean something.
+  running channel process is owned by that account. **Resolved 2026-08-18: neither.** 502/503/504
+  are the *runtime host's* uids, carried over with the rest of the copied server manifest, and
+  `instance-runtime-init.mjs` has never been run here because it is not meant to be — it is
+  root-only and provisions the container's volumes on the runtime host. The privilege separation is
+  real; it is simply in force somewhere else. The conclusion stands unchanged: a wizard must not
+  copy these numbers forward.
 - **`broker_adapter_gid: 20` (`staff`), `worker_handoff_gid: 12` (`everyone`).** Two stock macOS
   groups standing in for a handoff boundary. `everyone` is not a boundary.
-- **`broker_mode: local` on an agent whose broker is remote.** `mc-claude`'s manifest still says
-  `local` while its registration ssh's to the broker host and answers handshakes there. Either the
-  field means something narrower than its name, or it is stale on a working agent. We do not know
-  which, and a wizard must not copy it forward on the assumption that a working agent's manifest is
-  self-consistent.
+- ~~**`broker_mode: local` on an agent whose broker is remote.**~~ **Resolved 2026-08-18.**
+  Neither reading was right. The desktop manifest is a *copy of a server manifest*: `ad05b00e…` has
+  one manifest here and another at `/etc/nvoy/instances/claude-jaf.json` on the runtime host, where
+  a `nvoy-claude-jaf` container stack actually runs. `local` is correct **there** and meaningless
+  here. The instinct in this bullet — that a wizard must not copy a working agent's manifest
+  forward — was right for a reason this register could not see.
 - **Two checkouts of the same toolchain.** Registrations in the retired local form point at
   `…/nvoy-macos-desktop-binder/mcp/tools/`, not the other tree, and the two are not obviously in
   sync. Pointing a new agent at the wrong one is silent. The ssh form retires the question rather
@@ -426,9 +428,14 @@ about who instructs whom can be read backwards. An arrow cannot.
 
 ### Where it runs
 
-The flow spans a laptop, the bridge host, the Bunker and the public relays. It should run **where
-the credentials already are** — the operator's machine — and reach the bridge over the interfaces
-that exist, rather than becoming a second thing that must be deployed and kept current.
+The flow spans a workstation, the bridge host, the Bunker, the public relays and — added
+2026-08-18 — the **runtime host**, where each agent's broker/watcher/adapter containers run.
+
+The wizard should run where the operator already is, and reach the other hosts over the interfaces
+that exist. **It must not follow the credentials, because it is what decides where they go.** An
+earlier version of this section reasoned that the flow belongs "where the credentials already are —
+the operator's machine"; that is how six agent pairings came to sit on a workstation whose only role
+is to drive the wizard. A pairing belongs in its runtime's role-owned volume, and nowhere else.
 
 ---
 

--- a/docs/FLOW_ONBOARDING.md
+++ b/docs/FLOW_ONBOARDING.md
@@ -1,0 +1,158 @@
+# Onboarding, step by step
+
+What has to happen for a new agent to go from nothing to receiving a mention and waking on it —
+which surface owns each step, what it writes, how you prove it, and **what it looks like when it
+fails without saying so.** That last column is why this document exists. Every step in this chain
+can report success and leave the agent unreachable, and three of them do it silently today.
+
+This is a map of what the code does, not what it should do. Every row cites a file and line. Where
+a proof was actually run, its command is given; where one was not, the row says so rather than
+implying it passed.
+
+---
+
+## The steps
+
+| # | Step | Surface that owns it | What it writes | Proven by | Silent failure mode |
+|---|---|---|---|---|---|
+| 1 | **Identity** — mint a key, or adopt one the bunker already holds | `console/index.html:226` (mint) · `:339` + `console/adopt-identity.mjs` (adopt, #537) | nothing published; the page holds the secret only until step 2 | the public half is displayed | — |
+| 2 | **Custody** — the bunker proves it can sign for *this* key | `console/index.html:244`, `console/bunker-custody.mjs` | nothing published | one throwaway NIP-46 challenge, checked against the key **you named**, never the key the URI names (`console/index.html:339` copy) | a proof against the URI's own key would pass for any bunker that answers — which is why it is checked against the named key |
+| 3 | **Admit** — the key can sign in to the relay at all | `console/index.html:261-287` → `console/admission-client.mjs:117-141` | a `relay_members` row on the community relay | the claim returns `200 — joined` or `already_member` | `already_member` is **not** proof the key can authenticate — the page says so at the claim result. Membership buys write, not read |
+| 3a | **Consents** — terms, and age if the policy demands it | `console/index.html:275-287`, gate at `admission-client.mjs:122` | carried on the claim | both boxes are read at click time; never pre-ticked, and neither derives the other (`:277-279`) | — |
+| 4 | **Name** — publish `kind:0` on both sides | `console/index.html:296-308` → `console/profile-publish.mjs:47-68`, `:149` | `kind:0` with `content.name` = `content.display_name`, to the four public relays **and** the community relay over NIP-98 | cold read-back by id on the **public** relays, `nameVerdict` (`profile-publish.mjs:182`, `:212`). The **community** leg is accepted but not read back | two failures, both below: the step promises addressability it does not deliver, **and the only leg Buzz resolves against is the one that cannot be verified** |
+| 5 | **Inbox** — publish `kind:10050` | `console/index.html:316` → `console/dm-relay-publish.mjs` | the agent's DM relay list | cold read-back by id | without it the bridge logs `RETURN not sent` and drops the message; the agent sees an empty inbox, indistinguishable from no mail (#581, `console/index.html:310-314`) |
+| 6 | **Route** — the at-word waggle will carry | `console/config.html` → `console/task-routes.mjs` → `applyTaskRouteCommand` (`src/bridge.mjs:3119`) | `public.task_routes[]` = `{participant, sender, channel, mention, protocol}` | `task route: upsert …` in the bridge journal | **a mention that cannot match any at-word logs nothing at all** — see below |
+| 7 | **Carry** — the bridge matches the at-word and delivers | `src/bridge.mjs:3676-3722` | a sealed wrap to the agent's key | `RETURN` lines in the journal | a managed route is `(channel, sender)`-locked (`:3707`); a message from the wrong author is skipped with no per-route line |
+| 8 | **Wake** — the agent's watcher runs a hook | `tools/agent-inbox.mjs` (`--trust`, `--on-message`, `--spool`) | a spool record with a wake verdict | the hook's own output file grows | **without `--trust` every message is recorded as data**, `mayAct` is false, and the lane looks completely healthy (`agent-inbox.mjs:301`). The tool refuses `--on-message` with an empty trust list for exactly this reason (`:125`) |
+
+Steps 1–5 are one column of one page. Step 6 is a **different page**. Steps 7–8 are the bridge and
+the agent's own machine. Nothing carries state between them.
+
+---
+
+## The three registries
+
+I conflated these repeatedly and got four answers wrong in an hour. They are not the same list.
+
+| Registry | Written by | Read by | Rendered where | Gives the agent |
+|---|---|---|---|---|
+| **grant set** | signed NIP-DA 440s, replayed at every bridge start | `activeReturnLane` (`src/bridge.mjs:945-960`) | `console/agents.html` — **`WHO'S IN`** | admission. An entry with no route is synthesised as `{mention: 'guest', dynamic: true}`, and **dynamic entries are excluded from mention matching** (`:3678`, `:3722`) — reachable by explicit p-tag or direct reply only |
+| **`public.task_routes`** | `applyTaskRouteCommand` (`src/bridge.mjs:3119`), from `console/config.html` only | `scanReturnLane` (`:3676-3722`) | nowhere on `agents.html` | the at-word. `(channel, sender)`-locked |
+| **`public.return_lane`** | **nothing** — `src/bridge.mjs:440` is the only reference in the source tree and it is a boot-time read | same | nowhere | the at-word, unlocked. Hand-edited config |
+
+Two traps in that table:
+
+- **`agents.html`'s "Carry mentions out to it" does not write a lane entry.** It sends
+  `agent_return_lane`, which sets a **boolean on a roster row** (`src/bridge.mjs:2868`, `:2876`).
+  It enables the lane; it does not name anybody.
+- **The two row shapes cannot simply be merged.** Managed routes carry `scan_channel`/`scan_author`
+  that legacy rows have no field for; legacy rows carry `authors[]`/`alert_tags[]`
+  (`src/bridge.mjs:462-472`) that routes have no field for.
+
+---
+
+## Two namespaces, and nothing connects them
+
+**Buzz** resolves an at-word against `users.display_name`, written from the `kind:0` that step 4
+publishes. That is why `@DJ Codex` and `@GrokDoggyDog` resolve inside the community.
+
+**waggle** decides what to carry by matching a separately hand-typed string in
+`public.task_routes[].mention` (step 6). It is never derived from `display_name`, and that refusal
+is deliberate and documented in three places — a roster label is printable ASCII, a display name is
+not (`console/agent-roster.mjs:19-23`, `console/task-routes.mjs:198-200`,
+`docs/JOIN_RUNBOOK.md:103-107`).
+
+The refusal is sound. Two things around it are not:
+
+**1. Step 4 promises what step 6 owns.** Its label reads:
+
+> "Give it a name — *this is what an @word looks up — without it the key is on the list and nobody
+> can address it*" — `console/index.html:296`
+
+True of Buzz, false of waggle. An operator who completes the whole page has published a name, not a
+route, and has been told otherwise.
+
+**2. A mention that can never match fails silently.** The matcher is built as
+`@<mention>(?![\p{L}\p{N}_.'\-])` with flags `iu` (`src/task_route_mention.mjs:175-179`). The `@` is
+a literal first character: the "no leading boundary" note at `:171-173` means nothing constrains
+what precedes the `@`, not that the `@` is optional. So a route named `codex` cannot match the
+at-word `@DJ Codex` — and because it does not match as a prefix at that `@` position either, the
+`#415` near-miss diagnostic (`src/bridge.mjs:3693`) never fires.
+
+Run against the repo's own exported matcher:
+
+```
+$ node -e 'import("./src/task_route_mention.mjs").then(m => { … })'
+regex: @codex(?![\p{L}\p{N}_.'\-]) iu
+"@DJ Codex hello" -> false
+"ping @DJ Codex" -> false
+"hey @codex"     -> true
+"@Codex now"     -> true
+route "DJ Codex" vs "yo @DJ Codex" -> true
+arbitrate carried: {} nearMissed: {}
+```
+
+`nearMissed: {}` is the finding. No carry, and no line in the journal saying why.
+
+**3. The leg that matters is the leg that cannot be checked.** Buzz resolves an at-word against a
+`users` row written from the `kind:0` on the **community** relay. That is the leg step 4 cannot read
+back — membership buys write, not read (#399 is still open). The page says so honestly; publishing
+MC Claude's name on 2026-08-17 returned:
+
+> "the public half is proven — 3 of 4 relays served it back on a fresh connection, and the community
+> relay accepted it. The read-back is INCONCLUSIVE — membership buys write, not read, so nothing
+> here can confirm the name from this page."
+
+So the public half — which Buzz never consults for at-word resolution — is proven, and the community
+half — the only one that decides whether `@MC Claude` resolves — rests on a relay acknowledgement.
+This repo's own rule is that a relay OK proves nothing (`CLAUDE.md`, verification discipline). The
+step is correctly labelled INCONCLUSIVE rather than green, which is right; what is missing is any
+other route to the answer.
+
+**4. The one drift warning compares the wrong pair.** `console/agent-liveness.mjs:88-93` warns when
+`kind:0 display_name` differs from the **roster label**. It never reads `public.task_routes`, so
+`DJ Codex` vs `codex` produces no warning on any page.
+
+---
+
+## Live state, 2026-08-17
+
+Read from the bridge host and the public relays, not from config in a checkout.
+
+**Admitted (grant set)** — `journalctl -u waggle-read | grep 'NIPDA granted'`:
+`e4c0faf4…` (Pi Dog), `231952cb…` (DJ Codex), `61cb9345…` (GrokDoggyDog).
+
+**`public.task_routes`** — two rows, both `(channel a8186b53…, sender 4010ac43…)`-locked:
+`codex` → `231952cb…` · `MC Claude` → `ad05b00e…`
+
+**`public.return_lane`** — two rows, both `mention: claude`: `78856ed6…`, `ad05b00e…`
+
+**Only one route was ever set through the signed path** —
+`journalctl … | grep 'task route:'` returns exactly one line, `upsert … @MC Claude`, 2026-08-12. The
+`codex` row did not come through the console.
+
+**The scan sees fewer recipients than are admitted** —
+`return-lane scan: 1 channel(s) · 2 recipient(s) · signer gate 5 key(s)`, on every restart.
+
+What that adds up to, per agent:
+
+| Agent | Admitted | `kind:0` | Route mention | `@<display name>` carries? |
+|---|---|---|---|---|
+| MC Claude | no (config-only) | yes | `MC Claude` | **yes** — the route string happens to equal the display name |
+| DJ Codex | yes | `DJ Codex` | `codex` | **no**, and nothing is logged |
+| GrokDoggyDog | yes | `GrokDoggyDog` | none | **no** — `dynamic` entries are excluded from matching |
+| Pi Dog | yes | — | none | **no** — reached by p-tag and direct reply only |
+
+MC Claude is the only one that works, and it works by coincidence.
+
+---
+
+## What this map does not cover
+
+- Whether a claimed invite also opens **read** is an open question (#399). Community read-back is
+  still `403 RBAC: access denied`, which is the same refusal an unadmitted key gets, so it
+  distinguishes nothing.
+- Steps 2, 4 and 5 have cold read-back proofs in the code; **those proofs were not re-run for this
+  document.** The rows say what the code checks, not that it passed today.
+- Operational procedure — how to reach the boxes, how to message the crew — is in the private brief,
+  not here.

--- a/docs/FLOW_ONBOARDING.md
+++ b/docs/FLOW_ONBOARDING.md
@@ -3,7 +3,10 @@
 What has to happen for a new agent to go from nothing to receiving a mention and waking on it —
 which surface owns each step, what it writes, how you prove it, and **what it looks like when it
 fails without saying so.** That last column is why this document exists. Every step in this chain
-can report success and leave the agent unreachable, and three of them do it silently today.
+can report success and leave the agent unreachable, and three of them do it silently today. Two steps were missing from
+this map's first version and are added below as **0** and **6a**: choosing the agent's runtime
+harness, and provisioning the runtime that receives the wrap. Both were assumed rather than
+recorded, and the second is why one admitted agent has never received anything.
 
 This is a map of what the code does, not what it should do. Every row cites a file and line. Where
 a proof was actually run, its command is given; where one was not, the row says so rather than
@@ -15,6 +18,7 @@ implying it passed.
 
 | # | Step | Surface that owns it | What it writes | Proven by | Silent failure mode |
 |---|---|---|---|---|---|
+| 0 | **Harness** — which runtime drives this identity: Claude Code · Codex CLI · Pi · Grokbot · Gemini · generic MCP | **no surface owns it** | nothing | nothing | it is never asked, so it is never wrong — it is simply assumed. It fixes `delivery_mode`, the startup filename (`CLAUDE.md` / `AGENTS.md` / `GEMINI.md`), the wake mechanism, and whether step 6a is needed at all. Deciding it late means steps 1-6 all pass before anyone knows whether the agent can be woken |
 | 1 | **Identity** — mint a key, or adopt one the bunker already holds | `console/index.html:226` (mint) · `:339` + `console/adopt-identity.mjs` (adopt, #537) | nothing published; the page holds the secret only until step 2 | the public half is displayed | — |
 | 2 | **Custody** — the bunker proves it can sign for *this* key | `console/index.html:244`, `console/bunker-custody.mjs` | nothing published | one throwaway NIP-46 challenge, checked against the key **you named**, never the key the URI names (`console/index.html:339` copy) | a proof against the URI's own key would pass for any bunker that answers — which is why it is checked against the named key |
 | 3 | **Admit** — the key can sign in to the relay at all | `console/index.html:261-287` → `console/admission-client.mjs:117-141` | a `relay_members` row on the community relay | the claim returns `200 — joined` or `already_member` | `already_member` is **not** proof the key can authenticate — the page says so at the claim result. Membership buys write, not read |
@@ -22,6 +26,7 @@ implying it passed.
 | 4 | **Name** — publish `kind:0` on both sides | `console/index.html:296-308` → `console/profile-publish.mjs:47-68`, `:149` | `kind:0` with `content.name` = `content.display_name`, to the four public relays **and** the community relay over NIP-98 | cold read-back by id on the **public** relays, `nameVerdict` (`profile-publish.mjs:182`, `:212`). The **community** leg is accepted but not read back | two failures, both below: the step promises addressability it does not deliver, **and the only leg Buzz resolves against is the one that cannot be verified** |
 | 5 | **Inbox** — publish `kind:10050` | `console/index.html:316` → `console/dm-relay-publish.mjs` | the agent's DM relay list | cold read-back by id | without it the bridge logs `RETURN not sent` and drops the message; the agent sees an empty inbox, indistinguishable from no mail (#581, `console/index.html:310-314`) |
 | 6 | **Route** — the at-word waggle will carry | `console/config.html` → `console/task-routes.mjs` → `applyTaskRouteCommand` (`src/bridge.mjs:3119`) | `public.task_routes[]` = `{participant, sender, channel, mention, protocol}` | `task route: upsert …` in the bridge journal | **a mention that cannot match any at-word logs nothing at all** — see below |
+| 6a | **Runtime** — the nvoy stack that holds the pairing and does the waking | **nothing in this repo** — `/etc/nvoy/instances/<id>.json` + `render-instance-compose.mjs` on the runtime host | a root-owned manifest, a rendered Compose file, role-owned credential volumes | `nvoy-<id>-{broker,watcher,adapter}-1` running on the runtime host | **an agent can pass every other step and have no runtime at all.** GrokDoggyDog is admitted, named, routed, and the bridge will carry to him; there is no `nvoy-grokdoggydog` stack, so nothing has ever arrived and no step reports a failure |
 | 7 | **Carry** — the bridge matches the at-word and delivers | `src/bridge.mjs:3676-3722` | a sealed wrap to the agent's key | `RETURN` lines in the journal | a managed route is `(channel, sender)`-locked (`:3707`); a message from the wrong author is skipped with no per-route line |
 | 8 | **Wake** — the agent's watcher runs a hook | `tools/agent-inbox.mjs` (`--trust`, `--on-message`, `--spool`) | a spool record with a wake verdict | the hook's own output file grows | **without `--trust` every message is recorded as data**, `mayAct` is false, and the lane looks completely healthy (`agent-inbox.mjs:301`). The tool refuses `--on-message` with an empty trust list for exactly this reason (`:125`) |
 
@@ -168,6 +173,73 @@ Mention match, sender lock, channel lock, seal, courier trust and hook execution
 stated reason, one second after the source note.
 
 ---
+
+## The runtime is a container, and nothing in this repo creates it
+
+Steps 7 and 8 both presume a process exists to receive the wrap and run the hook. For every agent
+that works today that process is a Docker stack on the runtime host, and this repo neither creates
+it, configures it, nor mentions it.
+
+Verified on the runtime host, 2026-08-18:
+
+- A runtime is a root-owned manifest at `/etc/nvoy/instances/<id>.json` plus a Compose file rendered
+  from it by `render-instance-compose.mjs`, running `nvoy-<id>-{broker,watcher,adapter}-1`.
+- Two exist: `claude-jaf` (`ad05b00e…`) and `codex-jaf` (`231952cb…`).
+- Credentials are seated by `instance-runtime-init.mjs` — root-only, one-shot, and by its own header
+  the only role permitted to chown runtime roots. It copies the pairing into a role-owned volume and
+  exits before the broker starts.
+- There is no `grokdoggydog` stack. That is the whole reason he has never received anything.
+
+### `broker_mode` is documented backwards
+
+`docs/DESIGN_CONNECT_REMOTE_AGENT.md:213` records `broker_mode: local` as "the desktop path". It is
+the opposite. `runtime_manifest.mjs` refuses a credential reference under `remote` — *"a
+remote-broker Desktop manifest must be keyless"* — and requires one under `local`. **`local` means
+local to the runtime host, and the runtime host is the server.** `remote` is the keyless desktop
+shape.
+
+That document's open register had already noticed the smell and could not resolve it: *"`broker_mode:
+local` on an agent whose broker is remote… Either the field means something narrower than its name,
+or it is stale on a working agent."* It is neither. The desktop manifest is a copy of a server
+manifest. The same fact settles the register's next item — uids 502/503/504 "do not exist on this
+machine" because they are the runtime host's uids, and `instance-runtime-init.mjs` "has evidently
+never been run here" because it is not meant to be.
+
+### The consequence: custody lands in two places
+
+`tools/connect-agent.mjs:278-282` writes `state_dir`, `runtime_dir`, `spool_dir`, `bunker_uri_ref`
+and `bunker_client_ref` under the agent root on whatever machine it runs on, and leaves
+`broker_mode` at `local`. That is precisely the configuration `remote` exists to forbid, and the
+validator accepts it without complaint.
+
+Measured on the maintainer's workstation, 2026-08-18: six agent roots hold a `bunker-uri`, five of
+them a `bunker-client` as well, all mode `600`. Two of those identities — `ad05b00e…` and
+`231952cb…` — also have a production container stack on the runtime host with its own
+`nvoy-*_broker_credentials` volume. Their pairing therefore exists in two places, and only the
+volume is the one the running broker reads. The other four have a workstation pairing and no stack
+at all.
+
+The duplicate is hard to see because the two manifests do not share an id: `ad05b00e…` is
+`mc-claude` on the workstation and `claude-jaf` on the runtime host. Pi Dog reached the same
+requirement independently from the other direction (nvoy#113) — instance names should match agent
+names — and this is the cost of them not matching: nothing lines the two records up, so nothing
+reports that one identity has two homes.
+
+File permissions are not the finding. The finding is that **no step in this flow puts a credential
+into a runtime**, so the credential ends up wherever the tool happened to run.
+
+### What this implies for the order of the steps
+
+A pairing should be seated into its runtime at the moment custody is established, which means the
+runtime has to be provisioned **before** step 2, not discovered missing after step 6. Any ordering
+that mints a pairing before there is a volume to receive it must park it somewhere in the meantime,
+and "somewhere" has been the operator's workstation six times.
+
+This document maps what the code does. The reordering is a recommendation, and it belongs to the
+deployment-model specification rather than to this map.
+
+---
+
 
 ## What this map does not cover
 

--- a/docs/FLOW_ONBOARDING.md
+++ b/docs/FLOW_ONBOARDING.md
@@ -138,12 +138,34 @@ What that adds up to, per agent:
 
 | Agent | Admitted | `kind:0` | Route mention | `@<display name>` carries? |
 |---|---|---|---|---|
-| MC Claude | no (config-only) | yes | `MC Claude` | **yes** — the route string happens to equal the display name |
-| DJ Codex | yes | `DJ Codex` | `codex` | **no**, and nothing is logged |
-| GrokDoggyDog | yes | `GrokDoggyDog` | none | **no** — `dynamic` entries are excluded from matching |
+| MC Claude | no (config-only) | `MC Claude` | `MC Claude` + `claude` in `return_lane` | **yes** — two doors, and the route string happens to equal the display name |
+| DJ Codex | yes | `DJ Codex` | `codex`, **`DJ Codex` added 20:38** | **yes, since 20:38** — see below |
+| GrokDoggyDog | yes | `GrokDoggyDog` | **`GrokDoggyDog` added 20:39** | carries, but **no watcher exists** on his host |
 | Pi Dog | yes | — | none | **no** — reached by p-tag and direct reply only |
 
-MC Claude is the only one that works, and it works by coincidence.
+Before 20:38 MC Claude was the only one that worked, and it worked by coincidence — nobody had
+chosen to make the route string equal the display name; it happened to be typed that way.
+
+### The first end-to-end proof, 2026-08-17 20:42
+
+Two fixes were both required, which is why neither alone would have shown a change: the route
+mention had to equal the published name, **and** the watcher had to carry `--trust`. With only the
+first, the record reads `wake: false` and the hook never runs; with only the second, nothing is
+carried to wake on.
+
+Body typed in the channel: `@DJ Codex do you get this message`
+
+```
+bridge   RETURN 4/4 -> 231952cb5eb0…: sealed 612B (wrap 62a4a6e0cfa9…)
+watcher  id 62a4a6e0cfa94f8d…            <- same wrap, both ends
+         type waggle-channel-task-carry · reason "mention"
+         source 4010ac438206, kind 9, channel a8186b53…
+         wake true · mayAct true · forMe true · live true · first_seen true
+         wake_reason "sealed by 84753207f2c6…, which is on the trust list"
+```
+
+Mention match, sender lock, channel lock, seal, courier trust and hook execution all fired for the
+stated reason, one second after the source note.
 
 ---
 


### PR DESCRIPTION
Eight steps get an agent from nothing to waking on a mention. No artifact listed them. Which surface owns each one, what it writes, and how it is proven were being reconstructed by grep, per question — and got answered wrong four times in an hour on 2026-08-17.

`docs/FLOW_ONBOARDING.md` is that list. Every row cites a file and line. Where a proof was actually run its command and output are given; where one was not, the row says so.

## The column that matters

The last one: **what each step looks like when it fails without saying so.** Three steps do that today.

**The naming step promises what a different page owns.** `console/index.html:296` reads *"this is what an @word looks up — without it the key is on the list and nobody can address it"*. True of Buzz, which resolves against `users.display_name` written from the `kind:0` that step publishes. False of waggle, which matches a separately hand-typed string in `public.task_routes[].mention`, entered on `console/config.html`. An operator who completes the whole page has published a name and no route, and has been told otherwise.

**A route mention that cannot match logs nothing.** `taskRouteMentionMatcher` builds `@<mention>(?![\p{L}\p{N}_.'\-])` with flags `iu`. The `@` is a literal first character — the "no leading boundary" note at `src/task_route_mention.mjs:171-173` means nothing constrains what precedes the `@`, not that it is optional. So the live `codex` route cannot match `@DJ Codex`, and because it does not match as a prefix at that position either, the #415 near-miss diagnostic at `src/bridge.mjs:3693` never fires. Driven against the exported matcher:

```
regex: @codex(?![\p{L}\p{N}_.'\-]) iu
"ping @DJ Codex" -> false
"hey @codex"     -> true
arbitrate carried: {} nearMissed: {}
```

`nearMissed: {}` is the finding — no carry, and no line saying why.

**The name's community leg cannot be read back.** It is the only leg Buzz consults and the only one with no cold proof; membership buys write, not read (#399). The page reports INCONCLUSIVE, which is correct, and leaves the question open.

## Registries

Recorded because they were conflated repeatedly: the grant set behind `WHO'S IN`, `public.task_routes`, and `public.return_lane` — which has **no writer anywhere**. `src/bridge.mjs:440` is the only reference in the source tree and it is a boot-time read. `agents.html`'s "Carry mentions out to it" sets a boolean on a roster row (`:2868`); it enables the lane, it does not name anybody.

Live consequence, per agent: MC Claude is the only one whose display name carries, and it carries because someone happened to type a route string identical to it.

## Scope

Docs only — no code, no test count change. It is the spec for collapsing Access and Connect into one flow, and the fixes it exposes are separate PRs.

## Reviewer

@My Dude — the claim to attack is the matcher one, since everything downstream rests on it. I assert `codex` can never match `@DJ Codex` **and** produces no near-miss line. If the second half is wrong there is a diagnostic path I missed and the silence is not total.

Refs #582

Drafted with assistance from [Claude Code](https://claude.com/claude-code)