### PR TITLE
Refuse unsupported reply markers instead of silently dropping them

### DIFF
--- a/src/relay_send_intent.mjs
+++ b/src/relay_send_intent.mjs
@@ -98,6 +98,17 @@ export function mentionVerdict(body, { broadcast = false, allowUnaddressed = fal
   return refuse(unaddressed)
 }
 
+// A REPLY MARKER CANNOT REACH THE POSTED KIND-9 (#604). The rumor below freezes its tags to
+// `[['relay', dest]]`, and even if that changed, `buzz_policy_projection.buildBuzzEvent` hardcodes
+// the posted event's tags a second time. Two independent enforcement points, so a parent reference
+// handed to this function is dropped twice and reported nowhere.
+//
+// Refusing is the point. An `--in-reply-to` added to `tools/agent-send.mjs` without the rest of the
+// chain is a flag that does nothing and says nothing — the exact shape `buildIntent`'s own doc
+// comment already names elsewhere: a message the bridge refuses looks, from the agent's side,
+// exactly like a message nobody answered. A real implementation removes this guard deliberately.
+const REPLY_KEYS = Object.freeze(['inReplyTo', 'in_reply_to', 'replyTo', 'reply_to', 'parent', 'parentId'])
+
 /**
  * The rumor waggle expects, or a refusal. No crypto here — the caller seals it.
  *
@@ -106,7 +117,10 @@ export function mentionVerdict(body, { broadcast = false, allowUnaddressed = fal
  * and attributes the post to that key. Getting it wrong does not fail loudly — it produces a message
  * the bridge refuses, which from the agent's side looks exactly like a message nobody replied to.
  */
-export function buildIntent({ body, channel, self, at = null, broadcast = false, allowUnaddressed = false } = {}) {
+export function buildIntent(opts = {}) {
+  const { body, channel, self, at = null, broadcast = false, allowUnaddressed = false } = opts
+  const replyKey = REPLY_KEYS.find(k => opts[k] != null && opts[k] !== '')
+  if (replyKey) return refuse(`\`${replyKey}\` cannot be expressed — the rumor's tags are frozen here and the posted event's tags are hardcoded again in buzz_policy_projection.buildBuzzEvent, so a parent reference is dropped at two sites and reaches no reader (#604). Nothing was sent.`)
   const mention = mentionVerdict(body, { broadcast, allowUnaddressed })
   if (mention.ok !== true) return mention
   const me = String(self || '').toLowerCase()

--- a/tests/relay_send_intent.mjs
+++ b/tests/relay_send_intent.mjs
@@ -273,5 +273,32 @@ section('6. the tool, run — not matched (#587)')
   ok(empty.code === 1 && /empty body/.test(empty.err), 'an empty body is refused even with --dry-run')
 }
 
+section('a reply marker is unrepresentable, and says so (#604)')
+{
+  // Every spelling a caller might plausibly reach for. The point is not the list — it is that NONE
+  // of them can be set and quietly lost, because two hardcoded sites downstream drop a parent
+  // reference and report nothing.
+  for (const key of ['inReplyTo', 'in_reply_to', 'replyTo', 'reply_to', 'parent', 'parentId']) {
+    const r = buildIntent({ body: '@My Dude — probe', channel: CHANNEL, self: SELF, [key]: 'f'.repeat(64) })
+    // ASSERT THE REASON, NOT ONLY THE REFUSAL. `!ok` cannot tell a correct refusal from a correct
+    // refusal that sends the reader hunting in the wrong file.
+    ok(r.ok === false && r.reason.includes(key) && /#604/.test(r.reason) && /Nothing was sent/.test(r.reason),
+      `refuses \`${key}\`, names the field and #604`)
+  }
+
+  // POSITIVE CONTROL — the guard refuses the parent reference, not everything. A name with a space,
+  // because that is the fixture shape that shipped a live outage when it was missing (#168).
+  const clean = buildIntent({ body: '@My Dude — probe', channel: CHANNEL, self: SELF })
+  ok(clean.ok === true && clean.rumor.tags.length === 1 && clean.rumor.tags[0][0] === 'relay',
+    'POSITIVE CONTROL — an ordinary send still builds, with its single relay tag')
+
+  // ABSENCE IS NOT A VALUE. A caller threading an option through as null/'' must not be refused, or
+  // the guard fires on every send that merely mentions the field.
+  for (const empty of [null, undefined, '']) {
+    const r = buildIntent({ body: '@My Dude — probe', channel: CHANNEL, self: SELF, inReplyTo: empty })
+    ok(r.ok === true, `an absent inReplyTo (${JSON.stringify(empty)}) is not a refusal`)
+  }
+}
+
 console.log(`\nrelay_send_intent: ${pass} checks passed${fail ? `, ${fail} FAILED` : ''}`)
 process.exit(fail ? 1 : 0)


### PR DESCRIPTION
Prevention, not a feature. `buildIntent` accepted a reply marker, ignored it, and built an ordinary
send. This makes it refuse and say why.

## Why it cannot be expressed

A parent reference is dropped at **two independent sites**:

1. `src/relay_send_intent.mjs` freezes the rumor's tags to `[['relay', dest]]`.
2. `src/buzz_policy_projection.mjs:56` — `buildBuzzEvent` hardcodes the posted kind-9's tags a
   second time, independently.

So a fix confined to site 1 changes nothing observable. Neither site logs the drop. From the
agent's side, a send that lost its parent reference is indistinguishable from a message nobody
answered — the exact failure shape `buildIntent`'s own doc comment already names.

Refusing at the entry converts a silent double-drop into a stated refusal that names the field, the
second site, and the issue. A real implementation removes this guard deliberately.

## What this does NOT do

- **Does not implement agent-to-agent reachability.** The reply path exists in the bridge
  (`bridge.mjs:3707` exempts a direct reply to an event the recipient authored) and this does not
  make it usable. Nothing routes anywhere new.
- **Does not touch projection or the posted kind-9's tags.** `buzz_policy_projection.mjs` is named
  in the refusal message and is not modified. Deliberate: `buildBuzzEvent` is also called from
  `src/buzz_policy_artifacts.mjs:79` to re-derive an expected event for signature comparison, so a
  throw added there would break artifact verification.
- **Does not touch task routes, the return lane, or mention resolution.** No change to
  `task_route_mention.mjs`, `scan_authors`, `task_routes`, `return_lane`, or `mentionVerdict`. Who a
  mention resolves to is unchanged.

## Why it still needs an outside reviewer

It changes delivery-path behaviour. Input that previously returned `{ok:true}` and built a rumor now
returns `{ok:false}`. That is substantive under this repo's own rule regardless of diff size, and
merging deploys.

**Merge gate for the reviewer:** do not merge if any current caller can pass one of
`inReplyTo · in_reply_to · replyTo · reply_to · parent · parentId`, intentionally or accidentally.

What I found, for you to check rather than take: exactly one non-test caller exists —
`tools/agent-send.mjs:109` — and it is a fixed object literal with six named keys, no spread and no
computed key. `grep -rn "buildIntent" . --exclude-dir=node_modules` is the whole search.

The signature change is destructuring-inside rather than destructuring-in-the-parameter-list, so
every existing call site is unaffected.

## Tests

`tests/relay_send_intent.mjs`, 77 → 87 checks:

- 6 checks — one per key — asserting **the reason, not only the refusal**: the message names the
  field, cites #604, and says `Nothing was sent`. `!ok` alone cannot tell a correct refusal from a
  correct refusal that sends the reader hunting in the wrong file.
- **Positive control** — an ordinary send still builds and still carries its single `relay` tag. The
  guard refuses the parent reference, not everything. Fixture uses `@My Dude`, a name with a space,
  because that is the fixture shape whose absence shipped a live outage (#168).
- 3 checks — `null`, `undefined`, `''` are not refusals. A caller threading the option through as
  empty must not trip the guard.

`npm test` rc=0. `npx eslint src/relay_send_intent.mjs tests/relay_send_intent.mjs` rc=0, no output.

Refs #604

Drafted with assistance from [Claude Code](https://claude.com/claude-code)
